### PR TITLE
feat: include comments from protofile as type and moduledoc attributes

### DIFF
--- a/lib/elixirpb.pb.ex
+++ b/lib/elixirpb.pb.ex
@@ -1,10 +1,24 @@
 defmodule Elixirpb.FileOptions do
-  @moduledoc false
+  @moduledoc """
+  File level options
+
+  For example,
+  option (elixirpb.file).module_prefix = "Foo";
+  """
   use Protobuf, syntax: :proto2
 
+  @typedoc """
+  Specify a module prefix. This will override package name.
+  For example, the package is "hello" and a message is "Request", the message
+  will be "Hello.Request". But with module_prefix "Foo", the message will be
+  "Foo.Request"
+  """
+  @type module_prefix :: String.t()
+
   @type t :: %__MODULE__{
-          module_prefix: String.t()
+          module_prefix: module_prefix()
         }
+
   defstruct [:module_prefix]
 
   field :module_prefix, 1, optional: true, type: :string

--- a/lib/protobuf/protoc/context.ex
+++ b/lib/protobuf/protoc/context.ex
@@ -33,7 +33,7 @@ defmodule Protobuf.Protoc.Context do
 
             # Encapsulates information about the original source file from which a
             # FileDescriptorProto was generated.
-            source_code_info: %{ location: [] },
+            source_code_info: %{location: []},
 
             # path to a Location as per documentation for protobufs `descriptor.proto/SourceCodeInfo/Location`
             # see: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/descriptor.proto#L798

--- a/lib/protobuf/protoc/context.ex
+++ b/lib/protobuf/protoc/context.ex
@@ -29,7 +29,15 @@ defmodule Protobuf.Protoc.Context do
             gen_descriptors?: false,
 
             # Elixirpb.FileOptions
-            custom_file_options: %{}
+            custom_file_options: %{},
+
+            # Encapsulates information about the original source file from which a
+            # FileDescriptorProto was generated.
+            source_code_info: %{ location: [] },
+
+            # path to a Location as per documentation for protobufs `descriptor.proto/SourceCodeInfo/Location`
+            # see: https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/descriptor.proto#L798
+            location_path: []
 
   def cal_file_options(ctx, nil) do
     %{ctx | custom_file_options: %{}, module_prefix: ctx.package || ""}

--- a/lib/protobuf/protoc/generator/enum.ex
+++ b/lib/protobuf/protoc/generator/enum.ex
@@ -2,8 +2,14 @@ defmodule Protobuf.Protoc.Generator.Enum do
   @moduledoc false
   alias Protobuf.Protoc.Generator.Util
 
+  defp with_enum_message_path(%{location_path: path} = ctx, index) do
+    %{ctx | location_path: path ++ [5, index]}
+  end
+
   def generate_list(ctx, descs) do
-    Enum.map(descs, fn desc -> generate(ctx, desc) end)
+    descs
+    |> Enum.with_index()
+    |> Enum.map(fn {desc, index} -> generate(with_enum_message_path(ctx, index), desc) end)
   end
 
   def generate(%{namespace: ns} = ctx, desc) do
@@ -11,18 +17,57 @@ defmodule Protobuf.Protoc.Generator.Enum do
     fields = Enum.map(desc.value, fn f -> generate_field(f) end)
     msg_name = Util.mod_name(ctx, ns ++ [name])
     generate_desc = if ctx.gen_descriptors?, do: desc, else: nil
-    type = generate_type(desc.value)
+    type = generate_type(ctx, desc.value)
 
-    Protobuf.Protoc.Template.enum(msg_name, msg_opts(ctx, desc), fields, type, generate_desc)
+    docs =
+      Util.moduledoc_str(
+        ctx,
+        String.contains?(type, "@typedoc")
+      )
+
+    Protobuf.Protoc.Template.enum(
+      msg_name,
+      msg_opts(ctx, desc),
+      fields,
+      type,
+      generate_desc,
+      docs
+    )
   end
 
