### PR TITLE
Refactor some extensions-related code

### DIFF
--- a/lib/application.ex
+++ b/lib/application.ex
@@ -36,11 +36,10 @@ defmodule Protobuf.Application do
         :erlang.loaded()
 
       :interactive ->
-        for {app, _, _} <- Application.loaded_applications() do
+        Enum.flat_map(Application.loaded_applications(), fn {app, _desc, _vsn} ->
           {:ok, modules} = :application.get_key(app, :modules)
           modules
-        end
-        |> Enum.concat()
+        end)
     end
   end
 end

--- a/lib/application.ex
+++ b/lib/application.ex
@@ -11,35 +11,36 @@ defmodule Protobuf.Application do
   @doc false
   @impl true
   def start(_type, _args) do
-    if Application.get_env(:protobuf, :extensions, :disabled) == :enabled do
-      mods = get_all_modules()
-      Protobuf.Extension.__cal_extensions__(mods)
-    else
-      # Extensions in Protobuf should always be calculated for generating code
-      {:ok, mods} = :application.get_key(:protobuf, :modules)
-      Protobuf.Extension.__cal_extensions__(mods)
-    end
+    Protobuf.Extension.__cal_extensions__(get_all_modules())
 
-    children = []
-    Supervisor.start_link(children, strategy: :one_for_one)
+    Supervisor.start_link(_children = [], strategy: :one_for_one)
   end
 
+  @doc false
   @impl true
   def stop(_state) do
     Protobuf.Extension.__unload_extensions__()
     :ok
   end
 
-  defp get_all_modules() do
-    case :code.get_mode() do
-      :embedded ->
-        :erlang.loaded()
+  defp get_all_modules do
+    case Application.get_env(:protobuf, :extensions) do
+      :enabled ->
+        case :code.get_mode() do
+          :embedded ->
+            :erlang.loaded()
 
-      :interactive ->
-        Enum.flat_map(Application.loaded_applications(), fn {app, _desc, _vsn} ->
-          {:ok, modules} = :application.get_key(app, :modules)
-          modules
-        end)
+          :interactive ->
+            Enum.flat_map(Application.loaded_applications(), fn {app, _desc, _vsn} ->
+              {:ok, modules} = :application.get_key(app, :modules)
+              modules
+            end)
+        end
+
+      _disabled ->
+        # Extensions in Protobuf are required for generating code
+        {:ok, mods} = :application.get_key(:protobuf, :modules)
+        mods
     end
   end
 end

--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -86,14 +86,8 @@ defmodule Protobuf.DSL do
         unquote(def_extension_functions())
       end
 
-      if unquote(syntax == :proto3) do
-        def __default_struct__ do
-          unquote(Macro.escape(default_struct))
-        end
-      else
-        def __default_struct__ do
-          unquote(Macro.escape(default_struct))
-        end
+      def __default_struct__ do
+        unquote(Macro.escape(default_struct))
       end
     end
   end

--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -141,10 +141,6 @@ defmodule Protobuf.DSL do
 
   defp def_extension_functions() do
     quote do
-      def put_extension(%__MODULE__{} = struct, extension_mod, field, value) do
-        Protobuf.Extension.put(__MODULE__, struct, extension_mod, field, value)
-      end
-
       def put_extension(%{} = map, extension_mod, field, value) do
         Protobuf.Extension.put(__MODULE__, map, extension_mod, field, value)
       end

--- a/lib/protobuf/extension.ex
+++ b/lib/protobuf/extension.ex
@@ -114,18 +114,12 @@ defmodule Protobuf.Extension do
 
   @doc false
   def __cal_extensions__(mods) do
-    mods
-    |> Enum.filter(fn mod ->
-      if to_string(mod) =~ ~r/\.PbExtension$/ && Code.ensure_loaded?(mod) do
-        function_exported?(mod, :__protobuf_info__, 1)
-      end
-    end)
-    |> Enum.map(fn mod ->
-      {mod, mod.__protobuf_info__(:extension_props)}
-    end)
-    |> Enum.reject(fn {_mod, props} -> is_nil(props) end)
-    |> Enum.each(fn {mod, props} ->
-      Enum.each(props.extensions, fn {_, ext} ->
+    for mod <- mods,
+        to_string(mod) =~ ~r/\.PbExtension$/,
+        Code.ensure_loaded?(mod),
+        function_exported?(mod, :__protobuf_info__, 1),
+        %{extensions: extensions} = mod.__protobuf_info__(:extension_props) do
+      Enum.each(extensions, fn {_, ext} ->
         fnum = ext.field_props.fnum
         fnum_key = {Protobuf.Extension, ext.extendee, fnum}
 
@@ -135,7 +129,7 @@ defmodule Protobuf.Extension do
 
         :persistent_term.put(fnum_key, mod)
       end)
-    end)
+    end
   end
 
   @doc false


### PR DESCRIPTION
Opportunistic refactoring from the work on #164. Concentrated config-reading code inside `get_all_modules`, optimized `cal_extensions` to do fewer iterations and removed a few unreachable/redundant code paths.