### PR TITLE
Option to return maps with :__msg__ key instead of structs

### DIFF
--- a/lib/protobuf/decoder.ex
+++ b/lib/protobuf/decoder.ex
@@ -14,6 +14,12 @@ defmodule Protobuf.Decoder do
     kvs = raw_decode_key(data, [])
     %{repeated_fields: repeated_fields} = msg_props = module.__message_props__()
     struct = build_struct(kvs, msg_props, module.new())
+    
+    struct = if Process.get({:protobuf, :return_maps}) do
+      struct = Map.put(struct, :__msg__, struct.__struct__)
+      Map.delete(struct, :__struct__)
+    else struct end
+    
     reverse_repeated(struct, repeated_fields)
   end
 


### PR DESCRIPTION
A little hacky but I could not find a better way to do this without breaking some stuff. 

I am open to clean it up based on suggestions, but the basic idea is to have a way to return maps insteads of structs.  Structs are not very flexible (example put_in does not work) and other shenanigans.  