-  def generate_type(fields) do
+  defp with_enum_value_path(%{location_path: path} = ctx, index) do
+    %{ctx | location_path: path ++ [2, index]}
+  end
+
+  def generate_type(ctx, fields) do
+    value_types =
+      fields
+      |> Enum.with_index()
+      |> Enum.map(fn {f, index} ->
+        {f.name, Util.find_location(ctx |> with_enum_value_path(index)) |> Util.fmt_doc_str()}
+      end)
+
+    dedicated_type_str =
+      value_types
+      |> Enum.flat_map(fn {name, docs} ->
+        type_str = "@type #{Util.safe_type_name(name)} :: :#{name}"
+
+        if String.length(String.trim(docs)) > 0 do
+          ["", "@typedoc \"\"\"", docs, "\"\"\"", type_str, ""]
+        else
+          [type_str]
+        end
+      end)
+      |> Enum.join("\n")
+
     field_values =
       fields
-      |> Enum.map(fn f -> ":#{f.name}" end)
+      |> Enum.map(fn f -> "#{Util.safe_type_name(f.name)}()" end)
       |> Enum.join(" | ")
 
-    "@type t :: integer | " <> field_values
+    aggregate_type_str = "@type t :: integer | " <> field_values
+
+    dedicated_type_str <> "\n" <> aggregate_type_str
   end
 
   def generate_field(f) do

--- a/lib/protobuf/protoc/generator/service.ex
+++ b/lib/protobuf/protoc/generator/service.ex
@@ -26,7 +26,13 @@ defmodule Protobuf.Protoc.Generator.Service do
     name = Util.attach_raw_pkg(desc.name, ctx.package)
     methods = get_methods(ctx, desc.method)
     generate_desc = if ctx.gen_descriptors?, do: desc, else: nil
-    docs = Util.moduledoc_str(ctx, methods |> Enum.all?(fn m -> String.length(String.trim(m[:docs])) end))
+
+    docs =
+      Util.moduledoc_str(
+        ctx,
+        methods |> Enum.all?(fn m -> String.length(String.trim(m[:docs])) end)
+      )
+
     Protobuf.Protoc.Template.service(mod_name, name, methods, generate_desc, docs)
   end
 

--- a/lib/protobuf/protoc/generator/util.ex
+++ b/lib/protobuf/protoc/generator/util.ex
@@ -74,6 +74,7 @@ defmodule Protobuf.Protoc.Generator.Util do
     #    */
     |> Enum.map(&String.replace_prefix(&1, " ", ""))
     |> Enum.join("\n")
+    |> String.trim_leading()
     |> String.trim_trailing()
   end
 

--- a/lib/protobuf/protoc/generator/util.ex
+++ b/lib/protobuf/protoc/generator/util.ex
@@ -97,10 +97,19 @@ defmodule Protobuf.Protoc.Generator.Util do
     name = name |> to_string() |> String.downcase()
 
     try do
+      original_compiler_options = Code.compiler_options()
+
+      # `Code.compile_string/2` will also load the compiled module into memory causing: `warning: redefining module SafeTypeNameWrapper (current version defined in memory)`
+      # to disable these temporarily we modify the compiler options
+      Code.compiler_options(ignore_module_conflict: true)
+
       # this will fail for names like
       # - `or` that are elixir operators and therefore are limited in how they can be used
       # - `number` and other predefined types which can not be redefined (see: https://hexdocs.pm/elixir/typespecs.html)
       Code.compile_string("defmodule SafeTypeNameWrapper do @type #{name} :: any() end")
+
+      # reset to the original/unmodified compiler options
+      Code.compiler_options(original_compiler_options)
 
       name
     rescue

--- a/lib/protobuf/protoc/generator/util.ex
+++ b/lib/protobuf/protoc/generator/util.ex
@@ -95,10 +95,11 @@ defmodule Protobuf.Protoc.Generator.Util do
   @spec safe_type_name(binary()) :: binary()
   def safe_type_name(name) do
     prefix = "__"
