### PR TITLE
Update Protobuf.Decoder: Fix decoding packed varints

### DIFF
--- a/lib/protobuf/decoder.ex
+++ b/lib/protobuf/decoder.ex
@@ -185,16 +185,16 @@ defmodule Protobuf.Decoder do
     acc = current || []
 
     case prop.wire_type do
-      wire_varint() -> decode_varints(bin, acc)
+      wire_varint() -> decode_varints(bin, prop.type, acc)
       wire_32bits() -> decode_fixed32(bin, prop.type, acc)
       wire_64bits() -> decode_fixed64(bin, prop.type, acc)
     end
   end
 
-  defp decode_varints(<<>>, acc), do: acc
+  defp decode_varints(<<>>, _, acc), do: acc
 
-  decoder :defp, :decode_varints, [:acc] do
-    decode_varints(rest, [value | acc])
+  decoder :defp, :decode_varints, [:type, :acc] do
+    decode_varints(rest, type, [Wire.to_proto(type, value) | acc])
   end
 
   defp decode_fixed32(<<n::bits-32, bin::bits>>, type, acc) do

--- a/test/protobuf/decoder_test.exs
+++ b/test/protobuf/decoder_test.exs
@@ -117,6 +117,24 @@ defmodule Protobuf.DecoderTest do
              TestMsg.Foo2.new(a: 0, l: %{})
   end
 
+  test "decodes unpacked binary with SignedInt32Repeated for proto2" do
+    unpacked = <<8, 1, 8, 2, 8, 3, 8, 4, 8, 5>>
+
+    struct = Decoder.decode(unpacked, TestMsg.SignedInt32Repeated)
+
+    assert %TestMsg.SignedInt32Repeated{} = struct
+    assert struct.a == [-1, 1, -2, 2, -3]
+  end
+
+  test "decodes packed binary with SignedInt32RepeatedPacked for proto2" do
+    packed = <<10, 5, 1, 2, 3, 4, 5>>
+
+    struct = Decoder.decode(packed, TestMsg.SignedInt32RepeatedPacked)
+
+    assert %TestMsg.SignedInt32RepeatedPacked{} = struct
+    assert struct.a == [-1, 1, -2, 2, -3]
+  end
+
   test "decodes custom default message for proto2" do
     assert Decoder.decode(<<8, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0>>, TestMsg.Foo2) ==
              TestMsg.Foo2.new(a: 0, b: 0)

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -87,6 +87,24 @@ defmodule TestMsg do
     field :non_matched, 101, type: :int32, optional: true
   end
 
+  defmodule SignedInt32Repeated do
+    @moduledoc false
+    use Protobuf, syntax: :proto2
+
+    defstruct [:a]
+
+    field :a, 1, repeated: true, type: :sint32
+  end
+
+  defmodule SignedInt32RepeatedPacked do
+    @moduledoc false
+    use Protobuf, syntax: :proto2
+
+    defstruct [:a]
+
+    field :a, 1, repeated: true, type: :sint32, packed: true
+  end
+
   defmodule Oneof do
     @moduledoc false
     use Protobuf


### PR DESCRIPTION
Previously when decoding varints, the value was not correctly decoded
from wire format to protobuf format. Consequently when signed ints which
are encoded on the wire using ZigZag format, the values returned are not
correct. This commit updates the decoder to ensure all values are
transformed from wire format to protobuf format, and includes a couple
of unit tests to validate the expected behaviour.