### PR TITLE
Improve proto2 enums tests

### DIFF
--- a/test/protobuf/decoder_test.exs
+++ b/test/protobuf/decoder_test.exs
@@ -83,6 +83,10 @@ defmodule Protobuf.DecoderTest do
 
     struct = Decoder.decode(<<88, 2>>, TestMsg.Foo)
     assert struct == TestMsg.Foo.new(j: :B)
+
+    # Proto2 enums that are not zero-based default to their first value declared.
+    struct = Decoder.decode(<<>>, My.Test.Request)
+    assert struct.hat == :FEDORA
   end
 
   test "decodes unknown enum value" do

--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -208,6 +208,16 @@ defmodule Protobuf.EncoderTest do
 
     msg = TestMsg.EnumFoo2.new(a: 0, b: 1)
     assert Encoder.encode(msg) == <<8, 0, 16, 1>>
+
+    # Proto2 enums that are not zero-based default to their first value declared.
+    msg = My.Test.Request.new(deadline: nil)
+    assert Encoder.encode(msg) == <<32, 1>>
+
+    msg = My.Test.Request.new(deadline: nil, hat: 1)
+    assert Encoder.encode(msg) == <<32, 1>>
+
+    msg = My.Test.Request.new(deadline: nil, hat: :FEDORA)
+    assert Encoder.encode(msg) == <<32, 1>>
   end
 
   test "encodes with transformer module" do


### PR DESCRIPTION
Cover enums without a value defined for zero, which is invalid in `proto3` but possible in `proto2`. Follow-up to https://github.com/elixir-protobuf/protobuf/pull/128#pullrequestreview-781259562.

https://developers.google.com/protocol-buffers/docs/proto3#enum