-    reserved_names = ["and", "or", "not"]
+    reserved_names = ["and", "or", "not", "number"]
+    name = name |> to_string()
 
     if name in reserved_names do
-      prefix <> String.downcase(name)
+      String.downcase(prefix <> name)
     else
       String.downcase(name)
     end

--- a/lib/protobuf/protoc/template.ex
+++ b/lib/protobuf/protoc/template.ex
@@ -11,15 +11,15 @@ defmodule Protobuf.Protoc.Template do
     :def,
     :message,
     @msg_tmpl,
-    [:name, :options, :struct_fields, :typespec, :oneofs, :fields, :desc, :extensions],
+    [:name, :options, :struct_fields, :typespec, :oneofs, :fields, :desc, :extensions, :docs],
     trim: true
   )
 
-  EEx.function_from_file(:def, :enum, @enum_tmpl, [:name, :options, :fields, :type, :desc],
+  EEx.function_from_file(:def, :enum, @enum_tmpl, [:name, :options, :fields, :type, :desc, :docs],
     trim: true
   )
 
-  EEx.function_from_file(:def, :service, @svc_tmpl, [:mod_name, :name, :methods, :desc],
+  EEx.function_from_file(:def, :service, @svc_tmpl, [:mod_name, :name, :methods, :desc, :docs],
     trim: true
   )
 

--- a/priv/templates/enum.ex.eex
+++ b/priv/templates/enum.ex.eex
@@ -1,5 +1,8 @@
 defmodule <%= name %> do
+  <%= if not is_nil(docs) do %><%= docs %>
+  <% else %>
   @moduledoc false
+  <% end %>
   use Protobuf<%= options %>
   
   <%= type %>

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -1,8 +1,12 @@
 defmodule <%= name %> do
+  <%= if not is_nil(docs) do %><%= docs %>
+  <% else %>
   @moduledoc false
+  <% end %>
   use Protobuf<%= options %>
 
-  <%= typespec %>
+  <%= typespec <> "\n" %>
+  
   defstruct [<%= struct_fields %>]
 
   <%= if not is_nil(desc) do %>
@@ -17,7 +21,7 @@ defmodule <%= name %> do
 <%= for v <- oneofs do %>  <%= v %>
 <% end %>
 
-<%= for f <- fields do %>  field <%= f %>
+<%= for f <- fields do %>  <%= f %>
 <% end %>
 
   <%= if not is_nil(extensions) do %>

--- a/priv/templates/service.ex.eex
+++ b/priv/templates/service.ex.eex
@@ -11,12 +11,31 @@ defmodule <%= mod_name %>.Service do
   end
   <% end %>
 
-<%= Enum.map methods, fn(method) -> %>
-  rpc <%= method %>
+<%= Enum.map methods, fn(%{name: name, input: input, output: output}) -> %>
+  rpc <%= ":#{name}, #{input}, #{output}" %>
 <% end %>
 end
 
 defmodule <%= mod_name %>.Stub do
   @moduledoc false
   use GRPC.Stub, service: <%= mod_name %>.Service
+end
+
+defmodule <%= mod_name %>.Behaviour do
+  <%= docs %>
+
+  <%= methods |> Enum.flat_map(fn m ->
+    cb_str = "@callback #{m[:handler_name]}(input :: #{m[:input]}.t(), stream :: GRPC.Server.Stream.t()) :: #{m[:output]}.t()"
+
+    if String.length(String.trim(m[:docs])) > 0 do
+      ["", "@doc \"\"\"", m[:docs], "\"\"\"", cb_str, ""]
+    else
+      [cb_str]
+    end
+  end) |> Enum.join("\n") %>
+
+
+  @optional_callbacks <%= methods |> Enum.map_join(", ", fn m ->
+    "#{m[:handler_name]}: 2"
+  end) %>
 end

--- a/test/protobuf/protoc/generator/enum_test.exs
+++ b/test/protobuf/protoc/generator/enum_test.exs
@@ -19,7 +19,9 @@ defmodule Protobuf.Protoc.Generator.EnumTest do
     msg = Generator.generate(ctx, desc)
     assert msg =~ "defmodule EnumFoo do\n"
     assert msg =~ "use Protobuf, enum: true\n"
-    assert msg =~ "@type t :: integer | :A | :B\n"
+    assert msg =~ "@type a :: :A\n"
+    assert msg =~ "@type b :: :B\n"
+    assert msg =~ "@type t :: integer | a() | b()\n"
     refute msg =~ "defstruct "
     assert msg =~ "field :A, 0\n  field :B, 1\n"
   end

--- a/test/protobuf/protoc/generator/message_test.exs
+++ b/test/protobuf/protoc/generator/message_test.exs
@@ -68,8 +68,8 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
 
     {[], [msg]} = Generator.generate(ctx, desc)
     assert msg =~ "defstruct [:a, :b]\n"
-    assert msg =~ "a: integer"
-    assert msg =~ "b: String.t"
+    assert msg =~ "a :: integer"
+    assert msg =~ "b :: String.t"
     assert msg =~ "field :a, 1, optional: true, type: :int32\n"
     assert msg =~ "field :b, 2, required: true, type: :string\n"
   end
@@ -107,8 +107,8 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
 
     {[], [msg]} = Generator.generate(ctx, desc)
     assert msg =~ "defstruct [:a, :b, :c]\n"
-    assert msg =~ "a: integer"
-    assert msg =~ "b: String.t"
+    assert msg =~ "a :: integer"
+    assert msg =~ "b :: String.t"
     assert msg =~ "field :a, 1, type: :int32\n"
     assert msg =~ "field :b, 2, type: :string\n"
     assert msg =~ "field :c, 3, repeated: true, type: :int32\n"
@@ -133,7 +133,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       )
 
     {[], [msg]} = Generator.generate(ctx, desc)
-    assert msg =~ "a: integer"
+    assert msg =~ "a :: integer"
     assert msg =~ "field :a, 1, optional: true, type: :int32, default: 42\n"
   end
 
@@ -214,8 +214,10 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       )
 
     {[], [msg]} = Generator.generate(ctx, desc)
