### PR TITLE
Improve struct defaults

### DIFF
--- a/lib/elixirpb.pb.ex
+++ b/lib/elixirpb.pb.ex
@@ -5,7 +5,7 @@ defmodule Elixirpb.FileOptions do
   @type t :: %__MODULE__{
           module_prefix: String.t()
         }
-  defstruct [:module_prefix]
+  defstruct module_prefix: nil
 
   field :module_prefix, 1, optional: true, type: :string
 end

--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -29,7 +29,7 @@ defmodule Protobuf.Protoc.Generator.Message do
       new_namespace: new_ns,
       name: Util.mod_name(ctx, new_ns),
       options: msg_opts_str(ctx, desc.options),
-      structs: structs_str(desc, extensions),
+      structs: structs_str(ctx, desc, extensions),
       typespec: typespec_str(fields, desc.oneof_decl, extensions),
       fields: fields,
       oneofs: oneofs_str(desc.oneof_decl),
@@ -89,18 +89,30 @@ defmodule Protobuf.Protoc.Generator.Message do
     if String.length(str) > 0, do: ", " <> str, else: ""
   end
 
-  def structs_str(struct, extensions) do
-    fields = Enum.filter(struct.field, fn f -> !f.oneof_index end)
+  def structs_str(ctx, desc, extensions) do
+    oneof_fields = Enum.map(desc.oneof_decl, &{&1.name, nil})
+    proto3? = ctx.syntax == :proto3
 
     fields =
-      if Enum.empty?(extensions) do
-        fields
-      else
-        fields ++ [%{name: :__pb_extensions__}]
-      end
+      for f <- desc.field,
+          !f.oneof_index,
+          do: {f.name, struct_default_value(f, proto3?)}
 
-    Enum.map_join(struct.oneof_decl ++ fields, ", ", fn f -> ":#{f.name}" end)
+    extensions = if Enum.empty?(extensions), do: [], else: [{:__pb_extensions__, nil}]
+
+    Enum.map_join(oneof_fields ++ fields ++ extensions, ", ", fn {name, default_value} ->
+      "#{name}: #{default_value || inspect(nil)}"
+    end)
   end
+
+  defp struct_default_value(%{default_value: nil, label: :LABEL_REPEATED} = _field, _proto3?),
+    do: "[]"
+
+  defp struct_default_value(%{type: type, default_value: nil} = _field, true = _proto3?),
+    do: type |> TypeUtil.from_enum() |> Protobuf.Builder.type_default() |> inspect()
+
+  defp struct_default_value(%{type: type, default_value: default_value} = _field, _proto3?),
+    do: default_value(type, default_value)
 
   def typespec_str([], [], []), do: "  @type t :: %__MODULE__{}\n"
   def typespec_str([], [], [_ | _]), do: "  @type t :: %__MODULE__{__pb_extensions__: map}\n"

--- a/test/protobuf/protoc/generator/message_test.exs
+++ b/test/protobuf/protoc/generator/message_test.exs
@@ -67,7 +67,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       )
 
     {[], [msg]} = Generator.generate(ctx, desc)
-    assert msg =~ "defstruct [:a, :b]\n"
+    assert msg =~ "defstruct [a: nil, b: nil]\n"
     assert msg =~ "a: integer"
     assert msg =~ "b: String.t"
     assert msg =~ "field :a, 1, optional: true, type: :int32\n"
@@ -106,7 +106,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       )
 
     {[], [msg]} = Generator.generate(ctx, desc)
-    assert msg =~ "defstruct [:a, :b, :c]\n"
+    assert msg =~ "defstruct [a: 0, b: \"\", c: []]\n"
     assert msg =~ "a: integer"
     assert msg =~ "b: String.t"
     assert msg =~ "field :a, 1, type: :int32\n"
@@ -452,7 +452,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     assert msg =~ "second: {atom, any},\n"
     assert msg =~ "other: integer\n"
     refute msg =~ "a: integer,\n"
-    assert msg =~ "defstruct [:first, :second, :other]\n"
+    assert msg =~ "defstruct [first: nil, second: nil, other: nil]\n"
     assert msg =~ "oneof :first, 0\n"
     assert msg =~ "oneof :second, 1\n"
     assert msg =~ "field :a, 1, optional: true, type: :int32, oneof: 0\n"

--- a/test/protobuf/protoc/proto_gen/extension.pb.ex
+++ b/test/protobuf/protoc/proto_gen/extension.pb.ex
@@ -5,7 +5,7 @@ defmodule Protobuf.Protoc.ExtTest.Foo do
   @type t :: %__MODULE__{
           a: String.t()
         }
-  defstruct [:a]
+  defstruct a: nil
 
   field :a, 1, optional: true, type: :string
 end

