### PR TITLE
Fix compiler warning for Elixir versions prior to 1.12

### DIFF
--- a/lib/protobuf/wire/varint.ex
+++ b/lib/protobuf/wire/varint.ex
@@ -48,6 +48,8 @@ defmodule Protobuf.Wire.Varint do
   @max_bits 64
   @mask64 bsl(1, @max_bits) - 1
 
+  # generated: true is required here to silence compilation warnings in Elixir
+  # 1.10 and 1.11. OK to remove once we support only 1.12+
   @varints [
     {
       quote(do: <<0::1, value::7>>),
@@ -55,25 +57,25 @@ defmodule Protobuf.Wire.Varint do
     },
     {
       quote(do: <<1::1, x0::7, 0::1, x1::7>>),
-      quote(do: x0 + bsl(x1, 7))
+      quote(generated: true, do: x0 + bsl(x1, 7))
     },
     {
       quote(do: <<1::1, x0::7, 1::1, x1::7, 0::1, x2::7>>),
-      quote(do: x0 + bsl(x1, 7) + bsl(x2, 14))
+      quote(generated: true, do: x0 + bsl(x1, 7) + bsl(x2, 14))
     },
     {
       quote(do: <<1::1, x0::7, 1::1, x1::7, 1::1, x2::7, 0::1, x3::7>>),
-      quote(do: x0 + bsl(x1, 7) + bsl(x2, 14) + bsl(x3, 21))
+      quote(generated: true, do: x0 + bsl(x1, 7) + bsl(x2, 14) + bsl(x3, 21))
     },
     {
       quote(do: <<1::1, x0::7, 1::1, x1::7, 1::1, x2::7, 1::1, x3::7, 0::1, x4::7>>),
-      quote(do: x0 + bsl(x1, 7) + bsl(x2, 14) + bsl(x3, 21) + bsl(x4, 28))
+      quote(generated: true, do: x0 + bsl(x1, 7) + bsl(x2, 14) + bsl(x3, 21) + bsl(x4, 28))
     },
     {
       quote do
         <<1::1, x0::7, 1::1, x1::7, 1::1, x2::7, 1::1, x3::7, 1::1, x4::7, 0::1, x5::7>>
       end,
-      quote do
+      quote(generated: true) do
         x0 +
           bsl(x1, 7) +
           bsl(x2, 14) +
@@ -87,7 +89,7 @@ defmodule Protobuf.Wire.Varint do
         <<1::1, x0::7, 1::1, x1::7, 1::1, x2::7, 1::1, x3::7, 1::1, x4::7, 1::1, x5::7, 0::1,
           x6::7>>
       end,
-      quote do
+      quote(generated: true) do
         x0 +
           bsl(x1, 7) +
           bsl(x2, 14) +
@@ -102,7 +104,7 @@ defmodule Protobuf.Wire.Varint do
         <<1::1, x0::7, 1::1, x1::7, 1::1, x2::7, 1::1, x3::7, 1::1, x4::7, 1::1, x5::7, 1::1,
           x6::7, 0::1, x7::7>>
       end,
-      quote do
+      quote(generated: true) do
         x0 +
           bsl(x1, 7) +
           bsl(x2, 14) +
@@ -118,7 +120,7 @@ defmodule Protobuf.Wire.Varint do
         <<1::1, x0::7, 1::1, x1::7, 1::1, x2::7, 1::1, x3::7, 1::1, x4::7, 1::1, x5::7, 1::1,
           x6::7, 1::1, x7::7, 0::1, x8::7>>
       end,
-      quote do
+      quote(generated: true) do
         x0 +
           bsl(x1, 7) +
           bsl(x2, 14) +
@@ -135,7 +137,7 @@ defmodule Protobuf.Wire.Varint do
         <<1::1, x0::7, 1::1, x1::7, 1::1, x2::7, 1::1, x3::7, 1::1, x4::7, 1::1, x5::7, 1::1,
           x6::7, 1::1, x7::7, 1::1, x8::7, 0::1, x9::7>>
       end,
-      quote do
+      quote(generated: true) do
         band(
           x0 +
             bsl(x1, 7) +


### PR DESCRIPTION
That warning no longer shows up in Elixir 1.12, but still does in 1.11 and lower. Adding `generated: true` in a few places fixes it.

    warning: the result of the expression is ignored (suppress the warning by assigning the expression to the _ variable)
      lib/protobuf/decoder.ex:103