-    assert msg =~ "bar: Bar.t | nil"
-    assert msg =~ "baz: [Baz.t]"
+    assert msg =~ "@type bar :: Bar.t | nil"
+    assert msg =~ "bar: bar()"
+    assert msg =~ "@type baz :: [Baz.t]"
+    assert msg =~ "baz: baz()"
   end
 
   test "generate/2 supports map field" do
@@ -267,7 +269,8 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       )
 
     {[[]], [_, msg]} = Generator.generate(ctx, desc)
-    assert msg =~ "a: %{integer => FooBar.AbCd.Bar.t | nil}"
+    assert msg =~ "@type a :: %{integer => FooBar.AbCd.Bar.t | nil}"
+    assert msg =~ "a: a()"
     assert msg =~ "field :a, 1, repeated: true, type: FooBar.AbCd.Foo.ProjectsEntry, map: true\n"
   end
 
@@ -295,7 +298,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       )
 
     {[], [msg]} = Generator.generate(ctx, desc)
-    assert msg =~ "a: FooBar.AbCd.EnumFoo.t"
+    assert msg =~ "a :: FooBar.AbCd.EnumFoo.t"
     assert msg =~ "field :a, 1, optional: true, type: FooBar.AbCd.EnumFoo, enum: true\n"
   end
 
@@ -346,7 +349,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       )
 
     {[], [msg]} = Generator.generate(ctx, desc)