--- a/test/protobuf/protoc/proto_gen/test.pb.ex
+++ b/test/protobuf/protoc/proto_gen/test.pb.ex
@@ -47,7 +47,7 @@ defmodule My.Test.Request.SomeGroup do
   @type t :: %__MODULE__{
           group_field: integer
         }
-  defstruct [:group_field]
+  defstruct group_field: nil
 
   field :group_field, 9, optional: true, type: :int32
 end
@@ -60,7 +60,7 @@ defmodule My.Test.Request.NameMappingEntry do
           key: integer,
           value: String.t()
         }
-  defstruct [:key, :value]
+  defstruct key: nil, value: nil
 
   field :key, 1, optional: true, type: :int32
   field :value, 2, optional: true, type: :string
@@ -74,7 +74,7 @@ defmodule My.Test.Request.MsgMappingEntry do
           key: integer,
           value: My.Test.Reply.t() | nil
         }
-  defstruct [:key, :value]
+  defstruct key: nil, value: nil
 
   field :key, 1, optional: true, type: :sint64
   field :value, 2, optional: true, type: My.Test.Reply
@@ -95,17 +95,15 @@ defmodule My.Test.Request do
           reset: integer,
           get_key: String.t()
         }
-  defstruct [
-    :key,
-    :hue,
-    :hat,
-    :deadline,
-    :somegroup,
-    :name_mapping,
-    :msg_mapping,
-    :reset,
-    :get_key
-  ]
+  defstruct key: [],
+            hue: nil,
+            hat: :FEDORA,
+            deadline: "inf",
+            somegroup: nil,
+            name_mapping: [],
+            msg_mapping: [],
+            reset: nil,
+            get_key: nil
 
   field :key, 1, repeated: true, type: :int64
   field :hue, 3, optional: true, type: My.Test.Request.Color, enum: true
@@ -127,7 +125,7 @@ defmodule My.Test.Reply.Entry do
           value: integer,
           _my_field_name_2: integer
         }
-  defstruct [:key_that_needs_1234camel_CasIng, :value, :_my_field_name_2]
+  defstruct key_that_needs_1234camel_CasIng: nil, value: 7, _my_field_name_2: nil
 
   field :key_that_needs_1234camel_CasIng, 1, required: true, type: :int64
   field :value, 2, optional: true, type: :int64, default: 7
@@ -143,7 +141,7 @@ defmodule My.Test.Reply do
           compact_keys: [integer],
           __pb_extensions__: map
         }
-  defstruct [:found, :compact_keys, :__pb_extensions__]
+  defstruct found: [], compact_keys: [], __pb_extensions__: nil
 
   field :found, 1, repeated: true, type: My.Test.Reply.Entry
   field :compact_keys, 2, repeated: true, type: :int32, packed: true
@@ -159,7 +157,7 @@ defmodule My.Test.OtherBase do
           name: String.t(),
           __pb_extensions__: map
         }
-  defstruct [:name, :__pb_extensions__]
+  defstruct name: nil, __pb_extensions__: nil
 
   field :name, 1, optional: true, type: :string
 
@@ -181,7 +179,7 @@ defmodule My.Test.OtherReplyExtensions do
   @type t :: %__MODULE__{
           key: integer
         }
-  defstruct [:key]
+  defstruct key: nil
 
   field :key, 1, optional: true, type: :int32
 end
@@ -191,7 +189,7 @@ defmodule My.Test.OldReply do
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{__pb_extensions__: map}
-  defstruct [:__pb_extensions__]
+  defstruct __pb_extensions__: nil
 
   extensions [{100, 2_147_483_647}]
 end
@@ -203,7 +201,7 @@ defmodule My.Test.Communique.SomeGroup do
   @type t :: %__MODULE__{
           member: String.t()
         }
-  defstruct [:member]
+  defstruct member: nil
 
   field :member, 15, optional: true, type: :string
 end
@@ -224,7 +222,7 @@ defmodule My.Test.Communique do
           union: {atom, any},
           make_me_cry: boolean
         }
-  defstruct [:union, :make_me_cry]
+  defstruct union: nil, make_me_cry: nil
 
   oneof :union, 0
 
@@ -248,7 +246,7 @@ defmodule My.Test.Options do
   @type t :: %__MODULE__{
           opt1: String.t()
         }
-  defstruct [:opt1]
+  defstruct opt1: nil
 
   field :opt1, 1, optional: true, type: :string, deprecated: true
 end


### PR DESCRIPTION
The recommended option is to use the `new`
constructor, however, it doesn't mean we couldn't
have a better default for structs.

Let's say a has a repeated field, it would be nice to
be a list by default if somebody tries to `%Struct{}`.

Closes the issue:

https://github.com/tony612/protobuf-elixir/issues/93