### PR TITLE
Set sensible defaults for structs

### DIFF
--- a/test/protobuf/protoc/generator/message_test.exs
+++ b/test/protobuf/protoc/generator/message_test.exs
@@ -67,7 +67,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       )
 
     {[], [msg]} = Generator.generate(ctx, desc)
-    assert msg =~ "defstruct [:a, :b]\n"
+    assert msg =~ "defstruct [a: nil, b: nil]\n"
     assert msg =~ "a: integer"
     assert msg =~ "b: String.t"
     assert msg =~ "field :a, 1, optional: true, type: :int32\n"
@@ -106,7 +106,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       )
 
     {[], [msg]} = Generator.generate(ctx, desc)
-    assert msg =~ "defstruct [:a, :b, :c]\n"
+    assert msg =~ "defstruct [a: 0, b: \"\", c: []]\n"
     assert msg =~ "a: integer"
     assert msg =~ "b: String.t"
     assert msg =~ "field :a, 1, type: :int32\n"
@@ -452,7 +452,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     assert msg =~ "second: {atom, any},\n"
     assert msg =~ "other: integer\n"
     refute msg =~ "a: integer,\n"
-    assert msg =~ "defstruct [:first, :second, :other]\n"
+    assert msg =~ "defstruct [first: nil, second: nil, other: nil]\n"
     assert msg =~ "oneof :first, 0\n"
     assert msg =~ "oneof :second, 1\n"
     assert msg =~ "field :a, 1, optional: true, type: :int32, oneof: 0\n"
@@ -488,7 +488,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
         )
 
       {[], [msg]} = Generator.generate(ctx, desc)
-      assert msg =~ "defstruct [:simple, :the_field_name]\n"
+      assert msg =~ "defstruct [simple: 0, the_field_name: \"\"]\n"
       assert msg =~ "field :simple, 1, type: :int32\n"
       assert msg =~ "field :the_field_name, 2, type: :string, json_name: \"theFieldName\"\n"
     end
@@ -511,7 +511,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
         )
 
       {[], [msg]} = Generator.generate(ctx, desc)
-      assert msg =~ "defstruct [:the_field_name]\n"
+      assert msg =~ "defstruct [the_field_name: nil]\n"
       assert msg =~ "field :the_field_name, 1, required: true, type: :string\n"
     end
   end

--- a/test/protobuf/protoc/proto_gen/test.pb.ex
+++ b/test/protobuf/protoc/proto_gen/test.pb.ex
@@ -95,17 +95,15 @@ defmodule My.Test.Request do
           reset: integer,
           get_key: String.t()
         }
-  defstruct [
-    :key,
-    :hue,
-    :hat,
-    :deadline,
-    :somegroup,
-    :name_mapping,
-    :msg_mapping,
-    :reset,
-    :get_key
-  ]
+  defstruct key: [],
+            hue: nil,
+            hat: :FEDORA,
+            deadline: "inf",
+            somegroup: nil,
+            name_mapping: [],
+            msg_mapping: [],
+            reset: nil,
+            get_key: nil
 
   field :key, 1, repeated: true, type: :int64
   field :hue, 3, optional: true, type: My.Test.Request.Color, enum: true
@@ -127,7 +125,7 @@ defmodule My.Test.Reply.Entry do
           value: integer,
           _my_field_name_2: integer
         }
-  defstruct [:key_that_needs_1234camel_CasIng, :value, :_my_field_name_2]
+  defstruct key_that_needs_1234camel_CasIng: nil, value: 7, _my_field_name_2: nil
 
   field :key_that_needs_1234camel_CasIng, 1, required: true, type: :int64
   field :value, 2, optional: true, type: :int64, default: 7
@@ -143,7 +141,7 @@ defmodule My.Test.Reply do
           compact_keys: [integer],
           __pb_extensions__: map
         }
-  defstruct [:found, :compact_keys, :__pb_extensions__]
+  defstruct found: [], compact_keys: [], __pb_extensions__: nil
 
   field :found, 1, repeated: true, type: My.Test.Reply.Entry
   field :compact_keys, 2, repeated: true, type: :int32, packed: true


### PR DESCRIPTION
This commit updates the Message generator to ensure any repeated fields
are defined using an empty list when no default value is available. In
the case of :proto3 a default value a type-specific default is set as
per the protocol guides:

- https://developers.google.com/protocol-buffers/docs/proto?hl=en#optional
- https://developers.google.com/protocol-buffers/docs/proto3?hl=en#default