-    assert msg =~ "a: OtherPkg.MsgFoo.t"
+    assert msg =~ "a :: OtherPkg.MsgFoo.t"
     assert msg =~ "field :a, 1, optional: true, type: OtherPkg.MsgFoo\n"
   end
 
@@ -448,10 +451,14 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       )
 
     {[], [msg]} = Generator.generate(ctx, desc)
-    assert msg =~ "first: {atom, any},\n"
-    assert msg =~ "second: {atom, any},\n"
-    assert msg =~ "other: integer\n"
-    refute msg =~ "a: integer,\n"
+    assert msg =~ "@type first :: {:a, a()} | {:b, b()} | nil\n"
+    assert msg =~ "@type second :: {:c, c()} | {:d, d()} | nil\n"
+    assert msg =~ "@type other :: integer\n"
+    assert msg =~ "@type a :: integer\n"
+    refute msg =~ "a: integer\n"
+    assert msg =~ "other: other(),\n"
+    assert msg =~ "first: first(),\n"
+    assert msg =~ "second: second()\n"
     assert msg =~ "defstruct [:first, :second, :other]\n"
     assert msg =~ "oneof :first, 0\n"
     assert msg =~ "oneof :second, 1\n"

--- a/test/protobuf/protoc/proto/test.proto
+++ b/test/protobuf/protoc/proto/test.proto
@@ -6,6 +6,10 @@ package my.test;  // dotted package name
 //import "imp.proto";
 import "multi/multi1.proto";  // unused import
 
