### PR TITLE
Add more instructions for protoc-gen-elixir

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ end
 1. Install `protoc`(cpp) [here](https://github.com/google/protobuf/blob/master/src/README.md) or
    `brew install protobuf` on MacOS.
 
-2.  Install protoc plugin `protoc-gen-elixir` for Elixir . NOTE: You have to
-    make sure `protoc-gen-elixir`(this name is important) is in your PATH.
+2.  Install protoc plugin `protoc-gen-elixir` for Elixir using the command below. NOTE: You have to
+    make sure `protoc-gen-elixir` (this name is important) is in your PATH. Either add `PATH=~/.mix/escripts:$PATH` to your bash or zsh profile, or if you used asdf to install elixir, run `asdf reshim` and then check that protoc-gen-elixir works. 
 
     ```bash
     $ mix escript.install hex protobuf


### PR DESCRIPTION
Added some more instructions on getting protoc-gen-elixir available as a standalone executable (either via PATH or asdf reshimming). 

It's mentioned in the readme that this is important but it's clearer to have details on what to add or try to test that it's a standalone executable. I first thought the escript install would set the path and wasted a few hours trying to figure out why it was so painful to get the proto files to compile. Once I revisited setting up the PATH, compilation worked so easily. 

Refs https://github.com/elixir-protobuf/protobuf/issues/69
Refs https://github.com/elixir-grpc/grpc/issues/194

