### PR TITLE
Add repeated scalar types to property-based roundtrip tests

### DIFF
--- a/test/pbt/encode_decode_type_test.exs
+++ b/test/pbt/encode_decode_type_test.exs
@@ -11,7 +11,7 @@ defmodule Protobuf.EncodeDecodeTypeTest.PropertyGenerator do
     |> Protobuf.Encoder.encode(iolist: false)
   end
 
-  defmacro make_property(gen_func, field_type) do
+  defmacro make_properties(gen_func, field_type) do
     quote do
       property "#{unquote(field_type)} roundtrip" do
         check all n <- unquote(gen_func) do
@@ -21,13 +21,22 @@ defmodule Protobuf.EncodeDecodeTypeTest.PropertyGenerator do
           assert n == decode(field_type, bin)
         end
       end
+
+      property "repeated #{unquote(field_type)} roundtrip" do
+        check all n <- unquote(gen_func) do
+          field_type = :"repeated_#{unquote(field_type)}"
+          bin = encode(field_type, [n, n])
+
+          assert [n, n] == decode(field_type, bin)
+        end
+      end
     end
   end
 
   # Since float point is not precise, make canonical value before doing PBT
   # ref: http://hypothesis.works/articles/canonical-serialization/
   # and try 0.2 here: https://www.h-schmidt.net/FloatConverter/IEEE754.html
-  defmacro make_canonical_property(gen_func, field_type) do
+  defmacro make_canonical_properties(gen_func, field_type) do
     quote do
       property "#{unquote(field_type)} canonical roundtrip" do
         check all n <- unquote(gen_func) do
@@ -37,6 +46,17 @@ defmodule Protobuf.EncodeDecodeTypeTest.PropertyGenerator do
           bin = encode(field_type, canonical_val)
 
           assert canonical_val == decode(field_type, bin)
+        end
+      end
+
+      property "repeated #{unquote(field_type)} canonical roundtrip" do
+        check all n <- unquote(gen_func) do
+          field_type = :"repeated_#{unquote(field_type)}"
+          encoded_vals = encode(field_type, [n, n])
+          canonical_vals = decode(field_type, encoded_vals)
+          bin = encode(field_type, canonical_vals)
+
+          assert canonical_vals == decode(field_type, bin)
         end
       end
     end
@@ -65,18 +85,18 @@ defmodule Protobuf.EncodeDecodeTypeTest do
     map(integer(), &abs/1)
   end
 
-  make_property(integer(), :int32)
-  make_property(large_integer(), :int64)
-  make_property(uint32_gen(), :uint32)
-  make_property(uint64_gen(), :uint64)
-  make_property(integer(), :sint32)
-  make_property(large_integer(), :sint64)
+  make_properties(integer(), :int32)
+  make_properties(large_integer(), :int64)
+  make_properties(uint32_gen(), :uint32)
+  make_properties(uint64_gen(), :uint64)
+  make_properties(integer(), :sint32)
+  make_properties(large_integer(), :sint64)
 
-  make_property(boolean(), :bool)
+  make_properties(boolean(), :bool)
 
-  make_property(natural_number(), :fixed64)
-  make_property(large_integer(), :sfixed64)
+  make_properties(natural_number(), :fixed64)
+  make_properties(large_integer(), :sfixed64)
 
-  make_canonical_property(float(), :double)
-  make_canonical_property(float(), :float)
+  make_canonical_properties(float(), :double)
+  make_canonical_properties(float(), :float)
 end

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -194,7 +194,22 @@ defmodule TestMsg do
       :sint64,
       :fixed64,
       :sfixed64,
-      :bytes
+      :bytes,
+      :repeated_string,
+      :repeated_bool,
+      :repeated_float,
+      :repeated_double,
+      :repeated_int32,
+      :repeated_uint32,
+      :repeated_sint32,
+      :repeated_fixed32,
+      :repeated_sfixed32,
+      :repeated_int64,
+      :repeated_uint64,
+      :repeated_sint64,
+      :repeated_fixed64,
+      :repeated_sfixed64,
+      :repeated_bytes
     ]
 
     field :string, 1, type: :string
@@ -216,6 +231,26 @@ defmodule TestMsg do
     field :sfixed64, 14, type: :sfixed64
 
     field :bytes, 15, type: :bytes
+
+    field :repeated_string, 16, repeated: true, type: :string
+    field :repeated_bool, 17, repeated: true, type: :bool
+
+    field :repeated_float, 18, repeated: true, type: :float
+    field :repeated_double, 19, repeated: true, type: :double
+
+    field :repeated_int32, 20, repeated: true, type: :int32
+    field :repeated_uint32, 21, repeated: true, type: :uint32
+    field :repeated_sint32, 22, repeated: true, type: :sint32
+    field :repeated_fixed32, 23, repeated: true, type: :fixed32
+    field :repeated_sfixed32, 24, repeated: true, type: :sfixed32
+
+    field :repeated_int64, 25, repeated: true, type: :int64
+    field :repeated_uint64, 26, repeated: true, type: :uint64
+    field :repeated_sint64, 27, repeated: true, type: :sint64
+    field :repeated_fixed64, 28, repeated: true, type: :fixed64
+    field :repeated_sfixed64, 29, repeated: true, type: :sfixed64
+
+    field :repeated_bytes, 30, repeated: true, type: :bytes
   end
 
   defmodule MapIntToInt do


### PR DESCRIPTION
Follow-up to #169. These tests fail on master – further confirming the bug fixed in there – and will pass once we rebase against it.