+/*
+  The Comment, yadda yadda yadda
+  More details
+  */
 enum HatType {
   // deliberately skipping 0
   FEDORA = 1;

--- a/test/protobuf/protoc/proto_gen/extension.pb.ex
+++ b/test/protobuf/protoc/proto_gen/extension.pb.ex
@@ -2,9 +2,11 @@ defmodule Protobuf.Protoc.ExtTest.Foo do
   @moduledoc false
   use Protobuf, syntax: :proto2
 
+  @type a :: String.t()
   @type t :: %__MODULE__{
-          a: String.t()
+          a: a()
         }
+
   defstruct [:a]
 
   field :a, 1, optional: true, type: :string

--- a/test/protobuf/protoc/proto_gen/test.pb.ex
+++ b/test/protobuf/protoc/proto_gen/test.pb.ex
@@ -1,4 +1,8 @@
 defmodule My.Test.HatType do
+  @moduledoc """
+  The Comment, yadda yadda yadda
+  More details
+  """
   use Protobuf, enum: true, syntax: :proto2
 
   @typedoc """
@@ -117,7 +121,7 @@ defmodule My.Test.Request do
   @type key :: [integer]
 
   @typedoc """
-   optional imp.ImportedMessage imported_message = 2;
+  optional imp.ImportedMessage imported_message = 2;
 
   no default
   """
@@ -126,7 +130,7 @@ defmodule My.Test.Request do
   @type hat :: My.Test.HatType.t()
 
   @typedoc """
-   optional imp.ImportedMessage.Owner owner = 6;
+  optional imp.ImportedMessage.Owner owner = 6;
   """
   @type deadline :: float | :infinity | :negative_infinity | :nan
 

--- a/test/protobuf/protoc/proto_gen/test.pb.ex
+++ b/test/protobuf/protoc/proto_gen/test.pb.ex
@@ -1,18 +1,33 @@
 defmodule My.Test.HatType do
-  @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
 
-  @type t :: integer | :FEDORA | :FEZ
+  @typedoc """
+  deliberately skipping 0
+  """
+  @type fedora :: :FEDORA
+
+  @type fez :: :FEZ
+  @type t :: integer | fedora() | fez()
 
   field :FEDORA, 1
   field :FEZ, 2
 end
 
 defmodule My.Test.Days do
-  @moduledoc false
+  @moduledoc """
+  This enum represents days of the week.
+  """
   use Protobuf, enum: true, syntax: :proto2
 
-  @type t :: integer | :MONDAY | :TUESDAY | :LUNDI
+  @type monday :: :MONDAY
+  @type tuesday :: :TUESDAY
+
+  @typedoc """
+  same value as MONDAY
+  """
+  @type lundi :: :LUNDI
+
+  @type t :: integer | monday() | tuesday() | lundi()
 
   field :MONDAY, 1
   field :TUESDAY, 2
@@ -23,7 +38,10 @@ defmodule My.Test.Request.Color do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
 
-  @type t :: integer | :RED | :GREEN | :BLUE
+  @type red :: :RED
+  @type green :: :GREEN
+  @type blue :: :BLUE
+  @type t :: integer | red() | green() | blue()
 
   field :RED, 0
   field :GREEN, 1
@@ -34,7 +52,9 @@ defmodule My.Test.Reply.Entry.Game do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
 
-  @type t :: integer | :FOOTBALL | :TENNIS
+  @type football :: :FOOTBALL
+  @type tennis :: :TENNIS
+  @type t :: integer | football() | tennis()
 
   field :FOOTBALL, 1
   field :TENNIS, 2
@@ -44,9 +64,11 @@ defmodule My.Test.Request.SomeGroup do
   @moduledoc false
   use Protobuf, syntax: :proto2
 
+  @type group_field :: integer
   @type t :: %__MODULE__{
-          group_field: integer
+          group_field: group_field()
         }
+
   defstruct [:group_field]
 
   field :group_field, 9, optional: true, type: :int32
@@ -56,10 +78,13 @@ defmodule My.Test.Request.NameMappingEntry do
   @moduledoc false
   use Protobuf, map: true, syntax: :proto2
 
+  @type key :: integer
+  @type value :: String.t()
   @type t :: %__MODULE__{
-          key: integer,
-          value: String.t()
+          key: key(),
+          value: value()
         }
+
   defstruct [:key, :value]
 
   field :key, 1, optional: true, type: :int32
@@ -70,10 +95,13 @@ defmodule My.Test.Request.MsgMappingEntry do
   @moduledoc false
   use Protobuf, map: true, syntax: :proto2
 
+  @type key :: integer
+  @type value :: My.Test.Reply.t() | nil
   @type t :: %__MODULE__{
-          key: integer,
-          value: My.Test.Reply.t() | nil
+          key: key(),
+          value: value()
         }
+
   defstruct [:key, :value]
 
   field :key, 1, optional: true, type: :sint64
@@ -81,20 +109,63 @@ defmodule My.Test.Request.MsgMappingEntry do
 end
 
 defmodule My.Test.Request do
-  @moduledoc false
+  @moduledoc """
+  This is a message that might be sent somewhere.
+  """
   use Protobuf, syntax: :proto2
 
+  @type key :: [integer]
+
+  @typedoc """
+   optional imp.ImportedMessage imported_message = 2;
+
+  no default
+  """
+  @type hue :: My.Test.Request.Color.t()
+
+  @type hat :: My.Test.HatType.t()
+
+  @typedoc """
+   optional imp.ImportedMessage.Owner owner = 6;
+  """
+  @type deadline :: float | :infinity | :negative_infinity | :nan
+
+  @type somegroup :: any
+
+  @typedoc """
+  These foreign types are in imp2.proto,
+  which is publicly imported by imp.proto.
+   optional imp.PubliclyImportedMessage pub = 10;
+   optional imp.PubliclyImportedEnum pub_enum = 13 [default=HAIR];
+
+  This is a map field. It will generate map[int32]string.
+  """
+  @type name_mapping :: %{integer => String.t()}
+
+  @typedoc """
+  This is a map field whose value type is a message.
+  """
+  @type msg_mapping :: %{integer => My.Test.Reply.t() | nil}
+
+  @type reset :: integer
+
+  @typedoc """
+  This field should not conflict with any getters.
+  """
+  @type get_key :: String.t()
+
   @type t :: %__MODULE__{
-          key: [integer],
-          hue: My.Test.Request.Color.t(),
-          hat: My.Test.HatType.t(),
-          deadline: float | :infinity | :negative_infinity | :nan,
-          somegroup: any,
-          name_mapping: %{integer => String.t()},
-          msg_mapping: %{integer => My.Test.Reply.t() | nil},
-          reset: integer,
-          get_key: String.t()
+          key: key(),
+          hue: hue(),
+          hat: hat(),
+          deadline: deadline(),
+          somegroup: somegroup(),
+          name_mapping: name_mapping(),
+          msg_mapping: msg_mapping(),
+          reset: reset(),
+          get_key: get_key()
         }
+
   defstruct [
     :key,
     :hue,
@@ -122,11 +193,15 @@ defmodule My.Test.Reply.Entry do
   @moduledoc false
   use Protobuf, syntax: :proto2
 
+  @type key_that_needs_1234camel_casing :: integer
+  @type value :: integer
+  @type _my_field_name_2 :: integer
   @type t :: %__MODULE__{
-          key_that_needs_1234camel_CasIng: integer,
-          value: integer,
-          _my_field_name_2: integer
+          key_that_needs_1234camel_CasIng: key_that_needs_1234camel_casing(),
+          value: value(),
+          _my_field_name_2: _my_field_name_2()
         }
+
   defstruct [:key_that_needs_1234camel_CasIng, :value, :_my_field_name_2]
 
   field :key_that_needs_1234camel_CasIng, 1, required: true, type: :int64
@@ -138,11 +213,14 @@ defmodule My.Test.Reply do
   @moduledoc false
   use Protobuf, syntax: :proto2
 
+  @type found :: [My.Test.Reply.Entry.t()]
+  @type compact_keys :: [integer]
+  @type __pb_extensions__ :: map
   @type t :: %__MODULE__{
-          found: [My.Test.Reply.Entry.t()],
-          compact_keys: [integer],
-          __pb_extensions__: map
+          found: found(),
+          compact_keys: compact_keys()
         }
+
   defstruct [:found, :compact_keys, :__pb_extensions__]
 
   field :found, 1, repeated: true, type: My.Test.Reply.Entry
@@ -155,10 +233,12 @@ defmodule My.Test.OtherBase do
   @moduledoc false
   use Protobuf, syntax: :proto2
 
+  @type name :: String.t()
+  @type __pb_extensions__ :: map
   @type t :: %__MODULE__{
-          name: String.t(),
-          __pb_extensions__: map
+          name: name()
         }
+
   defstruct [:name, :__pb_extensions__]
 
   field :name, 1, optional: true, type: :string
@@ -171,6 +251,7 @@ defmodule My.Test.ReplyExtensions do
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{}
+
   defstruct []
 end
 
@@ -178,9 +259,11 @@ defmodule My.Test.OtherReplyExtensions do
   @moduledoc false
   use Protobuf, syntax: :proto2
 
+  @type key :: integer
   @type t :: %__MODULE__{
-          key: integer
+          key: key()
         }
+
   defstruct [:key]
 
   field :key, 1, optional: true, type: :int32
@@ -191,6 +274,7 @@ defmodule My.Test.OldReply do
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{__pb_extensions__: map}
+
   defstruct [:__pb_extensions__]
 
   extensions [{100, 2_147_483_647}]
@@ -200,9 +284,11 @@ defmodule My.Test.Communique.SomeGroup do
   @moduledoc false
   use Protobuf, syntax: :proto2
 
+  @type member :: String.t()
   @type t :: %__MODULE__{
-          member: String.t()
+          member: member()
         }
+
   defstruct [:member]
 
   field :member, 15, optional: true, type: :string
@@ -213,17 +299,51 @@ defmodule My.Test.Communique.Delta do
   use Protobuf, syntax: :proto2
 
   @type t :: %__MODULE__{}
+
   defstruct []
 end
 
 defmodule My.Test.Communique do
-  @moduledoc false
   use Protobuf, syntax: :proto2
 
+  @type make_me_cry :: boolean
+  @type __number :: integer
+  @type name :: String.t()
+  @type data :: binary
+  @type temp_c :: float | :infinity | :negative_infinity | :nan
+  @type height :: float | :infinity | :negative_infinity | :nan
+  @type today :: My.Test.Days.t()
+  @type maybe :: boolean
+
+  @typedoc """
+  name will conflict with Delta below
+  """
+  @type delta :: integer
+
+  @type msg :: My.Test.Reply.t() | nil
+  @type somegroup :: any
+
+  @typedoc """
+  This is a oneof, called "union".
+  """
+  @type union ::
+          {:number, __number()}
+          | {:name, name()}
+          | {:data, data()}
+          | {:temp_c, temp_c()}
+          | {:height, height()}
+          | {:today, today()}
+          | {:maybe, maybe()}
+          | {:delta, delta()}
+          | {:msg, msg()}
+          | {:somegroup, somegroup()}
+          | nil
+
   @type t :: %__MODULE__{
-          union: {atom, any},
-          make_me_cry: boolean
+          make_me_cry: make_me_cry(),
+          union: union()
         }
+
   defstruct [:union, :make_me_cry]
 
   oneof :union, 0
@@ -245,9 +365,11 @@ defmodule My.Test.Options do
   @moduledoc false
   use Protobuf, syntax: :proto2
 
+  @type opt1 :: String.t()
   @type t :: %__MODULE__{
-          opt1: String.t()
+          opt1: opt1()
         }
+
   defstruct [:opt1]
 
   field :opt1, 1, optional: true, type: :string, deprecated: true

--- a/test/protobuf/protoc/proto_gen/test.pb.ex
+++ b/test/protobuf/protoc/proto_gen/test.pb.ex
@@ -307,7 +307,7 @@ defmodule My.Test.Communique do
   use Protobuf, syntax: :proto2
 
   @type make_me_cry :: boolean
-  @type __number :: integer
+  @type number_ :: integer
   @type name :: String.t()
   @type data :: binary
   @type temp_c :: float | :infinity | :negative_infinity | :nan
@@ -327,7 +327,7 @@ defmodule My.Test.Communique do
   This is a oneof, called "union".
   """
   @type union ::
-          {:number, __number()}
+          {:number, number_()}
           | {:name, name()}
           | {:data, data()}
           | {:temp_c, temp_c()}


### PR DESCRIPTION
This PR integrates comments from `*.proto` files into the generated elixir code.
Our Team uses protobuf to describe our domain and gRPC Services.
We'd love the generated elixir code to include documentation from these files, so it gets included in hexdoc and is directly available during development without switching context.
Seeing #108 there seems to be at least some interest by others as well.

This PR:

- adds `@moduledoc` when a `message`/`enum` or `service` has a leading or trailing comment as reported by [`FileDescriptorProto.SourceCodeInfo.Location`](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/descriptor.proto#L798)
- adds `@typedoc` to fields and enum values when they have a leading or trailing comment as reported by [`FileDescriptorProto.SourceCodeInfo.Location`](https://github.com/protocolbuffers/protobuf/blob/master/src/google/protobuf/descriptor.proto#L798)
- adds `@moduledoc false` when no field or enum has a `@typedoc` annotation
- doesn't add `@moduledoc false` when any field or enum has a `@typedoc` annotation
- introduces a `MyService.Behaviour` module which sets up `@optional_callbacks` for each gRPC service rpc

To be able to add `@typedoc` annotations to the relevant pieces of code I had to split the `@type t :: __MODULE...` block into dedicated `@type <field> :: ...` statements, hence the modified tests.

The code focuses on `proto3` as I have not much experience with `proto2` there might be room for improvement here.

@jeffutter As you seem to have a demand for this feature too, maybe you can take a quick look and see if this would improve your situation?