### PR TITLE
Type-aware struct defaults, again

### DIFF
--- a/bench/lib/benchmarks.pb.ex
+++ b/bench/lib/benchmarks.pb.ex
@@ -8,10 +8,15 @@ defmodule Benchmarks.BenchmarkDataset do
           payload: [binary]
         }
 
-  defstruct [:name, :message_name, :payload]
+  defstruct name: "",
+            message_name: "",
+            payload: []
 
   field :name, 1, type: :string
+
   field :message_name, 2, type: :string, json_name: "messageName"
+
   field :payload, 3, repeated: true, type: :bytes
+
   def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message1/proto2/benchmark_message1_proto2.pb.ex
+++ b/bench/lib/datasets/google_message1/proto2/benchmark_message1_proto2.pb.ex
@@ -46,94 +46,132 @@ defmodule Benchmarks.Proto2.GoogleMessage1 do
           field131: integer
         }
 
-  defstruct [
-    :field1,
-    :field9,
-    :field18,
-    :field80,
-    :field81,
-    :field2,
-    :field3,
-    :field280,
-    :field6,
-    :field22,
-    :field4,
-    :field5,
-    :field59,
-    :field7,
-    :field16,
-    :field130,
-    :field12,
-    :field17,
-    :field13,
-    :field14,
-    :field104,
-    :field100,
-    :field101,
-    :field102,
-    :field103,
-    :field29,
-    :field30,
-    :field60,
-    :field271,
-    :field272,
-    :field150,
-    :field23,
-    :field24,
-    :field25,
-    :field15,
-    :field78,
-    :field67,
-    :field68,
-    :field128,
-    :field129,
-    :field131
-  ]
+  defstruct field1: "",
+            field9: nil,
+            field18: nil,
+            field80: nil,
+            field81: nil,
+            field2: 0,
+            field3: 0,
+            field280: nil,
+            field6: nil,
+            field22: nil,
+            field4: nil,
+            field5: [],
+            field59: nil,
+            field7: nil,
+            field16: nil,
+            field130: nil,
+            field12: nil,
+            field17: nil,
+            field13: nil,
+            field14: nil,
+            field104: nil,
+            field100: nil,
+            field101: nil,
+            field102: nil,
+            field103: nil,
+            field29: nil,
+            field30: nil,
+            field60: nil,
+            field271: nil,
+            field272: nil,
+            field150: nil,
+            field23: nil,
+            field24: nil,
+            field25: nil,
+            field15: nil,
+            field78: nil,
+            field67: nil,
+            field68: nil,
+            field128: nil,
+            field129: nil,
+            field131: nil
 
   field :field1, 1, required: true, type: :string
+
   field :field9, 9, optional: true, type: :string
+
   field :field18, 18, optional: true, type: :string
+
   field :field80, 80, optional: true, type: :bool, default: false
+
   field :field81, 81, optional: true, type: :bool, default: true
+
   field :field2, 2, required: true, type: :int32
+
   field :field3, 3, required: true, type: :int32
+
   field :field280, 280, optional: true, type: :int32
+
   field :field6, 6, optional: true, type: :int32, default: 0
+
   field :field22, 22, optional: true, type: :int64
+
   field :field4, 4, optional: true, type: :string
+
   field :field5, 5, repeated: true, type: :fixed64
+
   field :field59, 59, optional: true, type: :bool, default: false
+
   field :field7, 7, optional: true, type: :string
+
   field :field16, 16, optional: true, type: :int32
+
   field :field130, 130, optional: true, type: :int32, default: 0
+
   field :field12, 12, optional: true, type: :bool, default: true
+
   field :field17, 17, optional: true, type: :bool, default: true
+
   field :field13, 13, optional: true, type: :bool, default: true
+
   field :field14, 14, optional: true, type: :bool, default: true
+
   field :field104, 104, optional: true, type: :int32, default: 0
+
   field :field100, 100, optional: true, type: :int32, default: 0
+
   field :field101, 101, optional: true, type: :int32, default: 0
+
   field :field102, 102, optional: true, type: :string
+
   field :field103, 103, optional: true, type: :string
+
   field :field29, 29, optional: true, type: :int32, default: 0
+
   field :field30, 30, optional: true, type: :bool, default: false
+
   field :field60, 60, optional: true, type: :int32, default: -1
+
   field :field271, 271, optional: true, type: :int32, default: -1
+
   field :field272, 272, optional: true, type: :int32, default: -1
+
   field :field150, 150, optional: true, type: :int32
+
   field :field23, 23, optional: true, type: :int32, default: 0
+
   field :field24, 24, optional: true, type: :bool, default: false
+
   field :field25, 25, optional: true, type: :int32, default: 0
+
   field :field15, 15, optional: true, type: Benchmarks.Proto2.GoogleMessage1SubMessage
+
   field :field78, 78, optional: true, type: :bool
+
   field :field67, 67, optional: true, type: :int32, default: 0
+
   field :field68, 68, optional: true, type: :int32
+
   field :field128, 128, optional: true, type: :int32, default: 0
+
   field :field129, 129, optional: true, type: :string, default: "xxxxxxxxxxxxxxxxxxxxx"
+
   field :field131, 131, optional: true, type: :int32, default: 0
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.Proto2.GoogleMessage1SubMessage do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -161,48 +199,66 @@ defmodule Benchmarks.Proto2.GoogleMessage1SubMessage do
           field300: non_neg_integer
         }
 
-  defstruct [
-    :field1,
-    :field2,
-    :field3,
-    :field15,
-    :field12,
-    :field13,
-    :field14,
-    :field16,
-    :field19,
-    :field20,
-    :field28,
-    :field21,
-    :field22,
-    :field23,
-    :field206,
-    :field203,
-    :field204,
-    :field205,
-    :field207,
-    :field300
-  ]
+  defstruct field1: nil,
+            field2: nil,
+            field3: nil,
+            field15: nil,
+            field12: nil,
+            field13: nil,
+            field14: nil,
+            field16: nil,
+            field19: nil,
+            field20: nil,
+            field28: nil,
+            field21: nil,
+            field22: nil,
+            field23: nil,
+            field206: nil,
+            field203: nil,
+            field204: nil,
+            field205: nil,
+            field207: nil,
+            field300: nil
 
   field :field1, 1, optional: true, type: :int32, default: 0
+
   field :field2, 2, optional: true, type: :int32, default: 0
+
   field :field3, 3, optional: true, type: :int32, default: 0
+
   field :field15, 15, optional: true, type: :string
+
   field :field12, 12, optional: true, type: :bool, default: true
+
   field :field13, 13, optional: true, type: :int64
+
   field :field14, 14, optional: true, type: :int64
+
   field :field16, 16, optional: true, type: :int32
+
   field :field19, 19, optional: true, type: :int32, default: 2
+
   field :field20, 20, optional: true, type: :bool, default: true
+
   field :field28, 28, optional: true, type: :bool, default: true
+
   field :field21, 21, optional: true, type: :fixed64
+
   field :field22, 22, optional: true, type: :int32
+
   field :field23, 23, optional: true, type: :bool, default: false
+
   field :field206, 206, optional: true, type: :bool, default: false
+
   field :field203, 203, optional: true, type: :fixed32
+
   field :field204, 204, optional: true, type: :int32
+
   field :field205, 205, optional: true, type: :string
+
   field :field207, 207, optional: true, type: :uint64
+
   field :field300, 300, optional: true, type: :uint64
+
   def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message1/proto3/benchmark_message1_proto3.pb.ex
+++ b/bench/lib/datasets/google_message1/proto3/benchmark_message1_proto3.pb.ex
@@ -46,94 +46,132 @@ defmodule Benchmarks.Proto3.GoogleMessage1 do
           field131: integer
         }
 
-  defstruct [
-    :field1,
-    :field9,
-    :field18,
-    :field80,
-    :field81,
-    :field2,
-    :field3,
-    :field280,
-    :field6,
-    :field22,
-    :field4,
-    :field5,
-    :field59,
-    :field7,
-    :field16,
-    :field130,
-    :field12,
-    :field17,
-    :field13,
-    :field14,
-    :field104,
-    :field100,
-    :field101,
-    :field102,
-    :field103,
-    :field29,
-    :field30,
-    :field60,
-    :field271,
-    :field272,
-    :field150,
-    :field23,
-    :field24,
-    :field25,
-    :field15,
-    :field78,
-    :field67,
-    :field68,
-    :field128,
-    :field129,
-    :field131
-  ]
+  defstruct field1: "",
+            field9: "",
+            field18: "",
+            field80: false,
+            field81: false,
+            field2: 0,
+            field3: 0,
+            field280: 0,
+            field6: 0,
+            field22: 0,
+            field4: "",
+            field5: [],
+            field59: false,
+            field7: "",
+            field16: 0,
+            field130: 0,
+            field12: false,
+            field17: false,
+            field13: false,
+            field14: false,
+            field104: 0,
+            field100: 0,
+            field101: 0,
+            field102: "",
+            field103: "",
+            field29: 0,
+            field30: false,
+            field60: 0,
+            field271: 0,
+            field272: 0,
+            field150: 0,
+            field23: 0,
+            field24: false,
+            field25: 0,
+            field15: nil,
+            field78: false,
+            field67: 0,
+            field68: 0,
+            field128: 0,
+            field129: "",
+            field131: 0
 
   field :field1, 1, type: :string
+
   field :field9, 9, type: :string
+
   field :field18, 18, type: :string
+
   field :field80, 80, type: :bool
+
   field :field81, 81, type: :bool
+
   field :field2, 2, type: :int32
+
   field :field3, 3, type: :int32
+
   field :field280, 280, type: :int32
+
   field :field6, 6, type: :int32
+
   field :field22, 22, type: :int64
+
   field :field4, 4, type: :string
+
   field :field5, 5, repeated: true, type: :fixed64
+
   field :field59, 59, type: :bool
+
   field :field7, 7, type: :string
+
   field :field16, 16, type: :int32
+
   field :field130, 130, type: :int32
+
   field :field12, 12, type: :bool
+
   field :field17, 17, type: :bool
+
   field :field13, 13, type: :bool
+
   field :field14, 14, type: :bool
+
   field :field104, 104, type: :int32
+
   field :field100, 100, type: :int32
+
   field :field101, 101, type: :int32
+
   field :field102, 102, type: :string
+
   field :field103, 103, type: :string
+
   field :field29, 29, type: :int32
+
   field :field30, 30, type: :bool
+
   field :field60, 60, type: :int32
+
   field :field271, 271, type: :int32
+
   field :field272, 272, type: :int32
+
   field :field150, 150, type: :int32
+
   field :field23, 23, type: :int32
+
   field :field24, 24, type: :bool
+
   field :field25, 25, type: :int32
+
   field :field15, 15, type: Benchmarks.Proto3.GoogleMessage1SubMessage
+
   field :field78, 78, type: :bool
+
   field :field67, 67, type: :int32
+
   field :field68, 68, type: :int32
+
   field :field128, 128, type: :int32
+
   field :field129, 129, type: :string
+
   field :field131, 131, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.Proto3.GoogleMessage1SubMessage do
   @moduledoc false
   use Protobuf, syntax: :proto3
@@ -161,48 +199,66 @@ defmodule Benchmarks.Proto3.GoogleMessage1SubMessage do
           field300: non_neg_integer
         }
 
-  defstruct [
-    :field1,
-    :field2,
-    :field3,
-    :field15,
-    :field12,
-    :field13,
-    :field14,
-    :field16,
-    :field19,
-    :field20,
-    :field28,
-    :field21,
-    :field22,
-    :field23,
-    :field206,
-    :field203,
-    :field204,
-    :field205,
-    :field207,
-    :field300
-  ]
+  defstruct field1: 0,
+            field2: 0,
+            field3: 0,
+            field15: "",
+            field12: false,
+            field13: 0,
+            field14: 0,
+            field16: 0,
+            field19: 0,
+            field20: false,
+            field28: false,
+            field21: 0,
+            field22: 0,
+            field23: false,
+            field206: false,
+            field203: 0,
+            field204: 0,
+            field205: "",
+            field207: 0,
+            field300: 0
 
   field :field1, 1, type: :int32
+
   field :field2, 2, type: :int32
+
   field :field3, 3, type: :int32
+
   field :field15, 15, type: :string
+
   field :field12, 12, type: :bool
+
   field :field13, 13, type: :int64
+
   field :field14, 14, type: :int64
+
   field :field16, 16, type: :int32
+
   field :field19, 19, type: :int32
+
   field :field20, 20, type: :bool
+
   field :field28, 28, type: :bool
+
   field :field21, 21, type: :fixed64
+
   field :field22, 22, type: :int32
+
   field :field23, 23, type: :bool
+
   field :field206, 206, type: :bool
+
   field :field203, 203, type: :fixed32
+
   field :field204, 204, type: :int32
+
   field :field205, 205, type: :string
+
   field :field207, 207, type: :uint64
+
   field :field300, 300, type: :uint64
+
   def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message2/benchmark_message2.pb.ex
+++ b/bench/lib/datasets/google_message2/benchmark_message2.pb.ex
@@ -21,44 +21,57 @@ defmodule Benchmarks.Proto2.GoogleMessage2.Group1 do
           field31: Benchmarks.Proto2.GoogleMessage2GroupedMessage.t() | nil
         }
 
-  defstruct [
-    :field11,
-    :field26,
-    :field12,
-    :field13,
-    :field14,
-    :field15,
-    :field5,
-    :field27,
-    :field28,
-    :field29,
-    :field16,
-    :field22,
-    :field73,
-    :field20,
-    :field24,
-    :field31
-  ]
+  defstruct field11: 0.0,
+            field26: nil,
+            field12: nil,
+            field13: nil,
+            field14: [],
+            field15: 0,
+            field5: nil,
+            field27: nil,
+            field28: nil,
+            field29: nil,
+            field16: nil,
+            field22: [],
+            field73: [],
+            field20: nil,
+            field24: nil,
+            field31: nil
 
   field :field11, 11, required: true, type: :float
+
   field :field26, 26, optional: true, type: :float
+
   field :field12, 12, optional: true, type: :string
+
   field :field13, 13, optional: true, type: :string
+
   field :field14, 14, repeated: true, type: :string
+
   field :field15, 15, required: true, type: :uint64
+
   field :field5, 5, optional: true, type: :int32
+
   field :field27, 27, optional: true, type: :string
+
   field :field28, 28, optional: true, type: :int32
+
   field :field29, 29, optional: true, type: :string
+
   field :field16, 16, optional: true, type: :string
+
   field :field22, 22, repeated: true, type: :string
+
   field :field73, 73, repeated: true, type: :int32
+
   field :field20, 20, optional: true, type: :int32, default: 0
+
   field :field24, 24, optional: true, type: :string
+
   field :field31, 31, optional: true, type: Benchmarks.Proto2.GoogleMessage2GroupedMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.Proto2.GoogleMessage2 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -96,72 +109,99 @@ defmodule Benchmarks.Proto2.GoogleMessage2 do
           field206: boolean
         }
 
-  defstruct [
-    :field1,
-    :field3,
-    :field4,
-    :field30,
-    :field75,
-    :field6,
-    :field2,
-    :field21,
-    :field71,
-    :field25,
-    :field109,
-    :field210,
-    :field211,
-    :field212,
-    :field213,
-    :field216,
-    :field217,
-    :field218,
-    :field220,
-    :field221,
-    :field222,
-    :field63,
-    :group1,
-    :field128,
-    :field131,
-    :field127,
-    :field129,
-    :field130,
-    :field205,
-    :field206
-  ]
+  defstruct field1: nil,
+            field3: nil,
+            field4: nil,
+            field30: nil,
+            field75: nil,
+            field6: nil,
+            field2: nil,
+            field21: nil,
+            field71: nil,
+            field25: nil,
+            field109: nil,
+            field210: nil,
+            field211: nil,
+            field212: nil,
+            field213: nil,
+            field216: nil,
+            field217: nil,
+            field218: nil,
+            field220: nil,
+            field221: nil,
+            field222: nil,
+            field63: nil,
+            group1: [],
+            field128: [],
+            field131: nil,
+            field127: [],
+            field129: nil,
+            field130: [],
+            field205: nil,
+            field206: nil
 
   field :field1, 1, optional: true, type: :string
+
   field :field3, 3, optional: true, type: :int64
+
   field :field4, 4, optional: true, type: :int64
+
   field :field30, 30, optional: true, type: :int64
+
   field :field75, 75, optional: true, type: :bool, default: false
+
   field :field6, 6, optional: true, type: :string
+
   field :field2, 2, optional: true, type: :bytes
+
   field :field21, 21, optional: true, type: :int32, default: 0
+
   field :field71, 71, optional: true, type: :int32
+
   field :field25, 25, optional: true, type: :float
+
   field :field109, 109, optional: true, type: :int32, default: 0
+
   field :field210, 210, optional: true, type: :int32, default: 0
+
   field :field211, 211, optional: true, type: :int32, default: 0
+
   field :field212, 212, optional: true, type: :int32, default: 0
+
   field :field213, 213, optional: true, type: :int32, default: 0
+
   field :field216, 216, optional: true, type: :int32, default: 0
+
   field :field217, 217, optional: true, type: :int32, default: 0
+
   field :field218, 218, optional: true, type: :int32, default: 0
+
   field :field220, 220, optional: true, type: :int32, default: 0
+
   field :field221, 221, optional: true, type: :int32, default: 0
+
   field :field222, 222, optional: true, type: :float, default: 0.0
+
   field :field63, 63, optional: true, type: :int32
+
   field :group1, 10, repeated: true, type: :group
+
   field :field128, 128, repeated: true, type: :string
+
   field :field131, 131, optional: true, type: :int64
+
   field :field127, 127, repeated: true, type: :string
+
   field :field129, 129, optional: true, type: :int32
+
   field :field130, 130, repeated: true, type: :int64
+
   field :field205, 205, optional: true, type: :bool, default: false
+
   field :field206, 206, optional: true, type: :bool, default: false
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.Proto2.GoogleMessage2GroupedMessage do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -180,30 +220,39 @@ defmodule Benchmarks.Proto2.GoogleMessage2GroupedMessage do
           field11: integer
         }
 
-  defstruct [
-    :field1,
-    :field2,
-    :field3,
-    :field4,
-    :field5,
-    :field6,
-    :field7,
-    :field8,
-    :field9,
-    :field10,
-    :field11
-  ]
+  defstruct field1: nil,
+            field2: nil,
+            field3: nil,
+            field4: nil,
+            field5: nil,
+            field6: nil,
+            field7: nil,
+            field8: nil,
+            field9: nil,
+            field10: nil,
+            field11: nil
 
   field :field1, 1, optional: true, type: :float
+
   field :field2, 2, optional: true, type: :float
+
   field :field3, 3, optional: true, type: :float, default: 0.0
+
   field :field4, 4, optional: true, type: :bool
+
   field :field5, 5, optional: true, type: :bool
+
   field :field6, 6, optional: true, type: :bool, default: true
+
   field :field7, 7, optional: true, type: :bool, default: false
+
   field :field8, 8, optional: true, type: :float
+
   field :field9, 9, optional: true, type: :bool
+
   field :field10, 10, optional: true, type: :float
+
   field :field11, 11, optional: true, type: :int64
+
   def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message3/benchmark_message3.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3.pb.ex
@@ -20,42 +20,54 @@ defmodule Benchmarks.GoogleMessage3.GoogleMessage3 do
           field37533: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field37519,
-    :field37520,
-    :field37521,
-    :field37522,
-    :field37523,
-    :field37524,
-    :field37525,
-    :field37526,
-    :field37527,
-    :field37528,
-    :field37529,
-    :field37530,
-    :field37531,
-    :field37532,
-    :field37533
-  ]
+  defstruct field37519: nil,
+            field37520: nil,
+            field37521: nil,
+            field37522: nil,
+            field37523: nil,
+            field37524: nil,
+            field37525: nil,
+            field37526: nil,
+            field37527: nil,
+            field37528: nil,
+            field37529: nil,
+            field37530: nil,
+            field37531: nil,
+            field37532: nil,
+            field37533: nil
 
   field :field37519, 2, optional: true, type: Benchmarks.GoogleMessage3.Message37487
+
   field :field37520, 3, optional: true, type: Benchmarks.GoogleMessage3.Message36876
+
   field :field37521, 4, optional: true, type: Benchmarks.GoogleMessage3.Message13062
+
   field :field37522, 5, optional: true, type: Benchmarks.GoogleMessage3.Message952
+
   field :field37523, 6, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37524, 7, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37525, 8, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37526, 9, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37527, 10, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37528, 11, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37529, 12, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37530, 13, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37531, 14, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37532, 15, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37533, 16, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message1327 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -67,15 +79,21 @@ defmodule Benchmarks.GoogleMessage3.Message1327 do
           field1372: [Benchmarks.GoogleMessage3.UnusedEmptyMessage.t()]
         }
 
-  defstruct [:field1369, :field1370, :field1371, :field1372]
+  defstruct field1369: [],
+            field1370: [],
+            field1371: [],
+            field1372: []
 
   field :field1369, 1, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field1370, 3, repeated: true, type: Benchmarks.GoogleMessage3.Message1328
+
   field :field1371, 5, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field1372, 6, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message3672.Message3673 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -85,13 +103,15 @@ defmodule Benchmarks.GoogleMessage3.Message3672.Message3673 do
           field3739: integer
         }
 
-  defstruct [:field3738, :field3739]
+  defstruct field3738: 0,
+            field3739: 0
 
   field :field3738, 4, required: true, type: Benchmarks.GoogleMessage3.Enum3476, enum: true
+
   field :field3739, 5, required: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message3672.Message3674 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -101,13 +121,15 @@ defmodule Benchmarks.GoogleMessage3.Message3672.Message3674 do
           field3741: integer
         }
 
-  defstruct [:field3740, :field3741]
+  defstruct field3740: 0,
+            field3741: 0
 
   field :field3740, 7, required: true, type: Benchmarks.GoogleMessage3.Enum3476, enum: true
+
   field :field3741, 8, required: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message3672 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -125,32 +147,39 @@ defmodule Benchmarks.GoogleMessage3.Message3672 do
           field3736: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field3727,
-    :field3728,
-    :field3729,
-    :message3673,
-    :message3674,
-    :field3732,
-    :field3733,
-    :field3734,
-    :field3735,
-    :field3736
-  ]
+  defstruct field3727: nil,
+            field3728: nil,
+            field3729: nil,
+            message3673: [],
+            message3674: [],
+            field3732: nil,
+            field3733: nil,
+            field3734: nil,
+            field3735: nil,
+            field3736: nil
 
   field :field3727, 1, optional: true, type: Benchmarks.GoogleMessage3.Enum3476, enum: true
+
   field :field3728, 11, optional: true, type: :int32
+
   field :field3729, 2, optional: true, type: :int32
+
   field :message3673, 3, repeated: true, type: :group
+
   field :message3674, 6, repeated: true, type: :group
+
   field :field3732, 9, optional: true, type: :bool
+
   field :field3733, 10, optional: true, type: :int32
+
   field :field3734, 20, optional: true, type: Benchmarks.GoogleMessage3.Enum3476, enum: true
+
   field :field3735, 21, optional: true, type: :int32
+
   field :field3736, 50, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message3804 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -165,18 +194,30 @@ defmodule Benchmarks.GoogleMessage3.Message3804 do
           field3824: Benchmarks.GoogleMessage3.Enum3783.t()
         }
 
-  defstruct [:field3818, :field3819, :field3820, :field3821, :field3822, :field3823, :field3824]
+  defstruct field3818: 0,
+            field3819: false,
+            field3820: [],
+            field3821: nil,
+            field3822: nil,
+            field3823: nil,
+            field3824: nil
 
   field :field3818, 1, required: true, type: :int64
+
   field :field3819, 2, required: true, type: :bool
+
   field :field3820, 4, repeated: true, type: Benchmarks.GoogleMessage3.Enum3805, enum: true
+
   field :field3821, 5, optional: true, type: :int32
+
   field :field3822, 6, optional: true, type: :bool
+
   field :field3823, 7, optional: true, type: :int64
+
   field :field3824, 8, optional: true, type: Benchmarks.GoogleMessage3.Enum3783, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6849 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -185,12 +226,12 @@ defmodule Benchmarks.GoogleMessage3.Message6849 do
           field6910: [Benchmarks.GoogleMessage3.Message6850.t()]
         }
 
-  defstruct [:field6910]
+  defstruct field6910: []
 
   field :field6910, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message6850
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6866 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -199,12 +240,12 @@ defmodule Benchmarks.GoogleMessage3.Message6866 do
           field6973: [Benchmarks.GoogleMessage3.Message6863.t()]
         }
 
-  defstruct [:field6973]
+  defstruct field6973: []
 
   field :field6973, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message6863
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6870 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -213,12 +254,12 @@ defmodule Benchmarks.GoogleMessage3.Message6870 do
           field6991: [Benchmarks.GoogleMessage3.Message6871.t()]
         }
 
-  defstruct [:field6991]
+  defstruct field6991: []
 
   field :field6991, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message6871
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7651 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -271,102 +312,144 @@ defmodule Benchmarks.GoogleMessage3.Message7651 do
           field7729: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field7685,
-    :field7686,
-    :field7687,
-    :field7688,
-    :field7689,
-    :field7690,
-    :field7691,
-    :field7692,
-    :field7693,
-    :field7694,
-    :field7695,
-    :field7696,
-    :field7697,
-    :field7698,
-    :field7699,
-    :field7700,
-    :field7701,
-    :field7702,
-    :field7703,
-    :field7704,
-    :field7705,
-    :field7706,
-    :field7707,
-    :field7708,
-    :field7709,
-    :field7710,
-    :field7711,
-    :field7712,
-    :field7713,
-    :field7714,
-    :field7715,
-    :field7716,
-    :field7717,
-    :field7718,
-    :field7719,
-    :field7720,
-    :field7721,
-    :field7722,
-    :field7723,
-    :field7724,
-    :field7725,
-    :field7726,
-    :field7727,
-    :field7728,
-    :field7729
-  ]
+  defstruct field7685: nil,
+            field7686: nil,
+            field7687: nil,
+            field7688: nil,
+            field7689: nil,
+            field7690: nil,
+            field7691: nil,
+            field7692: nil,
+            field7693: nil,
+            field7694: nil,
+            field7695: nil,
+            field7696: nil,
+            field7697: nil,
+            field7698: nil,
+            field7699: nil,
+            field7700: nil,
+            field7701: nil,
+            field7702: nil,
+            field7703: nil,
+            field7704: [],
+            field7705: [],
+            field7706: [],
+            field7707: [],
+            field7708: nil,
+            field7709: nil,
+            field7710: nil,
+            field7711: nil,
+            field7712: nil,
+            field7713: nil,
+            field7714: nil,
+            field7715: [],
+            field7716: [],
+            field7717: [],
+            field7718: [],
+            field7719: [],
+            field7720: [],
+            field7721: nil,
+            field7722: nil,
+            field7723: nil,
+            field7724: nil,
+            field7725: nil,
+            field7726: nil,
+            field7727: nil,
+            field7728: nil,
+            field7729: nil
 
   field :field7685, 1, optional: true, type: :string
+
   field :field7686, 2, optional: true, type: :int64
+
   field :field7687, 3, optional: true, type: :int64
+
   field :field7688, 4, optional: true, type: :int64
+
   field :field7689, 5, optional: true, type: :int32
+
   field :field7690, 6, optional: true, type: :int32
+
   field :field7691, 7, optional: true, type: :int32
+
   field :field7692, 8, optional: true, type: :int32
+
   field :field7693, 9, optional: true, type: :int32
+
   field :field7694, 10, optional: true, type: :int32
+
   field :field7695, 11, optional: true, type: :int32
+
   field :field7696, 12, optional: true, type: :int32
+
   field :field7697, 13, optional: true, type: :int32
+
   field :field7698, 14, optional: true, type: :int32
+
   field :field7699, 15, optional: true, type: :int32
+
   field :field7700, 16, optional: true, type: :int32
+
   field :field7701, 17, optional: true, type: :int32
+
   field :field7702, 18, optional: true, type: :int32
+
   field :field7703, 19, optional: true, type: :bool
+
   field :field7704, 20, repeated: true, type: :int32
+
   field :field7705, 21, repeated: true, type: :int32
+
   field :field7706, 22, repeated: true, type: :string
+
   field :field7707, 23, repeated: true, type: :string
+
   field :field7708, 24, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field7709, 25, optional: true, type: :int32
+
   field :field7710, 26, optional: true, type: :int32
+
   field :field7711, 27, optional: true, type: :int32
+
   field :field7712, 43, optional: true, type: :int32
+
   field :field7713, 28, optional: true, type: :int32
+
   field :field7714, 29, optional: true, type: :int32
+
   field :field7715, 30, repeated: true, type: Benchmarks.GoogleMessage3.Message7547
+
   field :field7716, 31, repeated: true, type: Benchmarks.GoogleMessage3.Message7547
+
   field :field7717, 32, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field7718, 33, repeated: true, type: :string
+
   field :field7719, 34, repeated: true, type: :string
+
   field :field7720, 35, repeated: true, type: Benchmarks.GoogleMessage3.Message7648
+
   field :field7721, 36, optional: true, type: :bool
+
   field :field7722, 37, optional: true, type: :bool
+
   field :field7723, 38, optional: true, type: :bool
+
   field :field7724, 39, optional: true, type: :bool
+
   field :field7725, 40, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field7726, 41, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field7727, 42, optional: true, type: Benchmarks.GoogleMessage3.Enum7654, enum: true
+
   field :field7728, 44, optional: true, type: :string
+
   field :field7729, 45, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7864 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -380,17 +463,27 @@ defmodule Benchmarks.GoogleMessage3.Message7864 do
           field7871: [Benchmarks.GoogleMessage3.UnusedEmptyMessage.t()]
         }
 
-  defstruct [:field7866, :field7867, :field7868, :field7869, :field7870, :field7871]
+  defstruct field7866: nil,
+            field7867: nil,
+            field7868: [],
+            field7869: [],
+            field7870: [],
+            field7871: []
 
   field :field7866, 1, optional: true, type: :string
+
   field :field7867, 2, optional: true, type: :string
+
   field :field7868, 5, repeated: true, type: Benchmarks.GoogleMessage3.Message7865
+
   field :field7869, 6, repeated: true, type: Benchmarks.GoogleMessage3.Message7865
+
   field :field7870, 7, repeated: true, type: Benchmarks.GoogleMessage3.Message7865
+
   field :field7871, 8, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7929 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -418,52 +511,69 @@ defmodule Benchmarks.GoogleMessage3.Message7929 do
           field7961: integer
         }
 
-  defstruct [
-    :field7942,
-    :field7943,
-    :field7944,
-    :field7945,
-    :field7946,
-    :field7947,
-    :field7948,
-    :field7949,
-    :field7950,
-    :field7951,
-    :field7952,
-    :field7953,
-    :field7954,
-    :field7955,
-    :field7956,
-    :field7957,
-    :field7958,
-    :field7959,
-    :field7960,
-    :field7961
-  ]
+  defstruct field7942: nil,
+            field7943: nil,
+            field7944: nil,
+            field7945: nil,
+            field7946: nil,
+            field7947: nil,
+            field7948: nil,
+            field7949: nil,
+            field7950: [],
+            field7951: [],
+            field7952: [],
+            field7953: [],
+            field7954: [],
+            field7955: nil,
+            field7956: nil,
+            field7957: nil,
+            field7958: nil,
+            field7959: [],
+            field7960: [],
+            field7961: nil
 
   field :field7942, 1, optional: true, type: :int64
+
   field :field7943, 4, optional: true, type: :int64
+
   field :field7944, 5, optional: true, type: :int64
+
   field :field7945, 12, optional: true, type: :int64
+
   field :field7946, 13, optional: true, type: :int64
+
   field :field7947, 18, optional: true, type: :int64
+
   field :field7948, 6, optional: true, type: :int64
+
   field :field7949, 7, optional: true, type: :int64
+
   field :field7950, 8, repeated: true, type: Benchmarks.GoogleMessage3.Message7919
+
   field :field7951, 20, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field7952, 14, repeated: true, type: Benchmarks.GoogleMessage3.Message7920
+
   field :field7953, 15, repeated: true, type: Benchmarks.GoogleMessage3.Message7921
+
   field :field7954, 17, repeated: true, type: Benchmarks.GoogleMessage3.Message7928
+
   field :field7955, 19, optional: true, type: :int64
+
   field :field7956, 2, optional: true, type: :bool
+
   field :field7957, 3, optional: true, type: :int64
+
   field :field7958, 9, optional: true, type: :int64
+
   field :field7959, 10, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field7960, 11, repeated: true, type: :bytes
+
   field :field7961, 16, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8508 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -488,46 +598,60 @@ defmodule Benchmarks.GoogleMessage3.Message8508 do
           field8533: binary
         }
 
-  defstruct [
-    :field8517,
-    :field8518,
-    :field8519,
-    :field8520,
-    :field8521,
-    :field8522,
-    :field8523,
-    :field8524,
-    :field8525,
-    :field8526,
-    :field8527,
-    :field8528,
-    :field8529,
-    :field8530,
-    :field8531,
-    :field8532,
-    :field8533
-  ]
+  defstruct field8517: [],
+            field8518: [],
+            field8519: [],
+            field8520: nil,
+            field8521: nil,
+            field8522: [],
+            field8523: [],
+            field8524: [],
+            field8525: nil,
+            field8526: nil,
+            field8527: nil,
+            field8528: nil,
+            field8529: nil,
+            field8530: nil,
+            field8531: [],
+            field8532: nil,
+            field8533: nil
 
   field :field8517, 8, repeated: true, type: Benchmarks.GoogleMessage3.Message8511
+
   field :field8518, 9, repeated: true, type: Benchmarks.GoogleMessage3.Message8512
+
   field :field8519, 11, repeated: true, type: Benchmarks.GoogleMessage3.Message8513
+
   field :field8520, 13, optional: true, type: :bool
+
   field :field8521, 14, optional: true, type: Benchmarks.GoogleMessage3.Message8514
+
   field :field8522, 15, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8523, 16, repeated: true, type: Benchmarks.GoogleMessage3.Message8515
+
   field :field8524, 17, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8525, 1, optional: true, type: :int64
+
   field :field8526, 2, optional: true, type: :float
+
   field :field8527, 3, optional: true, type: :int64
+
   field :field8528, 4, optional: true, type: :int64
+
   field :field8529, 5, optional: true, type: :int32
+
   field :field8530, 6, optional: true, type: :bytes
+
   field :field8531, 7, repeated: true, type: :bytes
+
   field :field8532, 10, optional: true, type: :bool
+
   field :field8533, 12, optional: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message9122 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -537,13 +661,15 @@ defmodule Benchmarks.GoogleMessage3.Message9122 do
           field9133: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [:field9132, :field9133]
+  defstruct field9132: nil,
+            field9133: nil
 
   field :field9132, 1, optional: true, type: :float
+
   field :field9133, 2, optional: true, type: :float
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10177 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -552,12 +678,12 @@ defmodule Benchmarks.GoogleMessage3.Message10177 do
           field10270: [Benchmarks.GoogleMessage3.Message10155.t()]
         }
 
-  defstruct [:field10270]
+  defstruct field10270: []
 
   field :field10270, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message10155
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10278 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -568,14 +694,18 @@ defmodule Benchmarks.GoogleMessage3.Message10278 do
           field10288: integer
         }
 
-  defstruct [:field10286, :field10287, :field10288]
+  defstruct field10286: [],
+            field10287: [],
+            field10288: nil
 
   field :field10286, 1, repeated: true, type: :int32, packed: true
+
   field :field10287, 2, repeated: true, type: :int32, packed: true
+
   field :field10288, 3, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10323 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -584,12 +714,12 @@ defmodule Benchmarks.GoogleMessage3.Message10323 do
           field10360: [Benchmarks.GoogleMessage3.Message10320.t()]
         }
 
-  defstruct [:field10360]
+  defstruct field10360: []
 
   field :field10360, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message10320
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10324 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -599,13 +729,15 @@ defmodule Benchmarks.GoogleMessage3.Message10324 do
           field10363: Benchmarks.GoogleMessage3.Message10321.t() | nil
         }
 
-  defstruct [:field10362, :field10363]
+  defstruct field10362: [],
+            field10363: nil
 
   field :field10362, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message10322
+
   field :field10363, 2, optional: true, type: Benchmarks.GoogleMessage3.Message10321
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message11990 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -614,12 +746,12 @@ defmodule Benchmarks.GoogleMessage3.Message11990 do
           field12030: [Benchmarks.GoogleMessage3.Message11988.t()]
         }
 
-  defstruct [:field12030]
+  defstruct field12030: []
 
   field :field12030, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message11988
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message12691 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -630,14 +762,18 @@ defmodule Benchmarks.GoogleMessage3.Message12691 do
           field12715: Benchmarks.GoogleMessage3.Message12668.t() | nil
         }
 
-  defstruct [:field12713, :field12714, :field12715]
+  defstruct field12713: nil,
+            field12714: nil,
+            field12715: nil
 
   field :field12713, 1, optional: true, type: :string
+
   field :field12714, 2, optional: true, type: :int32
+
   field :field12715, 3, optional: true, type: Benchmarks.GoogleMessage3.Message12668
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message12870 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -665,52 +801,69 @@ defmodule Benchmarks.GoogleMessage3.Message12870 do
           field12898: integer
         }
 
-  defstruct [
-    :field12879,
-    :field12880,
-    :field12881,
-    :field12882,
-    :field12883,
-    :field12884,
-    :field12885,
-    :field12886,
-    :field12887,
-    :field12888,
-    :field12889,
-    :field12890,
-    :field12891,
-    :field12892,
-    :field12893,
-    :field12894,
-    :field12895,
-    :field12896,
-    :field12897,
-    :field12898
-  ]
+  defstruct field12879: 0,
+            field12880: nil,
+            field12881: 0,
+            field12882: nil,
+            field12883: nil,
+            field12884: nil,
+            field12885: [],
+            field12886: nil,
+            field12887: nil,
+            field12888: [],
+            field12889: nil,
+            field12890: nil,
+            field12891: nil,
+            field12892: nil,
+            field12893: nil,
+            field12894: nil,
+            field12895: nil,
+            field12896: nil,
+            field12897: nil,
+            field12898: nil
 
   field :field12879, 1, required: true, type: :int32
+
   field :field12880, 7, optional: true, type: :int32
+
   field :field12881, 2, required: true, type: :int32
+
   field :field12882, 3, optional: true, type: :uint64
+
   field :field12883, 2001, optional: true, type: :string
+
   field :field12884, 4, optional: true, type: :fixed64
+
   field :field12885, 14, repeated: true, type: :fixed64
+
   field :field12886, 9, optional: true, type: :int32
+
   field :field12887, 18, optional: true, type: :int64
+
   field :field12888, 8, repeated: true, type: Benchmarks.GoogleMessage3.Message12870
+
   field :field12889, 5, optional: true, type: :int32
+
   field :field12890, 6, optional: true, type: :uint64
+
   field :field12891, 10, optional: true, type: :int32
+
   field :field12892, 11, optional: true, type: :int32
+
   field :field12893, 12, optional: true, type: :double
+
   field :field12894, 13, optional: true, type: Benchmarks.GoogleMessage3.Message12825
+
   field :field12895, 15, optional: true, type: :double
+
   field :field12896, 16, optional: true, type: :string
+
   field :field12897, 17, optional: true, type: Benchmarks.GoogleMessage3.Enum12871, enum: true
+
   field :field12898, 19, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13154 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -720,13 +873,15 @@ defmodule Benchmarks.GoogleMessage3.Message13154 do
           field13165: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [:field13164, :field13165]
+  defstruct field13164: 0.0,
+            field13165: 0.0
 
   field :field13164, 1, required: true, type: :float
+
   field :field13165, 2, required: true, type: :float
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16507 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -767,79 +922,108 @@ defmodule Benchmarks.GoogleMessage3.Message16507 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field16510,
-    :field16511,
-    :field16512,
-    :field16513,
-    :field16514,
-    :field16515,
-    :field16516,
-    :field16517,
-    :field16518,
-    :field16519,
-    :field16520,
-    :field16521,
-    :field16522,
-    :field16523,
-    :field16524,
-    :field16525,
-    :field16526,
-    :field16527,
-    :field16528,
-    :field16529,
-    :field16530,
-    :field16531,
-    :field16532,
-    :field16533,
-    :field16534,
-    :field16535,
-    :field16536,
-    :field16537,
-    :field16538,
-    :field16539,
-    :field16540,
-    :field16541,
-    :__pb_extensions__
-  ]
+  defstruct field16510: nil,
+            field16511: nil,
+            field16512: nil,
+            field16513: [],
+            field16514: [],
+            field16515: nil,
+            field16516: [],
+            field16517: [],
+            field16518: nil,
+            field16519: nil,
+            field16520: [],
+            field16521: [],
+            field16522: [],
+            field16523: [],
+            field16524: nil,
+            field16525: nil,
+            field16526: nil,
+            field16527: nil,
+            field16528: nil,
+            field16529: [],
+            field16530: nil,
+            field16531: nil,
+            field16532: nil,
+            field16533: nil,
+            field16534: nil,
+            field16535: nil,
+            field16536: nil,
+            field16537: nil,
+            field16538: nil,
+            field16539: nil,
+            field16540: nil,
+            field16541: [],
+            __pb_extensions__: nil
 
   field :field16510, 3, optional: true, type: :bool
+
   field :field16511, 4, optional: true, type: :bool
+
   field :field16512, 14, optional: true, type: :bool
+
   field :field16513, 5, repeated: true, type: :string
+
   field :field16514, 6, repeated: true, type: :string
+
   field :field16515, 8, optional: true, type: :string
+
   field :field16516, 9, repeated: true, type: :int32
+
   field :field16517, 10, repeated: true, type: :int32
+
   field :field16518, 7, optional: true, type: :int32
+
   field :field16519, 15, optional: true, type: :string
+
   field :field16520, 11, repeated: true, type: :string
+
   field :field16521, 27, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16522, 22, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16523, 28, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16524, 18, optional: true, type: :string
+
   field :field16525, 19, optional: true, type: :int32
+
   field :field16526, 20, optional: true, type: :int32
+
   field :field16527, 23, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16528, 24, optional: true, type: :bool
+
   field :field16529, 25, repeated: true, type: :string
+
   field :field16530, 26, optional: true, type: :double
+
   field :field16531, 30, optional: true, type: Benchmarks.GoogleMessage3.Message16478
+
   field :field16532, 31, optional: true, type: :bool
+
   field :field16533, 32, optional: true, type: :string
+
   field :field16534, 33, optional: true, type: :bool
+
   field :field16535, 35, optional: true, type: :bool
+
   field :field16536, 36, optional: true, type: :bool
+
   field :field16537, 37, optional: true, type: :bool
+
   field :field16538, 38, optional: true, type: :bool
+
   field :field16539, 39, optional: true, type: :bool
+
   field :field16540, 40, optional: true, type: :bool
+
   field :field16541, 41, repeated: true, type: :string
+
   def transform_module(), do: nil
 
   extensions [{21, 22}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16564 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -848,12 +1032,12 @@ defmodule Benchmarks.GoogleMessage3.Message16564 do
           field16568: [Benchmarks.GoogleMessage3.Message16552.t()]
         }
 
-  defstruct [:field16568]
+  defstruct field16568: []
 
   field :field16568, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message16552
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16661 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -863,13 +1047,15 @@ defmodule Benchmarks.GoogleMessage3.Message16661 do
           field16672: [non_neg_integer]
         }
 
-  defstruct [:field16671, :field16672]
+  defstruct field16671: [],
+            field16672: []
 
   field :field16671, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message16660
+
   field :field16672, 2, repeated: true, type: :uint64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16746 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -881,15 +1067,21 @@ defmodule Benchmarks.GoogleMessage3.Message16746 do
           field16809: [Benchmarks.GoogleMessage3.Message16725.t()]
         }
 
-  defstruct [:field16806, :field16807, :field16808, :field16809]
+  defstruct field16806: [],
+            field16807: nil,
+            field16808: nil,
+            field16809: []
 
   field :field16806, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message16727
+
   field :field16807, 2, optional: true, type: :bool
+
   field :field16808, 3, optional: true, type: :bool
+
   field :field16809, 4, repeated: true, type: Benchmarks.GoogleMessage3.Message16725
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message17786.Message17787 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -923,64 +1115,87 @@ defmodule Benchmarks.GoogleMessage3.Message17786.Message17787 do
           field18202: boolean
         }
 
-  defstruct [
-    :field18177,
-    :field18178,
-    :field18179,
-    :field18180,
-    :field18181,
-    :field18182,
-    :field18183,
-    :field18184,
-    :field18185,
-    :field18186,
-    :field18187,
-    :field18188,
-    :field18189,
-    :field18190,
-    :field18191,
-    :field18192,
-    :field18193,
-    :field18194,
-    :field18195,
-    :field18196,
-    :field18197,
-    :field18198,
-    :field18199,
-    :field18200,
-    :field18201,
-    :field18202
-  ]
+  defstruct field18177: 0,
+            field18178: 0,
+            field18179: nil,
+            field18180: nil,
+            field18181: nil,
+            field18182: [],
+            field18183: nil,
+            field18184: nil,
+            field18185: nil,
+            field18186: nil,
+            field18187: nil,
+            field18188: nil,
+            field18189: nil,
+            field18190: nil,
+            field18191: nil,
+            field18192: nil,
+            field18193: nil,
+            field18194: nil,
+            field18195: nil,
+            field18196: nil,
+            field18197: nil,
+            field18198: [],
+            field18199: nil,
+            field18200: nil,
+            field18201: nil,
+            field18202: nil
 
   field :field18177, 2, required: true, type: :int32
+
   field :field18178, 3, required: true, type: :int32
+
   field :field18179, 4, optional: true, type: Benchmarks.GoogleMessage3.Message17783
+
   field :field18180, 5, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18181, 6, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18182, 8, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18183, 9, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18184, 10, optional: true, type: Benchmarks.GoogleMessage3.Message17726
+
   field :field18185, 11, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18186, 102, optional: true, type: Benchmarks.GoogleMessage3.Message16945
+
   field :field18187, 12, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18188, 13, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18189, 7, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18190, 100, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18191, 101, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18192, 14, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18193, 19, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18194, 22, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18195, 24, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18196, 21, optional: true, type: Benchmarks.GoogleMessage3.Enum16925, enum: true
+
   field :field18197, 18, optional: true, type: :bool
+
   field :field18198, 23, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field18199, 15, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18200, 16, optional: true, type: :string
+
   field :field18201, 17, optional: true, type: :string
+
   field :field18202, 99, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message17786 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -990,13 +1205,15 @@ defmodule Benchmarks.GoogleMessage3.Message17786 do
           field18175: [Benchmarks.GoogleMessage3.Message17782.t()]
         }
 
-  defstruct [:message17787, :field18175]
+  defstruct message17787: [],
+            field18175: []
 
   field :message17787, 1, repeated: true, type: :group
+
   field :field18175, 20, repeated: true, type: Benchmarks.GoogleMessage3.Message17782
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message22857 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1005,12 +1222,12 @@ defmodule Benchmarks.GoogleMessage3.Message22857 do
           field22874: [Benchmarks.GoogleMessage3.Message22853.t()]
         }
 
-  defstruct [:field22874]
+  defstruct field22874: []
 
   field :field22874, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message22853
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24404.Message24405 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1049,74 +1266,102 @@ defmodule Benchmarks.GoogleMessage3.Message24404.Message24405 do
           field24716: integer
         }
 
-  defstruct [
-    :field24686,
-    :field24687,
-    :field24688,
-    :field24689,
-    :field24690,
-    :field24691,
-    :field24692,
-    :field24693,
-    :field24694,
-    :field24695,
-    :field24696,
-    :field24697,
-    :field24698,
-    :field24699,
-    :field24700,
-    :field24701,
-    :field24702,
-    :field24703,
-    :field24704,
-    :field24705,
-    :field24706,
-    :field24707,
-    :field24708,
-    :field24709,
-    :field24710,
-    :field24711,
-    :field24712,
-    :field24713,
-    :field24714,
-    :field24715,
-    :field24716
-  ]
+  defstruct field24686: 0,
+            field24687: 0,
+            field24688: nil,
+            field24689: nil,
+            field24690: nil,
+            field24691: nil,
+            field24692: nil,
+            field24693: nil,
+            field24694: nil,
+            field24695: nil,
+            field24696: nil,
+            field24697: nil,
+            field24698: nil,
+            field24699: nil,
+            field24700: nil,
+            field24701: nil,
+            field24702: nil,
+            field24703: nil,
+            field24704: nil,
+            field24705: [],
+            field24706: nil,
+            field24707: nil,
+            field24708: nil,
+            field24709: nil,
+            field24710: nil,
+            field24711: nil,
+            field24712: nil,
+            field24713: nil,
+            field24714: nil,
+            field24715: nil,
+            field24716: nil
 
   field :field24686, 2, required: true, type: :int32
+
   field :field24687, 3, required: true, type: :int32
+
   field :field24688, 4, optional: true, type: Benchmarks.GoogleMessage3.Message24317
+
   field :field24689, 5, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24690, 6, optional: true, type: Benchmarks.GoogleMessage3.Message24376
+
   field :field24691, 7, optional: true, type: Benchmarks.GoogleMessage3.Message24345
+
   field :field24692, 8, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24693, 9, optional: true, type: Benchmarks.GoogleMessage3.Message24379
+
   field :field24694, 10, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24695, 11, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24696, 12, optional: true, type: Benchmarks.GoogleMessage3.Message24391
+
   field :field24697, 13, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24698, 14, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24699, 22, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24700, 23, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24701, 25, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24702, 18, optional: true, type: Benchmarks.GoogleMessage3.Enum16925, enum: true
+
   field :field24703, 20, optional: true, type: :float
+
   field :field24704, 19, optional: true, type: :bool
+
   field :field24705, 24, repeated: true, type: Benchmarks.GoogleMessage3.Enum16891, enum: true
+
   field :field24706, 15, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24707, 16, optional: true, type: :string
+
   field :field24708, 17, optional: true, type: :string
+
   field :field24709, 21, optional: true, type: :float
+
   field :field24710, 26, optional: true, type: :bool
+
   field :field24711, 27, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field24712, 28, optional: true, type: :bool
+
   field :field24713, 29, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field24714, 31, optional: true, type: :bool
+
   field :field24715, 99, optional: true, type: :bool
+
   field :field24716, 32, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24404 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1126,13 +1371,15 @@ defmodule Benchmarks.GoogleMessage3.Message24404 do
           field24684: Benchmarks.GoogleMessage3.Message24403.t() | nil
         }
 
-  defstruct [:message24405, :field24684]
+  defstruct message24405: [],
+            field24684: nil
 
   field :message24405, 1, repeated: true, type: :group
+
   field :field24684, 30, optional: true, type: Benchmarks.GoogleMessage3.Message24403
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message27300 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1142,13 +1389,15 @@ defmodule Benchmarks.GoogleMessage3.Message27300 do
           field27303: String.t()
         }
 
-  defstruct [:field27302, :field27303]
+  defstruct field27302: [],
+            field27303: nil
 
   field :field27302, 1, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field27303, 2, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message27453 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1179,63 +1428,84 @@ defmodule Benchmarks.GoogleMessage3.Message27453 do
           field27481: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field27459,
-    :field27460,
-    :field27461,
-    :field27462,
-    :field27463,
-    :field27464,
-    :field27465,
-    :field27466,
-    :field27467,
-    :field27468,
-    :field27469,
-    :field27470,
-    :field27471,
-    :field27472,
-    :field27473,
-    :field27474,
-    :field27475,
-    :field27476,
-    :field27477,
-    :field27478,
-    :field27479,
-    :field27480,
-    :field27481
-  ]
+  defstruct field27459: nil,
+            field27460: [],
+            field27461: [],
+            field27462: [],
+            field27463: [],
+            field27464: [],
+            field27465: [],
+            field27466: [],
+            field27467: [],
+            field27468: [],
+            field27469: nil,
+            field27470: [],
+            field27471: nil,
+            field27472: nil,
+            field27473: nil,
+            field27474: nil,
+            field27475: nil,
+            field27476: nil,
+            field27477: nil,
+            field27478: nil,
+            field27479: nil,
+            field27480: nil,
+            field27481: nil
 
   field :field27459, 15, optional: true, type: :string
+
   field :field27460, 1, repeated: true, type: :string
+
   field :field27461, 6, repeated: true, type: :float
+
   field :field27462, 27, repeated: true, type: :int32
+
   field :field27463, 28, repeated: true, type: :int32
+
   field :field27464, 24, repeated: true, type: Benchmarks.GoogleMessage3.Message27454
+
   field :field27465, 2, repeated: true, type: :string
+
   field :field27466, 7, repeated: true, type: :float
+
   field :field27467, 22, repeated: true, type: :string
+
   field :field27468, 23, repeated: true, type: :string
+
   field :field27469, 26, optional: true, type: :string
+
   field :field27470, 8, repeated: true, type: Benchmarks.GoogleMessage3.Message27357
+
   field :field27471, 16, optional: true, type: Benchmarks.GoogleMessage3.Message27360
+
   field :field27472, 25, optional: true, type: :string
+
   field :field27473, 11, optional: true, type: :string
+
   field :field27474, 13, optional: true, type: :bool
+
   field :field27475, 14, optional: true, type: :bool
+
   field :field27476, 17, optional: true, type: :bool
+
   field :field27477, 12, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field27478, 34_268_945, optional: true, type: :bool
+
   field :field27479, 20, optional: true, type: :bool
+
   field :field27480, 21, optional: true, type: :string
+
   field :field27481, 10, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.PbExtension do
   @moduledoc false
   use Protobuf, syntax: :proto2
 
   extend Benchmarks.GoogleMessage3.Message16945, :field17026, 472, optional: true, type: :string
+
   extend Benchmarks.GoogleMessage3.Message16945, :field17027, 818, repeated: true, type: :string
 
   extend Benchmarks.GoogleMessage3.Message16945, :field17031, 215,
@@ -1259,8 +1529,11 @@ defmodule Benchmarks.GoogleMessage3.PbExtension do
     type: Benchmarks.GoogleMessage3.Message0
 
   extend Benchmarks.GoogleMessage3.Message16945, :field17043, 224, optional: true, type: :string
+
   extend Benchmarks.GoogleMessage3.Message16945, :field17044, 225, optional: true, type: :string
+
   extend Benchmarks.GoogleMessage3.Message16945, :field17048, 63, repeated: true, type: :string
+
   extend Benchmarks.GoogleMessage3.Message16945, :field17049, 64, repeated: true, type: :string
 
   extend Benchmarks.GoogleMessage3.Message16945, :field17052, 233,
@@ -1272,6 +1545,7 @@ defmodule Benchmarks.GoogleMessage3.PbExtension do
     type: Benchmarks.GoogleMessage3.Message0
 
   extend Benchmarks.GoogleMessage3.Message16945, :field17056, 275, repeated: true, type: :string
+
   extend Benchmarks.GoogleMessage3.Message16945, :field17057, 226, optional: true, type: :string
 
   extend Benchmarks.GoogleMessage3.Message16945, :field17060, 27,
@@ -1303,11 +1577,17 @@ defmodule Benchmarks.GoogleMessage3.PbExtension do
     type: Benchmarks.GoogleMessage3.Message0
 
   extend Benchmarks.GoogleMessage3.Message16945, :field17102, 158, repeated: true, type: :string
+
   extend Benchmarks.GoogleMessage3.Message16945, :field17107, 166, repeated: true, type: :string
+
   extend Benchmarks.GoogleMessage3.Message16945, :field17133, 567, repeated: true, type: :string
+
   extend Benchmarks.GoogleMessage3.Message16945, :field17134, 572, repeated: true, type: :string
+
   extend Benchmarks.GoogleMessage3.Message16945, :field17160, 49, repeated: true, type: :string
+
   extend Benchmarks.GoogleMessage3.Message16945, :field17168, 32, repeated: true, type: :string
+
   extend Benchmarks.GoogleMessage3.Message16945, :field17170, 34, repeated: true, type: :string
 
   extend Benchmarks.GoogleMessage3.Message16945, :field17172, 509,
@@ -1365,6 +1645,7 @@ defmodule Benchmarks.GoogleMessage3.PbExtension do
     type: Benchmarks.GoogleMessage3.Message0
 
   extend Benchmarks.GoogleMessage3.Message16945, :field17460, 560, repeated: true, type: :string
+
   extend Benchmarks.GoogleMessage3.Message16945, :field17466, 552, repeated: true, type: :string
 
   extend Benchmarks.GoogleMessage3.Message16945, :field17617, 1080,
@@ -1373,97 +1654,105 @@ defmodule Benchmarks.GoogleMessage3.PbExtension do
 
   extend Benchmarks.GoogleMessage3.Message16945, :field17618, 1084, repeated: true, type: :int32
 
-  extend Benchmarks.GoogleMessage3.Message0, :"Message1327.field1373", 23_104_162,
+  extend Benchmarks.GoogleMessage3.Message0, :"Message27300.field27304", 24_956_467,
     optional: true,
-    type: Benchmarks.GoogleMessage3.Message1327
+    type: Benchmarks.GoogleMessage3.Message27300
 
-  extend Benchmarks.GoogleMessage3.Message0, :"Message3672.field3737", 3_144_435,
+  extend Benchmarks.GoogleMessage3.Message0, :"Message24404.field24685", 9_129_287,
     optional: true,
-    type: Benchmarks.GoogleMessage3.Message3672
+    type: Benchmarks.GoogleMessage3.Message24404
 
-  extend Benchmarks.GoogleMessage3.Message0, :"Message3804.field3825", 59_241_828,
+  extend Benchmarks.GoogleMessage3.Message0, :"Message16746.field16810", 28_406_765,
     optional: true,
-    type: Benchmarks.GoogleMessage3.Message3804
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message6849.field6911", 107_558_455,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message6849
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message6866.field6974", 22_259_060,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message6866
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message6870.field6992", 90_034_652,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message6870
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message7651.field7730", 55_876_009,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message7651
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message7864.field7872", 44_542_730,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message7864
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message7929.field7962", 53_392_238,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message7929
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message8508.field8534", 3_811_804,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message8508
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message9122.field9134", 120_398_939,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message9122
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message10177.field10271", 26_801_105,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message10177
-
-  extend Benchmarks.GoogleMessage3.Message10155, :"Message10278.field10289", 29_374_161,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message10278
-
-  extend Benchmarks.GoogleMessage3.Message10155, :"Message10323.field10361", 27_922_524,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message10323
-
-  extend Benchmarks.GoogleMessage3.Message10155, :"Message10324.field10364", 27_832_297,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message10324
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message11990.field12031", 21_265_426,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message11990
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message12691.field12716", 28_426_536,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message12691
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message12870.field12899", 5_447_656,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message12870
-
-  extend Benchmarks.GoogleMessage3.Message13145, :"Message13154.field13166", 47_301_086,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message13154
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message16507.field16542", 5_569_941,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message16507
+    type: Benchmarks.GoogleMessage3.Message16746
 
   extend Benchmarks.GoogleMessage3.Message0, :"Message16564.field16569", 25_830_030,
     optional: true,
     type: Benchmarks.GoogleMessage3.Message16564
 
+  extend Benchmarks.GoogleMessage3.Message13145, :"Message13154.field13166", 47_301_086,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message13154
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message12691.field12716", 28_426_536,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message12691
+
+  extend Benchmarks.GoogleMessage3.Message10155, :"Message10324.field10364", 27_832_297,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message10324
+
+  extend Benchmarks.GoogleMessage3.Message10155, :"Message10278.field10289", 29_374_161,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message10278
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message9122.field9134", 120_398_939,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message9122
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message7929.field7962", 53_392_238,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message7929
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message7651.field7730", 55_876_009,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message7651
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message6866.field6974", 22_259_060,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message6866
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message3804.field3825", 59_241_828,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message3804
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message3672.field3737", 3_144_435,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message3672
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message1327.field1373", 23_104_162,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message1327
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message6849.field6911", 107_558_455,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message6849
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message6870.field6992", 90_034_652,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message6870
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message7864.field7872", 44_542_730,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message7864
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message8508.field8534", 3_811_804,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message8508
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message10177.field10271", 26_801_105,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message10177
+
+  extend Benchmarks.GoogleMessage3.Message10155, :"Message10323.field10361", 27_922_524,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message10323
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message11990.field12031", 21_265_426,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message11990
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message12870.field12899", 5_447_656,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message12870
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message16507.field16542", 5_569_941,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message16507
+
   extend Benchmarks.GoogleMessage3.Message0, :"Message16661.field16673", 31_274_398,
     optional: true,
     type: Benchmarks.GoogleMessage3.Message16661
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message16746.field16810", 28_406_765,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message16746
 
   extend Benchmarks.GoogleMessage3.Message0, :"Message17786.field18176", 11_823_055,
     optional: true,
@@ -1472,14 +1761,6 @@ defmodule Benchmarks.GoogleMessage3.PbExtension do
   extend Benchmarks.GoogleMessage3.Message10155, :"Message22857.field22875", 67_799_715,
     optional: true,
     type: Benchmarks.GoogleMessage3.Message22857
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message24404.field24685", 9_129_287,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message24404
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message27300.field27304", 24_956_467,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message27300
 
   extend Benchmarks.GoogleMessage3.Message0, :"Message27453.field27482", 8_086_204,
     optional: true,

--- a/bench/lib/datasets/google_message3/benchmark_message3_1.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_1.pb.ex
@@ -6,12 +6,12 @@ defmodule Benchmarks.GoogleMessage3.Message34390 do
           field34452: [Benchmarks.GoogleMessage3.Message34387.t()]
         }
 
-  defstruct [:field34452]
+  defstruct field34452: []
 
   field :field34452, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message34387
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message34624 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -21,13 +21,15 @@ defmodule Benchmarks.GoogleMessage3.Message34624 do
           field34684: Benchmarks.GoogleMessage3.Message34621.t() | nil
         }
 
-  defstruct [:field34683, :field34684]
+  defstruct field34683: nil,
+            field34684: nil
 
   field :field34683, 1, optional: true, type: Benchmarks.GoogleMessage3.Message34621
+
   field :field34684, 2, optional: true, type: Benchmarks.GoogleMessage3.Message34621
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message34791.Message34792 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -37,13 +39,15 @@ defmodule Benchmarks.GoogleMessage3.Message34791.Message34792 do
           field34809: String.t()
         }
 
-  defstruct [:field34808, :field34809]
+  defstruct field34808: "",
+            field34809: nil
 
   field :field34808, 3, required: true, type: :string
+
   field :field34809, 4, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message34791 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -65,40 +69,51 @@ defmodule Benchmarks.GoogleMessage3.Message34791 do
           field34806: [non_neg_integer]
         }
 
-  defstruct [
-    :field34793,
-    :message34792,
-    :field34795,
-    :field34796,
-    :field34797,
-    :field34798,
-    :field34799,
-    :field34800,
-    :field34801,
-    :field34802,
-    :field34803,
-    :field34804,
-    :field34805,
-    :field34806
-  ]
+  defstruct field34793: nil,
+            message34792: [],
+            field34795: nil,
+            field34796: nil,
+            field34797: nil,
+            field34798: nil,
+            field34799: nil,
+            field34800: nil,
+            field34801: nil,
+            field34802: nil,
+            field34803: nil,
+            field34804: nil,
+            field34805: nil,
+            field34806: []
 
   field :field34793, 1, optional: true, type: :fixed64
+
   field :message34792, 2, repeated: true, type: :group
+
   field :field34795, 5, optional: true, type: :int32
+
   field :field34796, 6, optional: true, type: :int32
+
   field :field34797, 7, optional: true, type: :int32
+
   field :field34798, 8, optional: true, type: :int32
+
   field :field34799, 9, optional: true, type: :int32
+
   field :field34800, 10, optional: true, type: :int32
+
   field :field34801, 11, optional: true, type: :bool
+
   field :field34802, 12, optional: true, type: :float
+
   field :field34803, 13, optional: true, type: :int32
+
   field :field34804, 14, optional: true, type: :string
+
   field :field34805, 15, optional: true, type: :int64
+
   field :field34806, 17, repeated: true, type: :fixed64, packed: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message35483 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -112,17 +127,27 @@ defmodule Benchmarks.GoogleMessage3.Message35483 do
           field35504: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [:field35499, :field35500, :field35501, :field35502, :field35503, :field35504]
+  defstruct field35499: nil,
+            field35500: nil,
+            field35501: nil,
+            field35502: nil,
+            field35503: [],
+            field35504: nil
 
   field :field35499, 1, optional: true, type: :int32
+
   field :field35500, 2, optional: true, type: :string
+
   field :field35501, 3, optional: true, type: :string
+
   field :field35502, 4, optional: true, type: :string
+
   field :field35503, 5, repeated: true, type: Benchmarks.GoogleMessage3.Message35476
+
   field :field35504, 6, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message35807 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -138,28 +163,33 @@ defmodule Benchmarks.GoogleMessage3.Message35807 do
           field35817: integer
         }
 
-  defstruct [
-    :field35810,
-    :field35811,
-    :field35812,
-    :field35813,
-    :field35814,
-    :field35815,
-    :field35816,
-    :field35817
-  ]
+  defstruct field35810: nil,
+            field35811: nil,
+            field35812: nil,
+            field35813: nil,
+            field35814: nil,
+            field35815: nil,
+            field35816: nil,
+            field35817: nil
 
   field :field35810, 1, optional: true, type: :int32
+
   field :field35811, 2, optional: true, type: :int32
+
   field :field35812, 3, optional: true, type: :int32
+
   field :field35813, 4, optional: true, type: :int32
+
   field :field35814, 5, optional: true, type: :int32
+
   field :field35815, 6, optional: true, type: :int32
+
   field :field35816, 7, optional: true, type: :int32
+
   field :field35817, 8, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message37487 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -169,13 +199,15 @@ defmodule Benchmarks.GoogleMessage3.Message37487 do
           field37502: boolean
         }
 
-  defstruct [:field37501, :field37502]
+  defstruct field37501: nil,
+            field37502: nil
 
   field :field37501, 2, optional: true, type: :bytes
+
   field :field37502, 3, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13062 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -188,16 +220,24 @@ defmodule Benchmarks.GoogleMessage3.Message13062 do
           field13079: integer
         }
 
-  defstruct [:field13075, :field13076, :field13077, :field13078, :field13079]
+  defstruct field13075: nil,
+            field13076: nil,
+            field13077: nil,
+            field13078: nil,
+            field13079: nil
 
   field :field13075, 1, optional: true, type: :int64
+
   field :field13076, 2, optional: true, type: :string
+
   field :field13077, 3, optional: true, type: :int32
+
   field :field13078, 4, optional: true, type: :string
+
   field :field13079, 5, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message952 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -206,12 +246,12 @@ defmodule Benchmarks.GoogleMessage3.Message952 do
           field963: [Benchmarks.GoogleMessage3.Message949.t()]
         }
 
-  defstruct [:field963]
+  defstruct field963: []
 
   field :field963, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message949
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36877 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -224,25 +264,34 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36877 do
           field37048: integer
         }
 
-  defstruct [:field37044, :field37045, :field37046, :field37047, :field37048]
+  defstruct field37044: "",
+            field37045: nil,
+            field37046: nil,
+            field37047: nil,
+            field37048: nil
 
   field :field37044, 112, required: true, type: :string
+
   field :field37045, 113, optional: true, type: :int32
+
   field :field37046, 114, optional: true, type: :bytes
+
   field :field37047, 115, optional: true, type: :int32
+
   field :field37048, 157, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36878 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36879 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -252,85 +301,95 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36879 do
           field37051: integer
         }
 
-  defstruct [:field37050, :field37051]
+  defstruct field37050: "",
+            field37051: nil
 
   field :field37050, 56, required: true, type: :string
+
   field :field37051, 69, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36880 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36881 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36882 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36883 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36884 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36885 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36886 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36887 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36888 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -344,17 +403,27 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36888 do
           field37094: binary
         }
 
-  defstruct [:field37089, :field37090, :field37091, :field37092, :field37093, :field37094]
+  defstruct field37089: nil,
+            field37090: nil,
+            field37091: nil,
+            field37092: nil,
+            field37093: nil,
+            field37094: nil
 
   field :field37089, 75, optional: true, type: :uint64
+
   field :field37090, 76, optional: true, type: :bool
+
   field :field37091, 165, optional: true, type: :uint64
+
   field :field37092, 166, optional: true, type: :double
+
   field :field37093, 109, optional: true, type: :uint64
+
   field :field37094, 122, optional: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36889 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -387,71 +456,94 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36889 do
           field37119: [String.t()]
         }
 
-  defstruct [
-    :field37095,
-    :field37096,
-    :field37097,
-    :field37098,
-    :field37099,
-    :field37100,
-    :field37101,
-    :field37102,
-    :field37103,
-    :field37104,
-    :field37105,
-    :field37106,
-    :field37107,
-    :field37108,
-    :field37109,
-    :field37110,
-    :field37111,
-    :field37112,
-    :field37113,
-    :field37114,
-    :field37115,
-    :field37116,
-    :field37117,
-    :field37118,
-    :field37119
-  ]
+  defstruct field37095: nil,
+            field37096: nil,
+            field37097: nil,
+            field37098: nil,
+            field37099: nil,
+            field37100: nil,
+            field37101: nil,
+            field37102: nil,
+            field37103: nil,
+            field37104: nil,
+            field37105: [],
+            field37106: nil,
+            field37107: nil,
+            field37108: nil,
+            field37109: nil,
+            field37110: nil,
+            field37111: nil,
+            field37112: nil,
+            field37113: nil,
+            field37114: nil,
+            field37115: nil,
+            field37116: nil,
+            field37117: [],
+            field37118: nil,
+            field37119: []
 
   field :field37095, 117, optional: true, type: :int64
+
   field :field37096, 145, optional: true, type: :string
+
   field :field37097, 123, optional: true, type: :int32
+
   field :field37098, 163, optional: true, type: :bool
+
   field :field37099, 164, optional: true, type: :int32
+
   field :field37100, 149, optional: true, type: :int32
+
   field :field37101, 129, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37102, 124, optional: true, type: Benchmarks.GoogleMessage3.Message13174
+
   field :field37103, 128, optional: true, type: Benchmarks.GoogleMessage3.Message13169
+
   field :field37104, 132, optional: true, type: :uint64
+
   field :field37105, 131, repeated: true, type: Benchmarks.GoogleMessage3.Enum36890, enum: true
+
   field :field37106, 134, optional: true, type: :bool
+
   field :field37107, 140, optional: true, type: :bool
+
   field :field37108, 135, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37109, 136, optional: true, type: :float
+
   field :field37110, 156, optional: true, type: :float
+
   field :field37111, 142, optional: true, type: :bool
+
   field :field37112, 167, optional: true, type: :int64
+
   field :field37113, 146, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37114, 148, optional: true, type: :bool
+
   field :field37115, 154, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37116, 158, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field37117, 159, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field37118, 160, optional: true, type: :int32
+
   field :field37119, 161, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36910 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36911 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -463,15 +555,21 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36911 do
           field37124: Benchmarks.GoogleMessage3.Message35542.t() | nil
         }
 
-  defstruct [:field37121, :field37122, :field37123, :field37124]
+  defstruct field37121: nil,
+            field37122: nil,
+            field37123: nil,
+            field37124: nil
 
   field :field37121, 127, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37122, 130, optional: true, type: Benchmarks.GoogleMessage3.Message35538
+
   field :field37123, 144, optional: true, type: Benchmarks.GoogleMessage3.Message35540
+
   field :field37124, 150, optional: true, type: Benchmarks.GoogleMessage3.Message35542
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36912 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -481,13 +579,15 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36912 do
           field37126: Benchmarks.GoogleMessage3.Message3901.t() | nil
         }
 
-  defstruct [:field37125, :field37126]
+  defstruct field37125: nil,
+            field37126: nil
 
   field :field37125, 153, optional: true, type: Benchmarks.GoogleMessage3.Message3901
+
   field :field37126, 162, optional: true, type: Benchmarks.GoogleMessage3.Message3901
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36876 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -558,156 +658,218 @@ defmodule Benchmarks.GoogleMessage3.Message36876 do
           field37042: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field36980,
-    :message36877,
-    :message36878,
-    :message36879,
-    :field36984,
-    :message36880,
-    :field36986,
-    :field36987,
-    :field36988,
-    :field36989,
-    :field36990,
-    :field36991,
-    :field36992,
-    :field36993,
-    :field36994,
-    :field36995,
-    :field36996,
-    :field36997,
-    :field36998,
-    :field36999,
-    :field37000,
-    :message36881,
-    :field37002,
-    :message36882,
-    :field37004,
-    :field37005,
-    :field37006,
-    :field37007,
-    :field37008,
-    :field37009,
-    :field37010,
-    :field37011,
-    :field37012,
-    :field37013,
-    :field37014,
-    :field37015,
-    :message36883,
-    :message36884,
-    :message36885,
-    :message36886,
-    :field37020,
-    :field37021,
-    :field37022,
-    :field37023,
-    :message36887,
-    :field37025,
-    :field37026,
-    :field37027,
-    :field37028,
-    :field37029,
-    :field37030,
-    :message36888,
-    :field37032,
-    :field37033,
-    :field37034,
-    :field37035,
-    :field37036,
-    :field37037,
-    :message36889,
-    :message36910,
-    :message36911,
-    :message36912,
-    :field37042
-  ]
+  defstruct field36980: nil,
+            message36877: [],
+            message36878: [],
+            message36879: [],
+            field36984: [],
+            message36880: nil,
+            field36986: nil,
+            field36987: nil,
+            field36988: nil,
+            field36989: nil,
+            field36990: nil,
+            field36991: nil,
+            field36992: nil,
+            field36993: nil,
+            field36994: nil,
+            field36995: nil,
+            field36996: nil,
+            field36997: [],
+            field36998: nil,
+            field36999: nil,
+            field37000: nil,
+            message36881: [],
+            field37002: nil,
+            message36882: [],
+            field37004: nil,
+            field37005: nil,
+            field37006: nil,
+            field37007: nil,
+            field37008: nil,
+            field37009: nil,
+            field37010: nil,
+            field37011: nil,
+            field37012: nil,
+            field37013: nil,
+            field37014: nil,
+            field37015: nil,
+            message36883: nil,
+            message36884: [],
+            message36885: [],
+            message36886: nil,
+            field37020: [],
+            field37021: [],
+            field37022: nil,
+            field37023: nil,
+            message36887: nil,
+            field37025: [],
+            field37026: [],
+            field37027: nil,
+            field37028: nil,
+            field37029: nil,
+            field37030: nil,
+            message36888: nil,
+            field37032: [],
+            field37033: nil,
+            field37034: nil,
+            field37035: [],
+            field37036: nil,
+            field37037: nil,
+            message36889: nil,
+            message36910: [],
+            message36911: nil,
+            message36912: nil,
+            field37042: nil
 
   field :field36980, 1, optional: true, type: Benchmarks.GoogleMessage3.Message2356
+
   field :message36877, 111, repeated: true, type: :group
+
   field :message36878, 168, repeated: true, type: :group
+
   field :message36879, 55, repeated: true, type: :group
+
   field :field36984, 78, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :message36880, 137, optional: true, type: :group
+
   field :field36986, 59, optional: true, type: :uint64
+
   field :field36987, 121, optional: true, type: :bytes
+
   field :field36988, 2, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field36989, 118, optional: true, type: Benchmarks.GoogleMessage3.Message7029
+
   field :field36990, 11, optional: true, type: Benchmarks.GoogleMessage3.Message35573
+
   field :field36991, 21, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field36992, 22, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field36993, 13, optional: true, type: :float
+
   field :field36994, 20, optional: true, type: :int32
+
   field :field36995, 51, optional: true, type: :bool
+
   field :field36996, 57, optional: true, type: :bool
+
   field :field36997, 100, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field36998, 47, optional: true, type: :int32
+
   field :field36999, 48, optional: true, type: :int32
+
   field :field37000, 68, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :message36881, 23, repeated: true, type: :group
+
   field :field37002, 125, optional: true, type: Benchmarks.GoogleMessage3.Message4144
+
   field :message36882, 35, repeated: true, type: :group
+
   field :field37004, 49, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37005, 52, optional: true, type: Benchmarks.GoogleMessage3.Message18921
+
   field :field37006, 46, optional: true, type: Benchmarks.GoogleMessage3.Message36858
+
   field :field37007, 54, optional: true, type: Benchmarks.GoogleMessage3.Message18831
+
   field :field37008, 58, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37009, 10, optional: true, type: Benchmarks.GoogleMessage3.Message18283
+
   field :field37010, 44, optional: true, type: :string
+
   field :field37011, 103, optional: true, type: :string
+
   field :field37012, 43, optional: true, type: Benchmarks.GoogleMessage3.Message0
+
   field :field37013, 143, optional: true, type: Benchmarks.GoogleMessage3.Message0
+
   field :field37014, 53, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37015, 15, optional: true, type: Benchmarks.GoogleMessage3.Message36869
+
   field :message36883, 3, optional: true, type: :group
+
   field :message36884, 16, repeated: true, type: :group
+
   field :message36885, 27, repeated: true, type: :group
+
   field :message36886, 32, optional: true, type: :group
+
   field :field37020, 71, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field37021, 70, repeated: true, type: :int32
+
   field :field37022, 66, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37023, 67, optional: true, type: Benchmarks.GoogleMessage3.Message13090
+
   field :message36887, 62, optional: true, type: :group
+
   field :field37025, 50, repeated: true, type: Benchmarks.GoogleMessage3.Message10155
+
   field :field37026, 151, repeated: true, type: Benchmarks.GoogleMessage3.Message11874
+
   field :field37027, 12, optional: true, type: :string
+
   field :field37028, 72, optional: true, type: :int64
+
   field :field37029, 73, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37030, 108, optional: true, type: Benchmarks.GoogleMessage3.Message35546
+
   field :message36888, 74, optional: true, type: :group
+
   field :field37032, 104, repeated: true, type: Benchmarks.GoogleMessage3.Message19255
+
   field :field37033, 105, optional: true, type: Benchmarks.GoogleMessage3.Message33968
+
   field :field37034, 106, optional: true, type: :bool
+
   field :field37035, 107, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field37036, 110, optional: true, type: Benchmarks.GoogleMessage3.Message6644
+
   field :field37037, 133, optional: true, type: :bytes
+
   field :message36889, 116, optional: true, type: :group
+
   field :message36910, 119, repeated: true, type: :group
+
   field :message36911, 126, optional: true, type: :group
+
   field :message36912, 152, optional: true, type: :group
+
   field :field37042, 155, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message1328 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6850 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6863 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -748,87 +910,118 @@ defmodule Benchmarks.GoogleMessage3.Message6863 do
           field6963: boolean
         }
 
-  defstruct [
-    :field6931,
-    :field6932,
-    :field6933,
-    :field6934,
-    :field6935,
-    :field6936,
-    :field6937,
-    :field6938,
-    :field6939,
-    :field6940,
-    :field6941,
-    :field6942,
-    :field6943,
-    :field6944,
-    :field6945,
-    :field6946,
-    :field6947,
-    :field6948,
-    :field6949,
-    :field6950,
-    :field6951,
-    :field6952,
-    :field6953,
-    :field6954,
-    :field6955,
-    :field6956,
-    :field6957,
-    :field6958,
-    :field6959,
-    :field6960,
-    :field6961,
-    :field6962,
-    :field6963
-  ]
+  defstruct field6931: nil,
+            field6932: nil,
+            field6933: nil,
+            field6934: nil,
+            field6935: nil,
+            field6936: nil,
+            field6937: nil,
+            field6938: nil,
+            field6939: nil,
+            field6940: nil,
+            field6941: nil,
+            field6942: nil,
+            field6943: nil,
+            field6944: nil,
+            field6945: nil,
+            field6946: nil,
+            field6947: nil,
+            field6948: nil,
+            field6949: nil,
+            field6950: nil,
+            field6951: nil,
+            field6952: nil,
+            field6953: nil,
+            field6954: nil,
+            field6955: nil,
+            field6956: nil,
+            field6957: nil,
+            field6958: nil,
+            field6959: nil,
+            field6960: nil,
+            field6961: nil,
+            field6962: nil,
+            field6963: nil
 
   field :field6931, 1, optional: true, type: Benchmarks.GoogleMessage3.Enum6858, enum: true
+
   field :field6932, 2, optional: true, type: Benchmarks.GoogleMessage3.Enum6858, enum: true
+
   field :field6933, 36, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field6934, 27, optional: true, type: :bool
+
   field :field6935, 26, optional: true, type: Benchmarks.GoogleMessage3.Message6773
+
   field :field6936, 30, optional: true, type: :int32
+
   field :field6937, 37, optional: true, type: :int32
+
   field :field6938, 31, optional: true, type: Benchmarks.GoogleMessage3.Enum6815, enum: true
+
   field :field6939, 3, optional: true, type: :string
+
   field :field6940, 4, optional: true, type: :int32
+
   field :field6941, 15, optional: true, type: Benchmarks.GoogleMessage3.Enum6822, enum: true
+
   field :field6942, 10, optional: true, type: :bool
+
   field :field6943, 17, optional: true, type: :bool
+
   field :field6944, 18, optional: true, type: :float
+
   field :field6945, 19, optional: true, type: :float
+
   field :field6946, 5, optional: true, type: :int32
+
   field :field6947, 6, optional: true, type: :int32
+
   field :field6948, 7, optional: true, type: :bool
+
   field :field6949, 12, optional: true, type: :int32
+
   field :field6950, 8, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6951, 9, optional: true, type: :uint64
+
   field :field6952, 11, optional: true, type: :string
+
   field :field6953, 13, optional: true, type: :bytes
+
   field :field6954, 14, optional: true, type: :int32
+
   field :field6955, 16, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6956, 22, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6957, 38, optional: true, type: Benchmarks.GoogleMessage3.Message3886
+
   field :field6958, 20, optional: true, type: :string
+
   field :field6959, 21, optional: true, type: :uint32
+
   field :field6960, 23, optional: true, type: Benchmarks.GoogleMessage3.Message6743
+
   field :field6961, 29, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6962, 33, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6963, 34, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6871 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7547 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -838,13 +1031,15 @@ defmodule Benchmarks.GoogleMessage3.Message7547 do
           field7550: integer
         }
 
-  defstruct [:field7549, :field7550]
+  defstruct field7549: "",
+            field7550: 0
 
   field :field7549, 1, required: true, type: :bytes
+
   field :field7550, 2, required: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7648 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -864,45 +1059,55 @@ defmodule Benchmarks.GoogleMessage3.Message7648 do
           field7680: boolean
         }
 
-  defstruct [
-    :field7669,
-    :field7670,
-    :field7671,
-    :field7672,
-    :field7673,
-    :field7674,
-    :field7675,
-    :field7676,
-    :field7677,
-    :field7678,
-    :field7679,
-    :field7680
-  ]
+  defstruct field7669: nil,
+            field7670: nil,
+            field7671: nil,
+            field7672: nil,
+            field7673: nil,
+            field7674: nil,
+            field7675: nil,
+            field7676: nil,
+            field7677: nil,
+            field7678: nil,
+            field7679: nil,
+            field7680: nil
 
   field :field7669, 1, optional: true, type: :string
+
   field :field7670, 2, optional: true, type: :int32
+
   field :field7671, 3, optional: true, type: :int32
+
   field :field7672, 4, optional: true, type: :int32
+
   field :field7673, 5, optional: true, type: :int32
+
   field :field7674, 6, optional: true, type: :int32
+
   field :field7675, 7, optional: true, type: :float
+
   field :field7676, 8, optional: true, type: :bool
+
   field :field7677, 9, optional: true, type: :bool
+
   field :field7678, 10, optional: true, type: :bool
+
   field :field7679, 11, optional: true, type: :bool
+
   field :field7680, 12, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7865 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7928 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -912,13 +1117,15 @@ defmodule Benchmarks.GoogleMessage3.Message7928 do
           field7941: integer
         }
 
-  defstruct [:field7940, :field7941]
+  defstruct field7940: nil,
+            field7941: nil
 
   field :field7940, 1, optional: true, type: :string
+
   field :field7941, 2, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7919 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -929,14 +1136,18 @@ defmodule Benchmarks.GoogleMessage3.Message7919 do
           field7933: binary
         }
 
-  defstruct [:field7931, :field7932, :field7933]
+  defstruct field7931: nil,
+            field7932: nil,
+            field7933: nil
 
   field :field7931, 1, optional: true, type: :fixed64
+
   field :field7932, 2, optional: true, type: :int64
+
   field :field7933, 3, optional: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7920 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -946,13 +1157,15 @@ defmodule Benchmarks.GoogleMessage3.Message7920 do
           field7935: integer
         }
 
-  defstruct [:field7934, :field7935]
+  defstruct field7934: nil,
+            field7935: nil
 
   field :field7934, 1, optional: true, type: :int64
+
   field :field7935, 2, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7921 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -964,15 +1177,21 @@ defmodule Benchmarks.GoogleMessage3.Message7921 do
           field7939: Benchmarks.GoogleMessage3.UnusedEnum.t()
         }
 
-  defstruct [:field7936, :field7937, :field7938, :field7939]
+  defstruct field7936: nil,
+            field7937: nil,
+            field7938: nil,
+            field7939: nil
 
   field :field7936, 1, optional: true, type: :int32
+
   field :field7937, 2, optional: true, type: :int64
+
   field :field7938, 3, optional: true, type: :float
+
   field :field7939, 4, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8511 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -985,16 +1204,24 @@ defmodule Benchmarks.GoogleMessage3.Message8511 do
           field8543: String.t()
         }
 
-  defstruct [:field8539, :field8540, :field8541, :field8542, :field8543]
+  defstruct field8539: nil,
+            field8540: nil,
+            field8541: nil,
+            field8542: nil,
+            field8543: nil
 
   field :field8539, 1, optional: true, type: Benchmarks.GoogleMessage3.Message8224
+
   field :field8540, 2, optional: true, type: :string
+
   field :field8541, 3, optional: true, type: :bool
+
   field :field8542, 4, optional: true, type: :int64
+
   field :field8543, 5, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8512 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1008,17 +1235,27 @@ defmodule Benchmarks.GoogleMessage3.Message8512 do
           field8549: String.t()
         }
 
-  defstruct [:field8544, :field8545, :field8546, :field8547, :field8548, :field8549]
+  defstruct field8544: nil,
+            field8545: nil,
+            field8546: nil,
+            field8547: nil,
+            field8548: nil,
+            field8549: nil
 
   field :field8544, 1, optional: true, type: Benchmarks.GoogleMessage3.Message8301
+
   field :field8545, 2, optional: true, type: Benchmarks.GoogleMessage3.Message8302
+
   field :field8546, 3, optional: true, type: :string
+
   field :field8547, 4, optional: true, type: :bool
+
   field :field8548, 5, optional: true, type: :int64
+
   field :field8549, 6, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8513 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1030,15 +1267,21 @@ defmodule Benchmarks.GoogleMessage3.Message8513 do
           field8553: String.t()
         }
 
-  defstruct [:field8550, :field8551, :field8552, :field8553]
+  defstruct field8550: [],
+            field8551: nil,
+            field8552: nil,
+            field8553: nil
 
   field :field8550, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message8392
+
   field :field8551, 2, optional: true, type: :string
+
   field :field8552, 3, optional: true, type: :bool
+
   field :field8553, 4, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8514 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1051,16 +1294,24 @@ defmodule Benchmarks.GoogleMessage3.Message8514 do
           field8558: String.t()
         }
 
-  defstruct [:field8554, :field8555, :field8556, :field8557, :field8558]
+  defstruct field8554: nil,
+            field8555: nil,
+            field8556: nil,
+            field8557: [],
+            field8558: nil
 
   field :field8554, 1, optional: true, type: :string
+
   field :field8555, 2, optional: true, type: :int64
+
   field :field8556, 3, optional: true, type: :bool
+
   field :field8557, 4, repeated: true, type: Benchmarks.GoogleMessage3.Message8130
+
   field :field8558, 5, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8515 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1071,14 +1322,18 @@ defmodule Benchmarks.GoogleMessage3.Message8515 do
           field8561: String.t()
         }
 
-  defstruct [:field8559, :field8560, :field8561]
+  defstruct field8559: nil,
+            field8560: nil,
+            field8561: nil
 
   field :field8559, 1, optional: true, type: Benchmarks.GoogleMessage3.Message8479
+
   field :field8560, 2, optional: true, type: Benchmarks.GoogleMessage3.Message8478
+
   field :field8561, 3, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10320 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1093,26 +1348,30 @@ defmodule Benchmarks.GoogleMessage3.Message10320 do
           field10353: Benchmarks.GoogleMessage3.Enum10337.t()
         }
 
-  defstruct [
-    :field10347,
-    :field10348,
-    :field10349,
-    :field10350,
-    :field10351,
-    :field10352,
-    :field10353
-  ]
+  defstruct field10347: nil,
+            field10348: [],
+            field10349: nil,
+            field10350: nil,
+            field10351: nil,
+            field10352: nil,
+            field10353: nil
 
   field :field10347, 1, optional: true, type: Benchmarks.GoogleMessage3.Enum10335, enum: true
+
   field :field10348, 2, repeated: true, type: Benchmarks.GoogleMessage3.Message10319
+
   field :field10349, 3, optional: true, type: :int32
+
   field :field10350, 4, optional: true, type: :int32
+
   field :field10351, 5, optional: true, type: :int32
+
   field :field10352, 6, optional: true, type: :int32
+
   field :field10353, 7, optional: true, type: Benchmarks.GoogleMessage3.Enum10337, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10321 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1123,14 +1382,18 @@ defmodule Benchmarks.GoogleMessage3.Message10321 do
           field10356: non_neg_integer
         }
 
-  defstruct [:field10354, :field10355, :field10356]
+  defstruct field10354: nil,
+            field10355: nil,
+            field10356: nil
 
   field :field10354, 1, optional: true, type: :int32
+
   field :field10355, 2, optional: true, type: :int32
+
   field :field10356, 3, optional: true, type: :uint64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10322 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1141,14 +1404,18 @@ defmodule Benchmarks.GoogleMessage3.Message10322 do
           field10359: boolean
         }
 
-  defstruct [:field10357, :field10358, :field10359]
+  defstruct field10357: nil,
+            field10358: nil,
+            field10359: nil
 
   field :field10357, 1, optional: true, type: Benchmarks.GoogleMessage3.Message4016
+
   field :field10358, 2, optional: true, type: :bool
+
   field :field10359, 3, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message11988 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1160,15 +1427,21 @@ defmodule Benchmarks.GoogleMessage3.Message11988 do
           field12024: Benchmarks.GoogleMessage3.Message10155.t() | nil
         }
 
-  defstruct [:field12021, :field12022, :field12023, :field12024]
+  defstruct field12021: nil,
+            field12022: nil,
+            field12023: nil,
+            field12024: nil
 
   field :field12021, 1, optional: true, type: :string
+
   field :field12022, 2, optional: true, type: :string
+
   field :field12023, 3, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field12024, 4, optional: true, type: Benchmarks.GoogleMessage3.Message10155
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message12668 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1180,15 +1453,21 @@ defmodule Benchmarks.GoogleMessage3.Message12668 do
           field12680: integer
         }
 
-  defstruct [:field12677, :field12678, :field12679, :field12680]
+  defstruct field12677: [],
+            field12678: nil,
+            field12679: nil,
+            field12680: nil
 
   field :field12677, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message12669
+
   field :field12678, 2, optional: true, type: :int32
+
   field :field12679, 3, optional: true, type: :int32
+
   field :field12680, 4, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message12825 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1203,26 +1482,30 @@ defmodule Benchmarks.GoogleMessage3.Message12825 do
           field12868: [Benchmarks.GoogleMessage3.UnusedEmptyMessage.t()]
         }
 
-  defstruct [
-    :field12862,
-    :field12863,
-    :field12864,
-    :field12865,
-    :field12866,
-    :field12867,
-    :field12868
-  ]
+  defstruct field12862: [],
+            field12863: nil,
+            field12864: nil,
+            field12865: nil,
+            field12866: nil,
+            field12867: [],
+            field12868: []
 
   field :field12862, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message12818
+
   field :field12863, 2, optional: true, type: :int32
+
   field :field12864, 3, optional: true, type: Benchmarks.GoogleMessage3.Message12819
+
   field :field12865, 4, optional: true, type: Benchmarks.GoogleMessage3.Message12820
+
   field :field12866, 5, optional: true, type: :int32
+
   field :field12867, 6, repeated: true, type: Benchmarks.GoogleMessage3.Message12821
+
   field :field12868, 7, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16478 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1233,14 +1516,18 @@ defmodule Benchmarks.GoogleMessage3.Message16478 do
           field16483: integer
         }
 
-  defstruct [:field16481, :field16482, :field16483]
+  defstruct field16481: [],
+            field16482: nil,
+            field16483: nil
 
   field :field16481, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message16479
+
   field :field16482, 3, optional: true, type: :bool
+
   field :field16483, 2, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16552 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1251,14 +1538,18 @@ defmodule Benchmarks.GoogleMessage3.Message16552 do
           field16567: Benchmarks.GoogleMessage3.Enum16553.t()
         }
 
-  defstruct [:field16565, :field16566, :field16567]
+  defstruct field16565: nil,
+            field16566: nil,
+            field16567: nil
 
   field :field16565, 1, optional: true, type: :fixed64
+
   field :field16566, 2, optional: true, type: :int32
+
   field :field16567, 3, optional: true, type: Benchmarks.GoogleMessage3.Enum16553, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16660 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1269,14 +1560,18 @@ defmodule Benchmarks.GoogleMessage3.Message16660 do
           field16670: integer
         }
 
-  defstruct [:field16668, :field16669, :field16670]
+  defstruct field16668: nil,
+            field16669: nil,
+            field16670: nil
 
   field :field16668, 1, optional: true, type: :string
+
   field :field16669, 2, optional: true, type: :string
+
   field :field16670, 3, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16727 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1309,63 +1604,84 @@ defmodule Benchmarks.GoogleMessage3.Message16727 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field16782,
-    :field16783,
-    :field16784,
-    :field16785,
-    :field16786,
-    :field16787,
-    :field16788,
-    :field16789,
-    :field16790,
-    :field16791,
-    :field16792,
-    :field16793,
-    :field16794,
-    :field16795,
-    :field16796,
-    :field16797,
-    :field16798,
-    :field16799,
-    :field16800,
-    :field16801,
-    :field16802,
-    :field16803,
-    :field16804,
-    :field16805,
-    :__pb_extensions__
-  ]
+  defstruct field16782: 0,
+            field16783: "",
+            field16784: nil,
+            field16785: nil,
+            field16786: "",
+            field16787: nil,
+            field16788: nil,
+            field16789: 0,
+            field16790: nil,
+            field16791: nil,
+            field16792: nil,
+            field16793: nil,
+            field16794: nil,
+            field16795: [],
+            field16796: nil,
+            field16797: nil,
+            field16798: nil,
+            field16799: nil,
+            field16800: nil,
+            field16801: nil,
+            field16802: nil,
+            field16803: nil,
+            field16804: nil,
+            field16805: nil,
+            __pb_extensions__: nil
 
   field :field16782, 1, required: true, type: Benchmarks.GoogleMessage3.Enum16728, enum: true
+
   field :field16783, 2, required: true, type: :string
+
   field :field16784, 3, optional: true, type: :string
+
   field :field16785, 23, optional: true, type: :int32
+
   field :field16786, 4, required: true, type: :string
+
   field :field16787, 5, optional: true, type: :string
+
   field :field16788, 6, optional: true, type: :string
+
   field :field16789, 7, required: true, type: Benchmarks.GoogleMessage3.Enum16732, enum: true
+
   field :field16790, 8, optional: true, type: :string
+
   field :field16791, 9, optional: true, type: :string
+
   field :field16792, 10, optional: true, type: :string
+
   field :field16793, 11, optional: true, type: Benchmarks.GoogleMessage3.Enum16738, enum: true
+
   field :field16794, 12, optional: true, type: :int32
+
   field :field16795, 13, repeated: true, type: Benchmarks.GoogleMessage3.Message16722
+
   field :field16796, 19, optional: true, type: :bool
+
   field :field16797, 24, optional: true, type: :bool
+
   field :field16798, 14, optional: true, type: :string
+
   field :field16799, 15, optional: true, type: :int64
+
   field :field16800, 16, optional: true, type: :bool
+
   field :field16801, 17, optional: true, type: :string
+
   field :field16802, 18, optional: true, type: Benchmarks.GoogleMessage3.Enum16698, enum: true
+
   field :field16803, 20, optional: true, type: Benchmarks.GoogleMessage3.Message16724
+
   field :field16804, 22, optional: true, type: :bool
+
   field :field16805, 25, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16725 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1375,13 +1691,15 @@ defmodule Benchmarks.GoogleMessage3.Message16725 do
           field16775: [String.t()]
         }
 
-  defstruct [:field16774, :field16775]
+  defstruct field16774: nil,
+            field16775: []
 
   field :field16774, 1, optional: true, type: Benchmarks.GoogleMessage3.Enum16728, enum: true
+
   field :field16775, 2, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message17726 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1411,56 +1729,75 @@ defmodule Benchmarks.GoogleMessage3.Message17726 do
           field17822: [Benchmarks.GoogleMessage3.UnusedEmptyMessage.t()]
         }
 
-  defstruct [
-    :field17801,
-    :field17802,
-    :field17803,
-    :field17804,
-    :field17805,
-    :field17806,
-    :field17807,
-    :field17808,
-    :field17809,
-    :field17810,
-    :field17811,
-    :field17812,
-    :field17813,
-    :field17814,
-    :field17815,
-    :field17816,
-    :field17817,
-    :field17818,
-    :field17819,
-    :field17820,
-    :field17821,
-    :field17822
-  ]
+  defstruct field17801: nil,
+            field17802: [],
+            field17803: nil,
+            field17804: [],
+            field17805: nil,
+            field17806: [],
+            field17807: nil,
+            field17808: nil,
+            field17809: [],
+            field17810: [],
+            field17811: [],
+            field17812: [],
+            field17813: nil,
+            field17814: nil,
+            field17815: nil,
+            field17816: nil,
+            field17817: nil,
+            field17818: nil,
+            field17819: nil,
+            field17820: [],
+            field17821: [],
+            field17822: []
 
   field :field17801, 1, optional: true, type: :string
+
   field :field17802, 2, repeated: true, type: :string
+
   field :field17803, 3, optional: true, type: :string
+
   field :field17804, 4, repeated: true, type: :string
+
   field :field17805, 5, optional: true, type: :string
+
   field :field17806, 6, repeated: true, type: :string
+
   field :field17807, 7, optional: true, type: :string
+
   field :field17808, 8, optional: true, type: :string
+
   field :field17809, 15, repeated: true, type: :string
+
   field :field17810, 16, repeated: true, type: :string
+
   field :field17811, 17, repeated: true, type: :string
+
   field :field17812, 18, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field17813, 9, optional: true, type: :string
+
   field :field17814, 10, optional: true, type: :string
+
   field :field17815, 11, optional: true, type: :string
+
   field :field17816, 12, optional: true, type: :string
+
   field :field17817, 13, optional: true, type: :string
+
   field :field17818, 14, optional: true, type: :string
+
   field :field17819, 19, optional: true, type: :string
+
   field :field17820, 20, repeated: true, type: Benchmarks.GoogleMessage3.Message17728
+
   field :field17821, 21, repeated: true, type: Benchmarks.GoogleMessage3.Message17728
+
   field :field17822, 30, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message17782 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1470,13 +1807,15 @@ defmodule Benchmarks.GoogleMessage3.Message17782 do
           field18154: String.t()
         }
 
-  defstruct [:field18153, :field18154]
+  defstruct field18153: nil,
+            field18154: nil
 
   field :field18153, 1, optional: true, type: :string
+
   field :field18154, 2, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message17783.Message17784 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1490,17 +1829,27 @@ defmodule Benchmarks.GoogleMessage3.Message17783.Message17784 do
           field18167: String.t()
         }
 
-  defstruct [:field18162, :field18163, :field18164, :field18165, :field18166, :field18167]
+  defstruct field18162: nil,
+            field18163: nil,
+            field18164: nil,
+            field18165: [],
+            field18166: nil,
+            field18167: nil
 
   field :field18162, 5, optional: true, type: :string
+
   field :field18163, 6, optional: true, type: :string
+
   field :field18164, 7, optional: true, type: :string
+
   field :field18165, 8, repeated: true, type: :string
+
   field :field18166, 17, optional: true, type: :string
+
   field :field18167, 18, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message17783.Message17785 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1514,17 +1863,27 @@ defmodule Benchmarks.GoogleMessage3.Message17783.Message17785 do
           field18173: [String.t()]
         }
 
-  defstruct [:field18168, :field18169, :field18170, :field18171, :field18172, :field18173]
+  defstruct field18168: nil,
+            field18169: nil,
+            field18170: nil,
+            field18171: nil,
+            field18172: nil,
+            field18173: []
 
   field :field18168, 10, optional: true, type: :string
+
   field :field18169, 11, optional: true, type: :string
+
   field :field18170, 12, optional: true, type: Benchmarks.GoogleMessage3.Message17783
+
   field :field18171, 13, optional: true, type: :string
+
   field :field18172, 14, optional: true, type: :string
+
   field :field18173, 15, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message17783 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1538,17 +1897,27 @@ defmodule Benchmarks.GoogleMessage3.Message17783 do
           field18160: [String.t()]
         }
 
-  defstruct [:field18155, :field18156, :field18157, :message17784, :message17785, :field18160]
+  defstruct field18155: nil,
+            field18156: nil,
+            field18157: nil,
+            message17784: [],
+            message17785: [],
+            field18160: []
 
   field :field18155, 1, optional: true, type: :string
+
   field :field18156, 2, optional: true, type: :string
+
   field :field18157, 3, optional: true, type: :string
+
   field :message17784, 4, repeated: true, type: :group
+
   field :message17785, 9, repeated: true, type: :group
+
   field :field18160, 16, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16945 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1636,168 +2005,245 @@ defmodule Benchmarks.GoogleMessage3.Message16945 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field16946,
-    :field16947,
-    :field16948,
-    :field16949,
-    :field16950,
-    :field16951,
-    :field16952,
-    :field16953,
-    :field16954,
-    :field16955,
-    :field16956,
-    :field16957,
-    :field16958,
-    :field16959,
-    :field16960,
-    :field16961,
-    :field16962,
-    :field16963,
-    :field16964,
-    :field16965,
-    :field16966,
-    :field16967,
-    :field16968,
-    :field16969,
-    :field16970,
-    :field16971,
-    :field16972,
-    :field16973,
-    :field16974,
-    :field16975,
-    :field16976,
-    :field16977,
-    :field16978,
-    :field16979,
-    :field16980,
-    :field16981,
-    :field16982,
-    :field16983,
-    :field16984,
-    :field16985,
-    :field16986,
-    :field16987,
-    :field16988,
-    :field16989,
-    :field16990,
-    :field16991,
-    :field16992,
-    :field16993,
-    :field16994,
-    :field16995,
-    :field16996,
-    :field16997,
-    :field16998,
-    :field16999,
-    :field17000,
-    :field17001,
-    :field17002,
-    :field17003,
-    :field17004,
-    :field17005,
-    :field17006,
-    :field17007,
-    :field17008,
-    :field17009,
-    :field17010,
-    :field17011,
-    :field17012,
-    :field17013,
-    :field17014,
-    :field17015,
-    :field17016,
-    :field17017,
-    :field17018,
-    :field17019,
-    :field17020,
-    :field17021,
-    :field17022,
-    :field17023,
-    :field17024,
-    :__pb_extensions__
-  ]
+  defstruct field16946: nil,
+            field16947: nil,
+            field16948: nil,
+            field16949: nil,
+            field16950: nil,
+            field16951: nil,
+            field16952: [],
+            field16953: [],
+            field16954: [],
+            field16955: [],
+            field16956: [],
+            field16957: [],
+            field16958: [],
+            field16959: [],
+            field16960: [],
+            field16961: [],
+            field16962: [],
+            field16963: [],
+            field16964: [],
+            field16965: [],
+            field16966: [],
+            field16967: [],
+            field16968: [],
+            field16969: [],
+            field16970: [],
+            field16971: [],
+            field16972: [],
+            field16973: [],
+            field16974: [],
+            field16975: [],
+            field16976: [],
+            field16977: [],
+            field16978: [],
+            field16979: [],
+            field16980: [],
+            field16981: [],
+            field16982: [],
+            field16983: [],
+            field16984: [],
+            field16985: [],
+            field16986: [],
+            field16987: [],
+            field16988: [],
+            field16989: nil,
+            field16990: [],
+            field16991: [],
+            field16992: [],
+            field16993: [],
+            field16994: nil,
+            field16995: nil,
+            field16996: nil,
+            field16997: nil,
+            field16998: [],
+            field16999: [],
+            field17000: nil,
+            field17001: [],
+            field17002: [],
+            field17003: [],
+            field17004: [],
+            field17005: [],
+            field17006: [],
+            field17007: [],
+            field17008: [],
+            field17009: nil,
+            field17010: [],
+            field17011: [],
+            field17012: [],
+            field17013: [],
+            field17014: [],
+            field17015: [],
+            field17016: [],
+            field17017: [],
+            field17018: [],
+            field17019: [],
+            field17020: [],
+            field17021: [],
+            field17022: [],
+            field17023: [],
+            field17024: [],
+            __pb_extensions__: nil
 
   field :field16946, 1, optional: true, type: :string
+
   field :field16947, 2, optional: true, type: :string
+
   field :field16948, 3, optional: true, type: :string
+
   field :field16949, 4, optional: true, type: :string
+
   field :field16950, 5, optional: true, type: :string
+
   field :field16951, 872, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16952, 16, repeated: true, type: Benchmarks.GoogleMessage3.Message0
+
   field :field16953, 54, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16954, 55, repeated: true, type: Benchmarks.GoogleMessage3.Message0
+
   field :field16955, 58, repeated: true, type: :string
+
   field :field16956, 59, repeated: true, type: :string
+
   field :field16957, 62, repeated: true, type: :string
+
   field :field16958, 37, repeated: true, type: :string
+
   field :field16959, 18, repeated: true, type: :string
+
   field :field16960, 38, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16961, 67, repeated: true, type: Benchmarks.GoogleMessage3.Message0
+
   field :field16962, 130, repeated: true, type: Benchmarks.GoogleMessage3.Message0
+
   field :field16963, 136, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16964, 138, repeated: true, type: :string
+
   field :field16965, 156, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16966, 139, repeated: true, type: :string
+
   field :field16967, 126, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16968, 152, repeated: true, type: :string
+
   field :field16969, 183, repeated: true, type: Benchmarks.GoogleMessage3.Message0
+
   field :field16970, 168, repeated: true, type: :string
+
   field :field16971, 212, repeated: true, type: :string
+
   field :field16972, 213, repeated: true, type: :string
+
   field :field16973, 189, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16974, 190, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16975, 191, repeated: true, type: :string
+
   field :field16976, 192, repeated: true, type: :string
+
   field :field16977, 193, repeated: true, type: Benchmarks.GoogleMessage3.Message0
+
   field :field16978, 194, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16979, 195, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16980, 196, repeated: true, type: :int32
+
   field :field16981, 95, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16982, 96, repeated: true, type: :string
+
   field :field16983, 97, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16984, 1086, repeated: true, type: :string
+
   field :field16985, 98, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16986, 99, repeated: true, type: :string
+
   field :field16987, 100, repeated: true, type: :string
+
   field :field16988, 48, repeated: true, type: :string
+
   field :field16989, 22, optional: true, type: :string
+
   field :field16990, 51, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16991, 81, repeated: true, type: :string
+
   field :field16992, 85, repeated: true, type: :string
+
   field :field16993, 169, repeated: true, type: :string
+
   field :field16994, 260, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16995, 198, optional: true, type: :int32
+
   field :field16996, 204, optional: true, type: :int32
+
   field :field16997, 1087, optional: true, type: :string
+
   field :field16998, 197, repeated: true, type: :string
+
   field :field16999, 206, repeated: true, type: :string
+
   field :field17000, 211, optional: true, type: :string
+
   field :field17001, 205, repeated: true, type: :string
+
   field :field17002, 68, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field17003, 69, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field17004, 70, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field17005, 71, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field17006, 72, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field17007, 19, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field17008, 24, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field17009, 23, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field17010, 131, repeated: true, type: Benchmarks.GoogleMessage3.Message0
+
   field :field17011, 133, repeated: true, type: :string
+
   field :field17012, 142, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field17013, 143, repeated: true, type: :string
+
   field :field17014, 153, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field17015, 170, repeated: true, type: Benchmarks.GoogleMessage3.Message0
+
   field :field17016, 171, repeated: true, type: :string
+
   field :field17017, 172, repeated: true, type: :string
+
   field :field17018, 173, repeated: true, type: :string
+
   field :field17019, 174, repeated: true, type: :string
+
   field :field17020, 175, repeated: true, type: :string
+
   field :field17021, 186, repeated: true, type: :string
+
   field :field17022, 101, repeated: true, type: :string
+
   field :field17023, 102, repeated: true, type: Benchmarks.GoogleMessage3.Message0
+
   field :field17024, 274, repeated: true, type: :string
+
   def transform_module(), do: nil
 
   extensions [
@@ -2500,18 +2946,21 @@ defmodule Benchmarks.GoogleMessage3.Message16945 do
     {1085, 1086}
   ]
 end
-
 defmodule Benchmarks.GoogleMessage3.PbExtension do
   @moduledoc false
   use Protobuf, syntax: :proto2
 
-  extend Benchmarks.GoogleMessage3.Message0, :"Message34390.field34453", 92_144_610,
+  extend Benchmarks.GoogleMessage3.Message0, :"Message35807.field35818", 3_803_299,
     optional: true,
-    type: Benchmarks.GoogleMessage3.Message34390
+    type: Benchmarks.GoogleMessage3.Message35807
 
   extend Benchmarks.GoogleMessage3.Message0, :"Message34624.field34685", 18_178_548,
     optional: true,
     type: Benchmarks.GoogleMessage3.Message34624
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message34390.field34453", 92_144_610,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message34390
 
   extend Benchmarks.GoogleMessage3.Message0, :"Message34791.field34807", 6_330_340,
     optional: true,
@@ -2520,10 +2969,6 @@ defmodule Benchmarks.GoogleMessage3.PbExtension do
   extend Benchmarks.GoogleMessage3.Message0, :"Message35483.field35505", 7_913_554,
     optional: true,
     type: Benchmarks.GoogleMessage3.Message35483
-
-  extend Benchmarks.GoogleMessage3.Message0, :"Message35807.field35818", 3_803_299,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message35807
 
   extend Benchmarks.GoogleMessage3.Message0, :"Message16945.field17025", 22_068_132,
     optional: true,

--- a/bench/lib/datasets/google_message3/benchmark_message3_2.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_2.pb.ex
@@ -10,16 +10,24 @@ defmodule Benchmarks.GoogleMessage3.Message22853 do
           field22873: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [:field22869, :field22870, :field22871, :field22872, :field22873]
+  defstruct field22869: nil,
+            field22870: [],
+            field22871: [],
+            field22872: [],
+            field22873: nil
 
   field :field22869, 1, optional: true, type: Benchmarks.GoogleMessage3.Enum22854, enum: true
+
   field :field22870, 2, repeated: true, type: :uint32, packed: true
+
   field :field22871, 3, repeated: true, type: :float, packed: true
+
   field :field22872, 5, repeated: true, type: :float, packed: true
+
   field :field22873, 4, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24345 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -52,62 +60,84 @@ defmodule Benchmarks.GoogleMessage3.Message24345 do
           field24557: [Benchmarks.GoogleMessage3.Message24366.t()]
         }
 
-  defstruct [
-    :field24533,
-    :field24534,
-    :field24535,
-    :field24536,
-    :field24537,
-    :field24538,
-    :field24539,
-    :field24540,
-    :field24541,
-    :field24542,
-    :field24543,
-    :field24544,
-    :field24545,
-    :field24546,
-    :field24547,
-    :field24548,
-    :field24549,
-    :field24550,
-    :field24551,
-    :field24552,
-    :field24553,
-    :field24554,
-    :field24555,
-    :field24556,
-    :field24557
-  ]
+  defstruct field24533: nil,
+            field24534: nil,
+            field24535: nil,
+            field24536: nil,
+            field24537: nil,
+            field24538: nil,
+            field24539: nil,
+            field24540: "",
+            field24541: nil,
+            field24542: nil,
+            field24543: nil,
+            field24544: nil,
+            field24545: nil,
+            field24546: nil,
+            field24547: nil,
+            field24548: nil,
+            field24549: nil,
+            field24550: nil,
+            field24551: [],
+            field24552: nil,
+            field24553: nil,
+            field24554: nil,
+            field24555: nil,
+            field24556: [],
+            field24557: []
 
   field :field24533, 1, optional: true, type: :string
+
   field :field24534, 22, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field24535, 2, optional: true, type: Benchmarks.GoogleMessage3.Message24346
+
   field :field24536, 3, optional: true, type: :string
+
   field :field24537, 4, optional: true, type: :string
+
   field :field24538, 23, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field24539, 5, optional: true, type: :string
+
   field :field24540, 6, required: true, type: :string
+
   field :field24541, 7, optional: true, type: :string
+
   field :field24542, 8, optional: true, type: :string
+
   field :field24543, 9, optional: true, type: Benchmarks.GoogleMessage3.Message24316
+
   field :field24544, 10, optional: true, type: Benchmarks.GoogleMessage3.Message24376
+
   field :field24545, 11, optional: true, type: :string
+
   field :field24546, 19, optional: true, type: :string
+
   field :field24547, 20, optional: true, type: :string
+
   field :field24548, 21, optional: true, type: :string
+
   field :field24549, 12, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24550, 13, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24551, 14, repeated: true, type: :string
+
   field :field24552, 15, optional: true, type: :string
+
   field :field24553, 18, optional: true, type: :int32
+
   field :field24554, 16, optional: true, type: Benchmarks.GoogleMessage3.Message24379
+
   field :field24555, 17, optional: true, type: :string
+
   field :field24556, 24, repeated: true, type: Benchmarks.GoogleMessage3.Message24356
+
   field :field24557, 25, repeated: true, type: Benchmarks.GoogleMessage3.Message24366
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24403 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -117,13 +147,15 @@ defmodule Benchmarks.GoogleMessage3.Message24403 do
           field24682: Benchmarks.GoogleMessage3.Message24402.t() | nil
         }
 
-  defstruct [:field24681, :field24682]
+  defstruct field24681: nil,
+            field24682: nil
 
   field :field24681, 1, optional: true, type: Benchmarks.GoogleMessage3.Message24401
+
   field :field24682, 2, optional: true, type: Benchmarks.GoogleMessage3.Message24402
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24391 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -156,71 +188,94 @@ defmodule Benchmarks.GoogleMessage3.Message24391 do
           field24655: [String.t()]
         }
 
-  defstruct [
-    :field24631,
-    :field24632,
-    :field24633,
-    :field24634,
-    :field24635,
-    :field24636,
-    :field24637,
-    :field24638,
-    :field24639,
-    :field24640,
-    :field24641,
-    :field24642,
-    :field24643,
-    :field24644,
-    :field24645,
-    :field24646,
-    :field24647,
-    :field24648,
-    :field24649,
-    :field24650,
-    :field24651,
-    :field24652,
-    :field24653,
-    :field24654,
-    :field24655
-  ]
+  defstruct field24631: nil,
+            field24632: nil,
+            field24633: [],
+            field24634: nil,
+            field24635: [],
+            field24636: [],
+            field24637: nil,
+            field24638: nil,
+            field24639: nil,
+            field24640: nil,
+            field24641: nil,
+            field24642: nil,
+            field24643: nil,
+            field24644: nil,
+            field24645: [],
+            field24646: nil,
+            field24647: nil,
+            field24648: nil,
+            field24649: [],
+            field24650: nil,
+            field24651: nil,
+            field24652: nil,
+            field24653: nil,
+            field24654: [],
+            field24655: []
 
   field :field24631, 1, optional: true, type: :string
+
   field :field24632, 2, optional: true, type: :string
+
   field :field24633, 3, repeated: true, type: :string
+
   field :field24634, 4, optional: true, type: :string
+
   field :field24635, 5, repeated: true, type: :string
+
   field :field24636, 16, repeated: true, type: :string
+
   field :field24637, 17, optional: true, type: :string
+
   field :field24638, 25, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24639, 7, optional: true, type: :string
+
   field :field24640, 18, optional: true, type: :string
+
   field :field24641, 19, optional: true, type: :string
+
   field :field24642, 20, optional: true, type: :string
+
   field :field24643, 24, optional: true, type: :int32
+
   field :field24644, 8, optional: true, type: Benchmarks.GoogleMessage3.Message24379
+
   field :field24645, 9, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24646, 10, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24647, 11, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24648, 12, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24649, 13, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24650, 14, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24651, 21, optional: true, type: :string
+
   field :field24652, 22, optional: true, type: :int32
+
   field :field24653, 23, optional: true, type: :int32
+
   field :field24654, 15, repeated: true, type: :string
+
   field :field24655, 6, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message27454 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message27357 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -233,16 +288,24 @@ defmodule Benchmarks.GoogleMessage3.Message27357 do
           field27414: boolean
         }
 
-  defstruct [:field27410, :field27411, :field27412, :field27413, :field27414]
+  defstruct field27410: nil,
+            field27411: nil,
+            field27412: nil,
+            field27413: nil,
+            field27414: nil
 
   field :field27410, 1, optional: true, type: :string
+
   field :field27411, 2, optional: true, type: :float
+
   field :field27412, 3, optional: true, type: :string
+
   field :field27413, 4, optional: true, type: :bool
+
   field :field27414, 5, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message27360 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -254,15 +317,21 @@ defmodule Benchmarks.GoogleMessage3.Message27360 do
           field27429: [Benchmarks.GoogleMessage3.UnusedEmptyMessage.t()]
         }
 
-  defstruct [:field27426, :field27427, :field27428, :field27429]
+  defstruct field27426: nil,
+            field27427: nil,
+            field27428: nil,
+            field27429: []
 
   field :field27426, 1, optional: true, type: Benchmarks.GoogleMessage3.Message27358
+
   field :field27427, 2, optional: true, type: Benchmarks.GoogleMessage3.Enum27361, enum: true
+
   field :field27428, 3, optional: true, type: Benchmarks.GoogleMessage3.Message27358
+
   field :field27429, 4, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message34387 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -275,16 +344,24 @@ defmodule Benchmarks.GoogleMessage3.Message34387 do
           field34450: integer
         }
 
-  defstruct [:field34446, :field34447, :field34448, :field34449, :field34450]
+  defstruct field34446: nil,
+            field34447: [],
+            field34448: nil,
+            field34449: nil,
+            field34450: nil
 
   field :field34446, 1, optional: true, type: :string
+
   field :field34447, 2, repeated: true, type: Benchmarks.GoogleMessage3.Message34381
+
   field :field34448, 3, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field34449, 4, optional: true, type: Benchmarks.GoogleMessage3.Enum34388, enum: true
+
   field :field34450, 5, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message34621 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -310,48 +387,63 @@ defmodule Benchmarks.GoogleMessage3.Message34621 do
           field34668: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field34651,
-    :field34652,
-    :field34653,
-    :field34654,
-    :field34655,
-    :field34656,
-    :field34657,
-    :field34658,
-    :field34659,
-    :field34660,
-    :field34661,
-    :field34662,
-    :field34663,
-    :field34664,
-    :field34665,
-    :field34666,
-    :field34667,
-    :field34668
-  ]
+  defstruct field34651: nil,
+            field34652: nil,
+            field34653: nil,
+            field34654: nil,
+            field34655: nil,
+            field34656: nil,
+            field34657: nil,
+            field34658: nil,
+            field34659: nil,
+            field34660: nil,
+            field34661: nil,
+            field34662: nil,
+            field34663: nil,
+            field34664: nil,
+            field34665: nil,
+            field34666: nil,
+            field34667: [],
+            field34668: nil
 
   field :field34651, 1, optional: true, type: :double
+
   field :field34652, 2, optional: true, type: :double
+
   field :field34653, 3, optional: true, type: :double
+
   field :field34654, 4, optional: true, type: :double
+
   field :field34655, 11, optional: true, type: :double
+
   field :field34656, 13, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field34657, 14, optional: true, type: Benchmarks.GoogleMessage3.Message34619
+
   field :field34658, 5, optional: true, type: :string
+
   field :field34659, 9, optional: true, type: :string
+
   field :field34660, 12, optional: true, type: :double
+
   field :field34661, 19, optional: true, type: :bytes
+
   field :field34662, 15, optional: true, type: :string
+
   field :field34663, 16, optional: true, type: :string
+
   field :field34664, 17, optional: true, type: :string
+
   field :field34665, 18, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field34666, 20, optional: true, type: Benchmarks.GoogleMessage3.Message34621
+
   field :field34667, 100, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field34668, 101, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message35476 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -373,40 +465,51 @@ defmodule Benchmarks.GoogleMessage3.Message35476 do
           field35497: String.t()
         }
 
-  defstruct [
-    :field35484,
-    :field35485,
-    :field35486,
-    :field35487,
-    :field35488,
-    :field35489,
-    :field35490,
-    :field35491,
-    :field35492,
-    :field35493,
-    :field35494,
-    :field35495,
-    :field35496,
-    :field35497
-  ]
+  defstruct field35484: nil,
+            field35485: nil,
+            field35486: nil,
+            field35487: nil,
+            field35488: nil,
+            field35489: nil,
+            field35490: nil,
+            field35491: nil,
+            field35492: nil,
+            field35493: nil,
+            field35494: nil,
+            field35495: nil,
+            field35496: nil,
+            field35497: nil
 
   field :field35484, 1, optional: true, type: :string
+
   field :field35485, 2, optional: true, type: :string
+
   field :field35486, 3, optional: true, type: :string
+
   field :field35487, 4, optional: true, type: Benchmarks.GoogleMessage3.Enum35477, enum: true
+
   field :field35488, 5, optional: true, type: :float
+
   field :field35489, 6, optional: true, type: :float
+
   field :field35490, 7, optional: true, type: :float
+
   field :field35491, 8, optional: true, type: :float
+
   field :field35492, 9, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field35493, 10, optional: true, type: :int32
+
   field :field35494, 11, optional: true, type: :int32
+
   field :field35495, 12, optional: true, type: :int32
+
   field :field35496, 13, optional: true, type: :string
+
   field :field35497, 14, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message949 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -421,18 +524,30 @@ defmodule Benchmarks.GoogleMessage3.Message949 do
           field961: boolean
         }
 
-  defstruct [:field955, :field956, :field957, :field958, :field959, :field960, :field961]
+  defstruct field955: nil,
+            field956: nil,
+            field957: nil,
+            field958: nil,
+            field959: [],
+            field960: nil,
+            field961: nil
 
   field :field955, 1, optional: true, type: :string
+
   field :field956, 2, optional: true, type: :int64
+
   field :field957, 3, optional: true, type: :int64
+
   field :field958, 4, optional: true, type: Benchmarks.GoogleMessage3.Message730
+
   field :field959, 5, repeated: true, type: :string
+
   field :field960, 6, optional: true, type: :string
+
   field :field961, 7, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36869 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -442,22 +557,25 @@ defmodule Benchmarks.GoogleMessage3.Message36869 do
           field36971: integer
         }
 
-  defstruct [:field36970, :field36971]
+  defstruct field36970: nil,
+            field36971: nil
 
   field :field36970, 1, optional: true, type: :int32
+
   field :field36971, 2, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message33968.Message33969 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message33968 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -470,16 +588,24 @@ defmodule Benchmarks.GoogleMessage3.Message33968 do
           field33992: Benchmarks.GoogleMessage3.UnusedEnum.t()
         }
 
-  defstruct [:message33969, :field33989, :field33990, :field33991, :field33992]
+  defstruct message33969: [],
+            field33989: [],
+            field33990: nil,
+            field33991: nil,
+            field33992: nil
 
   field :message33969, 1, repeated: true, type: :group
+
   field :field33989, 3, repeated: true, type: Benchmarks.GoogleMessage3.Message33958
+
   field :field33990, 106, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field33991, 108, optional: true, type: :bool
+
   field :field33992, 107, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6644 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -503,44 +629,57 @@ defmodule Benchmarks.GoogleMessage3.Message6644 do
           field6716: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field6701,
-    :field6702,
-    :field6703,
-    :field6704,
-    :field6705,
-    :field6706,
-    :field6707,
-    :field6708,
-    :field6709,
-    :field6710,
-    :field6711,
-    :field6712,
-    :field6713,
-    :field6714,
-    :field6715,
-    :field6716
-  ]
+  defstruct field6701: nil,
+            field6702: nil,
+            field6703: nil,
+            field6704: nil,
+            field6705: nil,
+            field6706: nil,
+            field6707: nil,
+            field6708: [],
+            field6709: nil,
+            field6710: nil,
+            field6711: nil,
+            field6712: nil,
+            field6713: nil,
+            field6714: nil,
+            field6715: nil,
+            field6716: nil
 
   field :field6701, 8, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6702, 1, optional: true, type: :string
+
   field :field6703, 2, optional: true, type: :double
+
   field :field6704, 9, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6705, 3, optional: true, type: :bytes
+
   field :field6706, 19, optional: true, type: :bytes
+
   field :field6707, 4, optional: true, type: Benchmarks.GoogleMessage3.Message6637
+
   field :field6708, 18, repeated: true, type: Benchmarks.GoogleMessage3.Message6126
+
   field :field6709, 6, optional: true, type: :bool
+
   field :field6710, 10, optional: true, type: Benchmarks.GoogleMessage3.Message6643
+
   field :field6711, 12, optional: true, type: :string
+
   field :field6712, 14, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6713, 15, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6714, 16, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6715, 17, optional: true, type: :int32
+
   field :field6716, 20, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message18831.Message18832.Message18833 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -553,16 +692,24 @@ defmodule Benchmarks.GoogleMessage3.Message18831.Message18832.Message18833 do
           field18847: boolean
         }
 
-  defstruct [:field18843, :field18844, :field18845, :field18846, :field18847]
+  defstruct field18843: 0,
+            field18844: nil,
+            field18845: nil,
+            field18846: nil,
+            field18847: nil
 
   field :field18843, 7, required: true, type: :uint64
+
   field :field18844, 8, optional: true, type: :string
+
   field :field18845, 10, optional: true, type: :float
+
   field :field18846, 12, optional: true, type: :int32
+
   field :field18847, 13, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message18831.Message18832 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -577,26 +724,30 @@ defmodule Benchmarks.GoogleMessage3.Message18831.Message18832 do
           message18833: [any]
         }
 
-  defstruct [
-    :field18836,
-    :field18837,
-    :field18838,
-    :field18839,
-    :field18840,
-    :field18841,
-    :message18833
-  ]
+  defstruct field18836: nil,
+            field18837: nil,
+            field18838: nil,
+            field18839: nil,
+            field18840: nil,
+            field18841: [],
+            message18833: []
 
   field :field18836, 2, optional: true, type: :int32
+
   field :field18837, 5, optional: true, type: :string
+
   field :field18838, 3, optional: true, type: :float
+
   field :field18839, 9, optional: true, type: :float
+
   field :field18840, 11, optional: true, type: :int32
+
   field :field18841, 4, repeated: true, type: :uint64
+
   field :message18833, 6, repeated: true, type: :group
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message18831 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -605,12 +756,12 @@ defmodule Benchmarks.GoogleMessage3.Message18831 do
           message18832: [any]
         }
 
-  defstruct [:message18832]
+  defstruct message18832: []
 
   field :message18832, 1, repeated: true, type: :group
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13090 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -620,13 +771,15 @@ defmodule Benchmarks.GoogleMessage3.Message13090 do
           field13142: Benchmarks.GoogleMessage3.Message13088.t() | nil
         }
 
-  defstruct [:field13141, :field13142]
+  defstruct field13141: nil,
+            field13142: nil
 
   field :field13141, 1, optional: true, type: Benchmarks.GoogleMessage3.Message13083
+
   field :field13142, 2, optional: true, type: Benchmarks.GoogleMessage3.Message13088
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message11874 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -639,17 +792,24 @@ defmodule Benchmarks.GoogleMessage3.Message11874 do
           __pb_extensions__: map
         }
 
-  defstruct [:field11888, :field11889, :field11890, :field11891, :__pb_extensions__]
+  defstruct field11888: nil,
+            field11889: nil,
+            field11890: nil,
+            field11891: nil,
+            __pb_extensions__: nil
 
   field :field11888, 3, optional: true, type: Benchmarks.GoogleMessage3.Message10391
+
   field :field11889, 4, optional: true, type: :string
+
   field :field11890, 6, optional: true, type: Benchmarks.GoogleMessage3.Message11873
+
   field :field11891, 7, optional: true, type: :bool
+
   def transform_module(), do: nil
 
   extensions [{1, 2}, {2, 3}, {5, 6}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message4144.Message4145 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -663,17 +823,27 @@ defmodule Benchmarks.GoogleMessage3.Message4144.Message4145 do
           field4170: String.t()
         }
 
-  defstruct [:field4165, :field4166, :field4167, :field4168, :field4169, :field4170]
+  defstruct field4165: 0,
+            field4166: 0,
+            field4167: nil,
+            field4168: nil,
+            field4169: nil,
+            field4170: nil
 
   field :field4165, 2, required: true, type: Benchmarks.GoogleMessage3.Enum4146, enum: true
+
   field :field4166, 3, required: true, type: :int32
+
   field :field4167, 9, optional: true, type: Benchmarks.GoogleMessage3.Enum4160, enum: true
+
   field :field4168, 4, optional: true, type: :bytes
+
   field :field4169, 5, optional: true, type: Benchmarks.GoogleMessage3.Enum4152, enum: true
+
   field :field4170, 6, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message4144 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -682,21 +852,22 @@ defmodule Benchmarks.GoogleMessage3.Message4144 do
           message4145: [any]
         }
 
-  defstruct [:message4145]
+  defstruct message4145: []
 
   field :message4145, 1, repeated: true, type: :group
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message35573.Message35574 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message35573.Message35575.Message35576 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -729,62 +900,84 @@ defmodule Benchmarks.GoogleMessage3.Message35573.Message35575.Message35576 do
           field35771: Benchmarks.GoogleMessage3.Message0.t() | nil
         }
 
-  defstruct [
-    :field35747,
-    :field35748,
-    :field35749,
-    :field35750,
-    :field35751,
-    :field35752,
-    :field35753,
-    :field35754,
-    :field35755,
-    :field35756,
-    :field35757,
-    :field35758,
-    :field35759,
-    :field35760,
-    :field35761,
-    :field35762,
-    :field35763,
-    :field35764,
-    :field35765,
-    :field35766,
-    :field35767,
-    :field35768,
-    :field35769,
-    :field35770,
-    :field35771
-  ]
+  defstruct field35747: nil,
+            field35748: nil,
+            field35749: nil,
+            field35750: nil,
+            field35751: nil,
+            field35752: nil,
+            field35753: nil,
+            field35754: nil,
+            field35755: nil,
+            field35756: nil,
+            field35757: nil,
+            field35758: nil,
+            field35759: nil,
+            field35760: nil,
+            field35761: nil,
+            field35762: nil,
+            field35763: nil,
+            field35764: nil,
+            field35765: nil,
+            field35766: nil,
+            field35767: nil,
+            field35768: [],
+            field35769: [],
+            field35770: nil,
+            field35771: nil
 
   field :field35747, 5, optional: true, type: :fixed64
+
   field :field35748, 6, optional: true, type: :int32
+
   field :field35749, 49, optional: true, type: :int32
+
   field :field35750, 7, optional: true, type: :int32
+
   field :field35751, 59, optional: true, type: :uint32
+
   field :field35752, 14, optional: true, type: :int32
+
   field :field35753, 15, optional: true, type: :int32
+
   field :field35754, 35, optional: true, type: :int32
+
   field :field35755, 53, optional: true, type: :bytes
+
   field :field35756, 8, optional: true, type: :int32
+
   field :field35757, 9, optional: true, type: :string
+
   field :field35758, 10, optional: true, type: :fixed64
+
   field :field35759, 11, optional: true, type: :int32
+
   field :field35760, 12, optional: true, type: :int32
+
   field :field35761, 41, optional: true, type: :int32
+
   field :field35762, 30, optional: true, type: :int32
+
   field :field35763, 31, optional: true, type: :int32
+
   field :field35764, 13, optional: true, type: :int32
+
   field :field35765, 39, optional: true, type: :bytes
+
   field :field35766, 29, optional: true, type: :string
+
   field :field35767, 42, optional: true, type: :int32
+
   field :field35768, 32, repeated: true, type: :int32
+
   field :field35769, 51, repeated: true, type: :int32
+
   field :field35770, 54, optional: true, type: :int64
+
   field :field35771, 55, optional: true, type: Benchmarks.GoogleMessage3.Message0
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message35573.Message35575 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -830,88 +1023,123 @@ defmodule Benchmarks.GoogleMessage3.Message35573.Message35575 do
           message35576: any
         }
 
-  defstruct [
-    :field35709,
-    :field35710,
-    :field35711,
-    :field35712,
-    :field35713,
-    :field35714,
-    :field35715,
-    :field35716,
-    :field35717,
-    :field35718,
-    :field35719,
-    :field35720,
-    :field35721,
-    :field35722,
-    :field35723,
-    :field35724,
-    :field35725,
-    :field35726,
-    :field35727,
-    :field35728,
-    :field35729,
-    :field35730,
-    :field35731,
-    :field35732,
-    :field35733,
-    :field35734,
-    :field35735,
-    :field35736,
-    :field35737,
-    :field35738,
-    :field35739,
-    :field35740,
-    :field35741,
-    :field35742,
-    :field35743,
-    :field35744,
-    :field35745,
-    :message35576
-  ]
+  defstruct field35709: nil,
+            field35710: nil,
+            field35711: nil,
+            field35712: nil,
+            field35713: nil,
+            field35714: nil,
+            field35715: nil,
+            field35716: nil,
+            field35717: nil,
+            field35718: nil,
+            field35719: nil,
+            field35720: nil,
+            field35721: nil,
+            field35722: nil,
+            field35723: nil,
+            field35724: nil,
+            field35725: nil,
+            field35726: nil,
+            field35727: [],
+            field35728: [],
+            field35729: nil,
+            field35730: nil,
+            field35731: nil,
+            field35732: [],
+            field35733: [],
+            field35734: nil,
+            field35735: nil,
+            field35736: nil,
+            field35737: nil,
+            field35738: nil,
+            field35739: nil,
+            field35740: nil,
+            field35741: nil,
+            field35742: nil,
+            field35743: nil,
+            field35744: [],
+            field35745: nil,
+            message35576: nil
 
   field :field35709, 2, optional: true, type: :int64
+
   field :field35710, 3, optional: true, type: :string
+
   field :field35711, 19, optional: true, type: :string
+
   field :field35712, 20, optional: true, type: :int32
+
   field :field35713, 21, optional: true, type: :int32
+
   field :field35714, 22, optional: true, type: :int32
+
   field :field35715, 23, optional: true, type: :bool
+
   field :field35716, 47, optional: true, type: :int32
+
   field :field35717, 48, optional: true, type: :int32
+
   field :field35718, 24, optional: true, type: :bool
+
   field :field35719, 25, optional: true, type: :fixed64
+
   field :field35720, 52, optional: true, type: :bytes
+
   field :field35721, 18, optional: true, type: :int32
+
   field :field35722, 43, optional: true, type: :fixed32
+
   field :field35723, 26, optional: true, type: :bool
+
   field :field35724, 27, optional: true, type: :int32
+
   field :field35725, 17, optional: true, type: :int32
+
   field :field35726, 45, optional: true, type: :bool
+
   field :field35727, 33, repeated: true, type: :int32
+
   field :field35728, 58, repeated: true, type: :int32
+
   field :field35729, 34, optional: true, type: :float
+
   field :field35730, 1009, optional: true, type: :float
+
   field :field35731, 28, optional: true, type: :int32
+
   field :field35732, 1001, repeated: true, type: :fixed64
+
   field :field35733, 1002, repeated: true, type: :fixed64
+
   field :field35734, 44, optional: true, type: :int32
+
   field :field35735, 50, optional: true, type: :int32
+
   field :field35736, 36, optional: true, type: :int32
+
   field :field35737, 40, optional: true, type: :int32
+
   field :field35738, 1016, optional: true, type: :bool
+
   field :field35739, 1010, optional: true, type: :bool
+
   field :field35740, 37, optional: true, type: :int32
+
   field :field35741, 38, optional: true, type: :int32
+
   field :field35742, 46, optional: true, type: :string
+
   field :field35743, 60, optional: true, type: :uint32
+
   field :field35744, 56, repeated: true, type: :bytes
+
   field :field35745, 57, optional: true, type: Benchmarks.GoogleMessage3.Message0
+
   field :message35576, 4, required: true, type: :group
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message35573 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -930,34 +1158,42 @@ defmodule Benchmarks.GoogleMessage3.Message35573 do
           message35575: [any]
         }
 
-  defstruct [
-    :field35695,
-    :field35696,
-    :field35697,
-    :field35698,
-    :message35574,
-    :field35700,
-    :field35701,
-    :field35702,
-    :field35703,
-    :field35704,
-    :message35575
-  ]
+  defstruct field35695: nil,
+            field35696: nil,
+            field35697: nil,
+            field35698: nil,
+            message35574: [],
+            field35700: nil,
+            field35701: nil,
+            field35702: nil,
+            field35703: nil,
+            field35704: nil,
+            message35575: []
 
   field :field35695, 16, optional: true, type: :fixed64
+
   field :field35696, 1000, optional: true, type: :string
+
   field :field35697, 1004, optional: true, type: :string
+
   field :field35698, 1003, optional: true, type: :int32
+
   field :message35574, 1012, repeated: true, type: :group
+
   field :field35700, 1011, optional: true, type: :int64
+
   field :field35701, 1005, optional: true, type: :int64
+
   field :field35702, 1006, optional: true, type: :int64
+
   field :field35703, 1007, optional: true, type: :int64
+
   field :field35704, 1008, optional: true, type: :int64
+
   field :message35575, 1, repeated: true, type: :group
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36858.Message36859 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -967,13 +1203,15 @@ defmodule Benchmarks.GoogleMessage3.Message36858.Message36859 do
           field36969: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [:field36968, :field36969]
+  defstruct field36968: 0,
+            field36969: nil
 
   field :field36968, 9, required: true, type: Benchmarks.GoogleMessage3.Enum36860, enum: true
+
   field :field36969, 10, optional: true, type: :float
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message36858 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -993,36 +1231,45 @@ defmodule Benchmarks.GoogleMessage3.Message36858 do
           message36859: [any]
         }
 
-  defstruct [
-    :field36956,
-    :field36957,
-    :field36958,
-    :field36959,
-    :field36960,
-    :field36961,
-    :field36962,
-    :field36963,
-    :field36964,
-    :field36965,
-    :field36966,
-    :message36859
-  ]
+  defstruct field36956: [],
+            field36957: [],
+            field36958: [],
+            field36959: nil,
+            field36960: nil,
+            field36961: nil,
+            field36962: nil,
+            field36963: nil,
+            field36964: nil,
+            field36965: nil,
+            field36966: nil,
+            message36859: []
 
   field :field36956, 1, repeated: true, type: :int32
+
   field :field36957, 2, repeated: true, type: :string
+
   field :field36958, 12, repeated: true, type: :string
+
   field :field36959, 3, optional: true, type: :int32
+
   field :field36960, 4, optional: true, type: :int32
+
   field :field36961, 14, optional: true, type: :int32
+
   field :field36962, 11, optional: true, type: :string
+
   field :field36963, 5, optional: true, type: :bool
+
   field :field36964, 13, optional: true, type: :bool
+
   field :field36965, 6, optional: true, type: :int64
+
   field :field36966, 7, optional: true, type: Benchmarks.GoogleMessage3.Message35506
+
   field :message36859, 8, repeated: true, type: :group
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13174 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1051,54 +1298,72 @@ defmodule Benchmarks.GoogleMessage3.Message13174 do
           field13257: integer
         }
 
-  defstruct [
-    :field13237,
-    :field13238,
-    :field13239,
-    :field13240,
-    :field13241,
-    :field13242,
-    :field13243,
-    :field13244,
-    :field13245,
-    :field13246,
-    :field13247,
-    :field13248,
-    :field13249,
-    :field13250,
-    :field13251,
-    :field13252,
-    :field13253,
-    :field13254,
-    :field13255,
-    :field13256,
-    :field13257
-  ]
+  defstruct field13237: 0,
+            field13238: nil,
+            field13239: 0,
+            field13240: nil,
+            field13241: nil,
+            field13242: nil,
+            field13243: nil,
+            field13244: nil,
+            field13245: nil,
+            field13246: nil,
+            field13247: nil,
+            field13248: nil,
+            field13249: nil,
+            field13250: nil,
+            field13251: nil,
+            field13252: nil,
+            field13253: nil,
+            field13254: nil,
+            field13255: nil,
+            field13256: nil,
+            field13257: nil
 
   field :field13237, 6, required: true, type: :int32
+
   field :field13238, 3, optional: true, type: :int32
+
   field :field13239, 4, required: true, type: :int32
+
   field :field13240, 8, optional: true, type: :int32
+
   field :field13241, 5, optional: true, type: :double
+
   field :field13242, 7, optional: true, type: :double
+
   field :field13243, 17, optional: true, type: :int32
+
   field :field13244, 19, optional: true, type: :int32
+
   field :field13245, 20, optional: true, type: :double
+
   field :field13246, 9, optional: true, type: :int32
+
   field :field13247, 10, optional: true, type: :double
+
   field :field13248, 11, optional: true, type: :int32
+
   field :field13249, 21, optional: true, type: Benchmarks.GoogleMessage3.Message13151
+
   field :field13250, 1, optional: true, type: :int32
+
   field :field13251, 2, optional: true, type: :double
+
   field :field13252, 15, optional: true, type: :double
+
   field :field13253, 16, optional: true, type: :double
+
   field :field13254, 12, optional: true, type: :double
+
   field :field13255, 13, optional: true, type: :double
+
   field :field13256, 14, optional: true, type: :double
+
   field :field13257, 18, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message18283 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1211,223 +1476,324 @@ defmodule Benchmarks.GoogleMessage3.Message18283 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field18478,
-    :field18479,
-    :field18480,
-    :field18481,
-    :field18482,
-    :field18483,
-    :field18484,
-    :field18485,
-    :field18486,
-    :field18487,
-    :field18488,
-    :field18489,
-    :field18490,
-    :field18491,
-    :field18492,
-    :field18493,
-    :field18494,
-    :field18495,
-    :field18496,
-    :field18497,
-    :field18498,
-    :field18499,
-    :field18500,
-    :field18501,
-    :field18502,
-    :field18503,
-    :field18504,
-    :field18505,
-    :field18506,
-    :field18507,
-    :field18508,
-    :field18509,
-    :field18510,
-    :field18511,
-    :field18512,
-    :field18513,
-    :field18514,
-    :field18515,
-    :field18516,
-    :field18517,
-    :field18518,
-    :field18519,
-    :field18520,
-    :field18521,
-    :field18522,
-    :field18523,
-    :field18524,
-    :field18525,
-    :field18526,
-    :field18527,
-    :field18528,
-    :field18529,
-    :field18530,
-    :field18531,
-    :field18532,
-    :field18533,
-    :field18534,
-    :field18535,
-    :field18536,
-    :field18537,
-    :field18538,
-    :field18539,
-    :field18540,
-    :field18541,
-    :field18542,
-    :field18543,
-    :field18544,
-    :field18545,
-    :field18546,
-    :field18547,
-    :field18548,
-    :field18549,
-    :field18550,
-    :field18551,
-    :field18552,
-    :field18553,
-    :field18554,
-    :field18555,
-    :field18556,
-    :field18557,
-    :field18558,
-    :field18559,
-    :field18560,
-    :field18561,
-    :field18562,
-    :field18563,
-    :field18564,
-    :field18565,
-    :field18566,
-    :field18567,
-    :field18568,
-    :field18569,
-    :field18570,
-    :field18571,
-    :field18572,
-    :field18573,
-    :field18574,
-    :field18575,
-    :field18576,
-    :field18577,
-    :field18578,
-    :field18579,
-    :field18580,
-    :field18581,
-    :__pb_extensions__
-  ]
+  defstruct field18478: nil,
+            field18479: nil,
+            field18480: nil,
+            field18481: nil,
+            field18482: nil,
+            field18483: nil,
+            field18484: nil,
+            field18485: nil,
+            field18486: nil,
+            field18487: nil,
+            field18488: nil,
+            field18489: nil,
+            field18490: nil,
+            field18491: nil,
+            field18492: nil,
+            field18493: nil,
+            field18494: nil,
+            field18495: nil,
+            field18496: nil,
+            field18497: nil,
+            field18498: nil,
+            field18499: nil,
+            field18500: nil,
+            field18501: nil,
+            field18502: nil,
+            field18503: nil,
+            field18504: nil,
+            field18505: nil,
+            field18506: nil,
+            field18507: [],
+            field18508: [],
+            field18509: [],
+            field18510: nil,
+            field18511: nil,
+            field18512: nil,
+            field18513: nil,
+            field18514: nil,
+            field18515: nil,
+            field18516: nil,
+            field18517: nil,
+            field18518: nil,
+            field18519: [],
+            field18520: nil,
+            field18521: nil,
+            field18522: nil,
+            field18523: nil,
+            field18524: nil,
+            field18525: nil,
+            field18526: nil,
+            field18527: nil,
+            field18528: nil,
+            field18529: nil,
+            field18530: nil,
+            field18531: nil,
+            field18532: nil,
+            field18533: nil,
+            field18534: nil,
+            field18535: nil,
+            field18536: nil,
+            field18537: nil,
+            field18538: nil,
+            field18539: nil,
+            field18540: nil,
+            field18541: nil,
+            field18542: nil,
+            field18543: nil,
+            field18544: nil,
+            field18545: nil,
+            field18546: nil,
+            field18547: nil,
+            field18548: nil,
+            field18549: nil,
+            field18550: nil,
+            field18551: [],
+            field18552: nil,
+            field18553: [],
+            field18554: nil,
+            field18555: nil,
+            field18556: nil,
+            field18557: nil,
+            field18558: nil,
+            field18559: nil,
+            field18560: nil,
+            field18561: nil,
+            field18562: [],
+            field18563: [],
+            field18564: nil,
+            field18565: nil,
+            field18566: nil,
+            field18567: nil,
+            field18568: nil,
+            field18569: nil,
+            field18570: nil,
+            field18571: nil,
+            field18572: nil,
+            field18573: nil,
+            field18574: nil,
+            field18575: nil,
+            field18576: nil,
+            field18577: nil,
+            field18578: nil,
+            field18579: nil,
+            field18580: nil,
+            field18581: nil,
+            __pb_extensions__: nil
 
   field :field18478, 1, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18479, 4, optional: true, type: :int32
+
   field :field18480, 106, optional: true, type: :int32
+
   field :field18481, 107, optional: true, type: :int32
+
   field :field18482, 108, optional: true, type: :int32
+
   field :field18483, 109, optional: true, type: :int32
+
   field :field18484, 105, optional: true, type: :int32
+
   field :field18485, 113, optional: true, type: :int32
+
   field :field18486, 114, optional: true, type: :int32
+
   field :field18487, 124, optional: true, type: :int32
+
   field :field18488, 125, optional: true, type: :int32
+
   field :field18489, 128, optional: true, type: :int32
+
   field :field18490, 135, optional: true, type: :int32
+
   field :field18491, 166, optional: true, type: :bool
+
   field :field18492, 136, optional: true, type: :bool
+
   field :field18493, 140, optional: true, type: :int32
+
   field :field18494, 171, optional: true, type: :int32
+
   field :field18495, 148, optional: true, type: :int32
+
   field :field18496, 145, optional: true, type: :int32
+
   field :field18497, 117, optional: true, type: :float
+
   field :field18498, 146, optional: true, type: :int32
+
   field :field18499, 3, optional: true, type: :string
+
   field :field18500, 5, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18501, 6, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18502, 9, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18503, 155, optional: true, type: Benchmarks.GoogleMessage3.Message18253
+
   field :field18504, 184, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18505, 163, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18506, 16, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18507, 20, repeated: true, type: :int32
+
   field :field18508, 7, repeated: true, type: :int32
+
   field :field18509, 194, repeated: true, type: :string
+
   field :field18510, 30, optional: true, type: :bytes
+
   field :field18511, 31, optional: true, type: :int32
+
   field :field18512, 178, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18513, 8, optional: true, type: :string
+
   field :field18514, 2, optional: true, type: :float
+
   field :field18515, 100, optional: true, type: :float
+
   field :field18516, 101, optional: true, type: :float
+
   field :field18517, 102, optional: true, type: :float
+
   field :field18518, 103, optional: true, type: :int32
+
   field :field18519, 104, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18520, 110, optional: true, type: :int32
+
   field :field18521, 112, optional: true, type: :int32
+
   field :field18522, 111, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18523, 115, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18524, 119, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18525, 127, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18526, 185, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18527, 120, optional: true, type: :int32
+
   field :field18528, 132, optional: true, type: :int32
+
   field :field18529, 126, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18530, 129, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18531, 131, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18532, 150, optional: true, type: :fixed64
+
   field :field18533, 133, optional: true, type: :int32
+
   field :field18534, 134, optional: true, type: :int32
+
   field :field18535, 139, optional: true, type: :int32
+
   field :field18536, 137, optional: true, type: :fixed64
+
   field :field18537, 138, optional: true, type: :fixed64
+
   field :field18538, 141, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18539, 142, optional: true, type: :int32
+
   field :field18540, 181, optional: true, type: :int32
+
   field :field18541, 143, optional: true, type: Benchmarks.GoogleMessage3.Message16816
+
   field :field18542, 154, optional: true, type: Benchmarks.GoogleMessage3.Message16685
+
   field :field18543, 144, optional: true, type: :int32
+
   field :field18544, 147, optional: true, type: :int64
+
   field :field18545, 149, optional: true, type: :int64
+
   field :field18546, 151, optional: true, type: :int32
+
   field :field18547, 152, optional: true, type: :int32
+
   field :field18548, 153, optional: true, type: :int32
+
   field :field18549, 161, optional: true, type: :float
+
   field :field18550, 123, optional: true, type: Benchmarks.GoogleMessage3.Message0
+
   field :field18551, 156, repeated: true, type: :int64
+
   field :field18552, 157, optional: true, type: :int32
+
   field :field18553, 188, repeated: true, type: :fixed64
+
   field :field18554, 158, optional: true, type: :int32
+
   field :field18555, 159, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18556, 160, optional: true, type: :bool
+
   field :field18557, 162, optional: true, type: :uint64
+
   field :field18558, 164, optional: true, type: :int32
+
   field :field18559, 10, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18560, 167, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18561, 168, optional: true, type: :int32
+
   field :field18562, 169, repeated: true, type: :fixed64
+
   field :field18563, 170, repeated: true, type: :string
+
   field :field18564, 172, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18565, 173, optional: true, type: :int64
+
   field :field18566, 174, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18567, 175, optional: true, type: :int64
+
   field :field18568, 189, optional: true, type: :uint32
+
   field :field18569, 176, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18570, 177, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18571, 179, optional: true, type: :uint32
+
   field :field18572, 180, optional: true, type: :uint32
+
   field :field18573, 182, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18574, 183, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18575, 121, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18576, 186, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18577, 187, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18578, 190, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18579, 191, optional: true, type: :int32
+
   field :field18580, 192, optional: true, type: :float
+
   field :field18581, 193, optional: true, type: :bool
+
   def transform_module(), do: nil
 
   extensions [{116, 117}, {118, 119}, {130, 131}, {165, 166}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13169 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1438,14 +1804,18 @@ defmodule Benchmarks.GoogleMessage3.Message13169 do
           field13225: String.t()
         }
 
-  defstruct [:field13223, :field13224, :field13225]
+  defstruct field13223: [],
+            field13224: nil,
+            field13225: nil
 
   field :field13223, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message13168
+
   field :field13224, 2, required: true, type: Benchmarks.GoogleMessage3.Message13167
+
   field :field13225, 3, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message19255 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1454,12 +1824,12 @@ defmodule Benchmarks.GoogleMessage3.Message19255 do
           field19257: String.t()
         }
 
-  defstruct [:field19257]
+  defstruct field19257: nil
 
   field :field19257, 1, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message35542 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1470,14 +1840,18 @@ defmodule Benchmarks.GoogleMessage3.Message35542 do
           field35545: boolean
         }
 
-  defstruct [:field35543, :field35544, :field35545]
+  defstruct field35543: nil,
+            field35544: nil,
+            field35545: nil
 
   field :field35543, 1, optional: true, type: :bool
+
   field :field35544, 2, optional: true, type: :bool
+
   field :field35545, 3, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message3901 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1497,36 +1871,45 @@ defmodule Benchmarks.GoogleMessage3.Message3901 do
           field4001: integer
         }
 
-  defstruct [
-    :field3990,
-    :field3991,
-    :field3992,
-    :field3993,
-    :field3994,
-    :field3995,
-    :field3996,
-    :field3997,
-    :field3998,
-    :field3999,
-    :field4000,
-    :field4001
-  ]
+  defstruct field3990: nil,
+            field3991: nil,
+            field3992: nil,
+            field3993: nil,
+            field3994: nil,
+            field3995: nil,
+            field3996: nil,
+            field3997: nil,
+            field3998: nil,
+            field3999: nil,
+            field4000: nil,
+            field4001: nil
 
   field :field3990, 1, optional: true, type: :int32
+
   field :field3991, 2, optional: true, type: :int32
+
   field :field3992, 3, optional: true, type: :int32
+
   field :field3993, 4, optional: true, type: :int32
+
   field :field3994, 7, optional: true, type: :int32
+
   field :field3995, 8, optional: true, type: :int32
+
   field :field3996, 9, optional: true, type: :int32
+
   field :field3997, 10, optional: true, type: :int32
+
   field :field3998, 11, optional: true, type: :int32
+
   field :field3999, 12, optional: true, type: :int32
+
   field :field4000, 6, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field4001, 5, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.PbExtension do
   @moduledoc false
   use Protobuf, syntax: :proto2

--- a/bench/lib/datasets/google_message3/benchmark_message3_3.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_3.pb.ex
@@ -7,13 +7,15 @@ defmodule Benchmarks.GoogleMessage3.Message35546.Message35547 do
           field35570: integer
         }
 
-  defstruct [:field35569, :field35570]
+  defstruct field35569: 0,
+            field35570: 0
 
   field :field35569, 5, required: true, type: :int32
+
   field :field35570, 6, required: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message35546.Message35548 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -23,13 +25,15 @@ defmodule Benchmarks.GoogleMessage3.Message35546.Message35548 do
           field35572: integer
         }
 
-  defstruct [:field35571, :field35572]
+  defstruct field35571: 0,
+            field35572: 0
 
   field :field35571, 11, required: true, type: :int64
+
   field :field35572, 12, required: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message35546 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -49,36 +53,45 @@ defmodule Benchmarks.GoogleMessage3.Message35546 do
           field35567: String.t()
         }
 
-  defstruct [
-    :field35556,
-    :field35557,
-    :field35558,
-    :field35559,
-    :message35547,
-    :message35548,
-    :field35562,
-    :field35563,
-    :field35564,
-    :field35565,
-    :field35566,
-    :field35567
-  ]
+  defstruct field35556: nil,
+            field35557: nil,
+            field35558: nil,
+            field35559: nil,
+            message35547: nil,
+            message35548: nil,
+            field35562: nil,
+            field35563: nil,
+            field35564: nil,
+            field35565: nil,
+            field35566: nil,
+            field35567: nil
 
   field :field35556, 1, optional: true, type: :int64
+
   field :field35557, 2, optional: true, type: :int32
+
   field :field35558, 3, optional: true, type: :bool
+
   field :field35559, 13, optional: true, type: :int64
+
   field :message35547, 4, optional: true, type: :group
+
   field :message35548, 10, optional: true, type: :group
+
   field :field35562, 14, optional: true, type: :bool
+
   field :field35563, 15, optional: true, type: :bool
+
   field :field35564, 16, optional: true, type: :int32
+
   field :field35565, 17, optional: true, type: :bool
+
   field :field35566, 18, optional: true, type: :bool
+
   field :field35567, 100, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message2356.Message2357 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -98,45 +111,55 @@ defmodule Benchmarks.GoogleMessage3.Message2356.Message2357 do
           field2410: binary
         }
 
-  defstruct [
-    :field2399,
-    :field2400,
-    :field2401,
-    :field2402,
-    :field2403,
-    :field2404,
-    :field2405,
-    :field2406,
-    :field2407,
-    :field2408,
-    :field2409,
-    :field2410
-  ]
+  defstruct field2399: nil,
+            field2400: nil,
+            field2401: nil,
+            field2402: nil,
+            field2403: nil,
+            field2404: nil,
+            field2405: nil,
+            field2406: "",
+            field2407: nil,
+            field2408: nil,
+            field2409: nil,
+            field2410: nil
 
   field :field2399, 9, optional: true, type: :int64
+
   field :field2400, 10, optional: true, type: :int32
+
   field :field2401, 11, optional: true, type: :int32
+
   field :field2402, 12, optional: true, type: :int32
+
   field :field2403, 13, optional: true, type: :int32
+
   field :field2404, 116, optional: true, type: :int32
+
   field :field2405, 106, optional: true, type: :int32
+
   field :field2406, 14, required: true, type: :bytes
+
   field :field2407, 45, optional: true, type: :int32
+
   field :field2408, 112, optional: true, type: :int32
+
   field :field2409, 122, optional: true, type: :bool
+
   field :field2410, 124, optional: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message2356.Message2358 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message2356.Message2359 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -152,28 +175,33 @@ defmodule Benchmarks.GoogleMessage3.Message2356.Message2359 do
           field2420: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [
-    :field2413,
-    :field2414,
-    :field2415,
-    :field2416,
-    :field2417,
-    :field2418,
-    :field2419,
-    :field2420
-  ]
+  defstruct field2413: nil,
+            field2414: nil,
+            field2415: nil,
+            field2416: nil,
+            field2417: nil,
+            field2418: nil,
+            field2419: nil,
+            field2420: nil
 
   field :field2413, 41, optional: true, type: :string
+
   field :field2414, 42, optional: true, type: :string
+
   field :field2415, 43, optional: true, type: :string
+
   field :field2416, 44, optional: true, type: :string
+
   field :field2417, 46, optional: true, type: :int32
+
   field :field2418, 47, optional: true, type: :string
+
   field :field2419, 110, optional: true, type: :float
+
   field :field2420, 111, optional: true, type: :float
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message2356 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -212,74 +240,102 @@ defmodule Benchmarks.GoogleMessage3.Message2356 do
           field2398: String.t()
         }
 
-  defstruct [
-    :field2368,
-    :field2369,
-    :field2370,
-    :field2371,
-    :field2372,
-    :field2373,
-    :field2374,
-    :field2375,
-    :field2376,
-    :field2377,
-    :field2378,
-    :field2379,
-    :field2380,
-    :field2381,
-    :field2382,
-    :field2383,
-    :field2384,
-    :field2385,
-    :field2386,
-    :field2387,
-    :message2357,
-    :field2389,
-    :message2358,
-    :message2359,
-    :field2392,
-    :field2393,
-    :field2394,
-    :field2395,
-    :field2396,
-    :field2397,
-    :field2398
-  ]
+  defstruct field2368: nil,
+            field2369: nil,
+            field2370: nil,
+            field2371: nil,
+            field2372: "",
+            field2373: nil,
+            field2374: nil,
+            field2375: nil,
+            field2376: nil,
+            field2377: nil,
+            field2378: nil,
+            field2379: nil,
+            field2380: nil,
+            field2381: nil,
+            field2382: nil,
+            field2383: nil,
+            field2384: nil,
+            field2385: nil,
+            field2386: nil,
+            field2387: nil,
+            message2357: nil,
+            field2389: nil,
+            message2358: nil,
+            message2359: [],
+            field2392: nil,
+            field2393: nil,
+            field2394: nil,
+            field2395: nil,
+            field2396: nil,
+            field2397: nil,
+            field2398: nil
 
   field :field2368, 121, optional: true, type: Benchmarks.GoogleMessage3.Message1374
+
   field :field2369, 1, optional: true, type: :uint64
+
   field :field2370, 2, optional: true, type: :int32
+
   field :field2371, 17, optional: true, type: :int32
+
   field :field2372, 3, required: true, type: :string
+
   field :field2373, 7, optional: true, type: :int32
+
   field :field2374, 8, optional: true, type: :bytes
+
   field :field2375, 4, optional: true, type: :string
+
   field :field2376, 101, optional: true, type: :string
+
   field :field2377, 102, optional: true, type: :int32
+
   field :field2378, 103, optional: true, type: :int32
+
   field :field2379, 104, optional: true, type: :int32
+
   field :field2380, 113, optional: true, type: :int32
+
   field :field2381, 114, optional: true, type: :int32
+
   field :field2382, 115, optional: true, type: :int32
+
   field :field2383, 117, optional: true, type: :int32
+
   field :field2384, 118, optional: true, type: :int32
+
   field :field2385, 119, optional: true, type: :int32
+
   field :field2386, 105, optional: true, type: :int32
+
   field :field2387, 5, optional: true, type: :bytes
+
   field :message2357, 6, optional: true, type: :group
+
   field :field2389, 120, optional: true, type: :string
+
   field :message2358, 107, optional: true, type: :group
+
   field :message2359, 40, repeated: true, type: :group
+
   field :field2392, 50, optional: true, type: :int32
+
   field :field2393, 60, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field2394, 70, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field2395, 80, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field2396, 90, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field2397, 100, optional: true, type: :string
+
   field :field2398, 123, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7029.Message7030 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -290,14 +346,18 @@ defmodule Benchmarks.GoogleMessage3.Message7029.Message7030 do
           field7228: integer
         }
 
-  defstruct [:field7226, :field7227, :field7228]
+  defstruct field7226: nil,
+            field7227: nil,
+            field7228: nil
 
   field :field7226, 14, optional: true, type: :string
+
   field :field7227, 15, optional: true, type: :string
+
   field :field7228, 16, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7029.Message7031 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -311,17 +371,27 @@ defmodule Benchmarks.GoogleMessage3.Message7029.Message7031 do
           field7234: integer
         }
 
-  defstruct [:field7229, :field7230, :field7231, :field7232, :field7233, :field7234]
+  defstruct field7229: nil,
+            field7230: nil,
+            field7231: nil,
+            field7232: nil,
+            field7233: nil,
+            field7234: nil
 
   field :field7229, 22, optional: true, type: :string
+
   field :field7230, 23, optional: true, type: :int32
+
   field :field7231, 24, optional: true, type: :int32
+
   field :field7232, 30, optional: true, type: :int32
+
   field :field7233, 31, optional: true, type: :int32
+
   field :field7234, 35, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7029 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -371,96 +441,135 @@ defmodule Benchmarks.GoogleMessage3.Message7029 do
           field7224: integer
         }
 
-  defstruct [
-    :field7183,
-    :field7184,
-    :field7185,
-    :field7186,
-    :field7187,
-    :field7188,
-    :field7189,
-    :field7190,
-    :field7191,
-    :field7192,
-    :field7193,
-    :field7194,
-    :field7195,
-    :field7196,
-    :field7197,
-    :field7198,
-    :field7199,
-    :field7200,
-    :field7201,
-    :field7202,
-    :field7203,
-    :field7204,
-    :field7205,
-    :field7206,
-    :message7030,
-    :message7031,
-    :field7209,
-    :field7210,
-    :field7211,
-    :field7212,
-    :field7213,
-    :field7214,
-    :field7215,
-    :field7216,
-    :field7217,
-    :field7218,
-    :field7219,
-    :field7220,
-    :field7221,
-    :field7222,
-    :field7223,
-    :field7224
-  ]
+  defstruct field7183: 0,
+            field7184: nil,
+            field7185: nil,
+            field7186: nil,
+            field7187: nil,
+            field7188: nil,
+            field7189: nil,
+            field7190: nil,
+            field7191: nil,
+            field7192: nil,
+            field7193: nil,
+            field7194: nil,
+            field7195: nil,
+            field7196: nil,
+            field7197: nil,
+            field7198: nil,
+            field7199: nil,
+            field7200: nil,
+            field7201: nil,
+            field7202: nil,
+            field7203: nil,
+            field7204: nil,
+            field7205: nil,
+            field7206: nil,
+            message7030: [],
+            message7031: [],
+            field7209: nil,
+            field7210: nil,
+            field7211: nil,
+            field7212: nil,
+            field7213: nil,
+            field7214: nil,
+            field7215: nil,
+            field7216: nil,
+            field7217: nil,
+            field7218: nil,
+            field7219: nil,
+            field7220: nil,
+            field7221: nil,
+            field7222: nil,
+            field7223: nil,
+            field7224: nil
 
   field :field7183, 1, required: true, type: :int32
+
   field :field7184, 2, optional: true, type: :int32
+
   field :field7185, 3, optional: true, type: :int32
+
   field :field7186, 4, optional: true, type: :int32
+
   field :field7187, 5, optional: true, type: :int32
+
   field :field7188, 6, optional: true, type: :int32
+
   field :field7189, 17, optional: true, type: :int32
+
   field :field7190, 18, optional: true, type: :int32
+
   field :field7191, 49, optional: true, type: :int32
+
   field :field7192, 28, optional: true, type: :int32
+
   field :field7193, 33, optional: true, type: :int32
+
   field :field7194, 25, optional: true, type: :int32
+
   field :field7195, 26, optional: true, type: :int32
+
   field :field7196, 40, optional: true, type: :int32
+
   field :field7197, 41, optional: true, type: :int32
+
   field :field7198, 42, optional: true, type: :int32
+
   field :field7199, 43, optional: true, type: :int32
+
   field :field7200, 19, optional: true, type: :int32
+
   field :field7201, 7, optional: true, type: :int32
+
   field :field7202, 8, optional: true, type: :int32
+
   field :field7203, 9, optional: true, type: :int32
+
   field :field7204, 10, optional: true, type: :int32
+
   field :field7205, 11, optional: true, type: :int32
+
   field :field7206, 12, optional: true, type: :int32
+
   field :message7030, 13, repeated: true, type: :group
+
   field :message7031, 21, repeated: true, type: :group
+
   field :field7209, 20, optional: true, type: :int32
+
   field :field7210, 27, optional: true, type: :float
+
   field :field7211, 29, optional: true, type: :int32
+
   field :field7212, 32, optional: true, type: :int32
+
   field :field7213, 48, optional: true, type: :string
+
   field :field7214, 34, optional: true, type: :bool
+
   field :field7215, 36, optional: true, type: :int32
+
   field :field7216, 37, optional: true, type: :float
+
   field :field7217, 38, optional: true, type: :bool
+
   field :field7218, 39, optional: true, type: :bool
+
   field :field7219, 44, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field7220, 45, optional: true, type: :int32
+
   field :field7221, 46, optional: true, type: :int32
+
   field :field7222, 47, optional: true, type: :int32
+
   field :field7223, 50, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field7224, 51, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message35538 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -469,12 +578,12 @@ defmodule Benchmarks.GoogleMessage3.Message35538 do
           field35539: integer
         }
 
-  defstruct [:field35539]
+  defstruct field35539: 0
 
   field :field35539, 1, required: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message18921.Message18922 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -505,58 +614,78 @@ defmodule Benchmarks.GoogleMessage3.Message18921.Message18922 do
           field18981: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [
-    :field18959,
-    :field18960,
-    :field18961,
-    :field18962,
-    :field18963,
-    :field18964,
-    :field18965,
-    :field18966,
-    :field18967,
-    :field18968,
-    :field18969,
-    :field18970,
-    :field18971,
-    :field18972,
-    :field18973,
-    :field18974,
-    :field18975,
-    :field18976,
-    :field18977,
-    :field18978,
-    :field18979,
-    :field18980,
-    :field18981
-  ]
+  defstruct field18959: nil,
+            field18960: nil,
+            field18961: nil,
+            field18962: nil,
+            field18963: nil,
+            field18964: nil,
+            field18965: nil,
+            field18966: nil,
+            field18967: nil,
+            field18968: nil,
+            field18969: nil,
+            field18970: nil,
+            field18971: [],
+            field18972: nil,
+            field18973: nil,
+            field18974: nil,
+            field18975: nil,
+            field18976: nil,
+            field18977: nil,
+            field18978: nil,
+            field18979: nil,
+            field18980: [],
+            field18981: nil
 
   field :field18959, 6, optional: true, type: :uint64
+
   field :field18960, 13, optional: true, type: :string
+
   field :field18961, 21, optional: true, type: :bool
+
   field :field18962, 33, optional: true, type: :bool
+
   field :field18963, 7, optional: true, type: :int32
+
   field :field18964, 8, optional: true, type: :int32
+
   field :field18965, 9, optional: true, type: :string
+
   field :field18966, 10, optional: true, type: Benchmarks.GoogleMessage3.Message18856
+
   field :field18967, 34, optional: true, type: :uint64
+
   field :field18968, 11, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18969, 35, optional: true, type: :uint64
+
   field :field18970, 12, optional: true, type: :float
+
   field :field18971, 14, repeated: true, type: :string
+
   field :field18972, 15, optional: true, type: :bool
+
   field :field18973, 16, optional: true, type: :bool
+
   field :field18974, 22, optional: true, type: :float
+
   field :field18975, 18, optional: true, type: :int32
+
   field :field18976, 19, optional: true, type: :int32
+
   field :field18977, 20, optional: true, type: :int32
+
   field :field18978, 25, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18979, 26, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field18980, 27, repeated: true, type: :string
+
   field :field18981, 28, optional: true, type: :float
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message18921 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -576,36 +705,45 @@ defmodule Benchmarks.GoogleMessage3.Message18921 do
           field18957: [Benchmarks.GoogleMessage3.UnusedEmptyMessage.t()]
         }
 
-  defstruct [
-    :field18946,
-    :field18947,
-    :field18948,
-    :field18949,
-    :field18950,
-    :field18951,
-    :field18952,
-    :message18922,
-    :field18954,
-    :field18955,
-    :field18956,
-    :field18957
-  ]
+  defstruct field18946: nil,
+            field18947: nil,
+            field18948: nil,
+            field18949: nil,
+            field18950: nil,
+            field18951: nil,
+            field18952: nil,
+            message18922: [],
+            field18954: [],
+            field18955: [],
+            field18956: [],
+            field18957: []
 
   field :field18946, 1, optional: true, type: :string
+
   field :field18947, 2, optional: true, type: :fixed64
+
   field :field18948, 3, optional: true, type: :int32
+
   field :field18949, 4, optional: true, type: :double
+
   field :field18950, 17, optional: true, type: :bool
+
   field :field18951, 23, optional: true, type: :bool
+
   field :field18952, 24, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :message18922, 5, repeated: true, type: :group
+
   field :field18954, 29, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field18955, 30, repeated: true, type: Benchmarks.GoogleMessage3.Message18943
+
   field :field18956, 31, repeated: true, type: Benchmarks.GoogleMessage3.Message18944
+
   field :field18957, 32, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message35540 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -614,12 +752,12 @@ defmodule Benchmarks.GoogleMessage3.Message35540 do
           field35541: boolean
         }
 
-  defstruct [:field35541]
+  defstruct field35541: nil
 
   field :field35541, 1, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message3886.Message3887 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -631,15 +769,21 @@ defmodule Benchmarks.GoogleMessage3.Message3886.Message3887 do
           field3935: binary
         }
 
-  defstruct [:field3932, :field3933, :field3934, :field3935]
+  defstruct field3932: "",
+            field3933: nil,
+            field3934: nil,
+            field3935: nil
 
   field :field3932, 2, required: true, type: :string
+
   field :field3933, 9, optional: true, type: :string
+
   field :field3934, 3, optional: true, type: Benchmarks.GoogleMessage3.Message3850
+
   field :field3935, 8, optional: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message3886 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -648,12 +792,12 @@ defmodule Benchmarks.GoogleMessage3.Message3886 do
           message3887: [any]
         }
 
-  defstruct [:message3887]
+  defstruct message3887: []
 
   field :message3887, 1, repeated: true, type: :group
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6743 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -669,28 +813,33 @@ defmodule Benchmarks.GoogleMessage3.Message6743 do
           field6766: Benchmarks.GoogleMessage3.Message6742.t() | nil
         }
 
-  defstruct [
-    :field6759,
-    :field6760,
-    :field6761,
-    :field6762,
-    :field6763,
-    :field6764,
-    :field6765,
-    :field6766
-  ]
+  defstruct field6759: nil,
+            field6760: nil,
+            field6761: nil,
+            field6762: nil,
+            field6763: nil,
+            field6764: nil,
+            field6765: nil,
+            field6766: nil
 
   field :field6759, 1, optional: true, type: Benchmarks.GoogleMessage3.Message6721
+
   field :field6760, 2, optional: true, type: Benchmarks.GoogleMessage3.Message6723
+
   field :field6761, 8, optional: true, type: Benchmarks.GoogleMessage3.Message6723
+
   field :field6762, 3, optional: true, type: Benchmarks.GoogleMessage3.Message6725
+
   field :field6763, 4, optional: true, type: Benchmarks.GoogleMessage3.Message6726
+
   field :field6764, 5, optional: true, type: Benchmarks.GoogleMessage3.Message6733
+
   field :field6765, 6, optional: true, type: Benchmarks.GoogleMessage3.Message6734
+
   field :field6766, 7, optional: true, type: Benchmarks.GoogleMessage3.Message6742
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6773 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -708,32 +857,39 @@ defmodule Benchmarks.GoogleMessage3.Message6773 do
           field6803: Benchmarks.GoogleMessage3.Enum6782.t()
         }
 
-  defstruct [
-    :field6794,
-    :field6795,
-    :field6796,
-    :field6797,
-    :field6798,
-    :field6799,
-    :field6800,
-    :field6801,
-    :field6802,
-    :field6803
-  ]
+  defstruct field6794: nil,
+            field6795: nil,
+            field6796: nil,
+            field6797: nil,
+            field6798: nil,
+            field6799: nil,
+            field6800: nil,
+            field6801: nil,
+            field6802: nil,
+            field6803: nil
 
   field :field6794, 1, optional: true, type: Benchmarks.GoogleMessage3.Enum6769, enum: true
+
   field :field6795, 9, optional: true, type: :int32
+
   field :field6796, 10, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field6797, 11, optional: true, type: :int32
+
   field :field6798, 2, optional: true, type: :int32
+
   field :field6799, 3, optional: true, type: Benchmarks.GoogleMessage3.Enum6774, enum: true
+
   field :field6800, 5, optional: true, type: :double
+
   field :field6801, 7, optional: true, type: :double
+
   field :field6802, 8, optional: true, type: :double
+
   field :field6803, 6, optional: true, type: Benchmarks.GoogleMessage3.Enum6782, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8224 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -768,66 +924,90 @@ defmodule Benchmarks.GoogleMessage3.Message8224 do
           field8281: [Benchmarks.GoogleMessage3.UnusedEmptyMessage.t()]
         }
 
-  defstruct [
-    :field8255,
-    :field8256,
-    :field8257,
-    :field8258,
-    :field8259,
-    :field8260,
-    :field8261,
-    :field8262,
-    :field8263,
-    :field8264,
-    :field8265,
-    :field8266,
-    :field8267,
-    :field8268,
-    :field8269,
-    :field8270,
-    :field8271,
-    :field8272,
-    :field8273,
-    :field8274,
-    :field8275,
-    :field8276,
-    :field8277,
-    :field8278,
-    :field8279,
-    :field8280,
-    :field8281
-  ]
+  defstruct field8255: nil,
+            field8256: nil,
+            field8257: nil,
+            field8258: nil,
+            field8259: nil,
+            field8260: nil,
+            field8261: nil,
+            field8262: nil,
+            field8263: nil,
+            field8264: nil,
+            field8265: nil,
+            field8266: [],
+            field8267: nil,
+            field8268: nil,
+            field8269: nil,
+            field8270: nil,
+            field8271: nil,
+            field8272: nil,
+            field8273: nil,
+            field8274: [],
+            field8275: nil,
+            field8276: nil,
+            field8277: nil,
+            field8278: [],
+            field8279: nil,
+            field8280: nil,
+            field8281: []
 
   field :field8255, 1, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8256, 2, optional: true, type: Benchmarks.GoogleMessage3.Message8184
+
   field :field8257, 3, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   field :field8258, 4, optional: true, type: :string
+
   field :field8259, 5, optional: true, type: :string
+
   field :field8260, 6, optional: true, type: :bool
+
   field :field8261, 7, optional: true, type: :int64
+
   field :field8262, 8, optional: true, type: :string
+
   field :field8263, 9, optional: true, type: :int64
+
   field :field8264, 10, optional: true, type: :double
+
   field :field8265, 11, optional: true, type: :int64
+
   field :field8266, 12, repeated: true, type: :string
+
   field :field8267, 13, optional: true, type: :int64
+
   field :field8268, 14, optional: true, type: :int32
+
   field :field8269, 15, optional: true, type: :int32
+
   field :field8270, 16, optional: true, type: :int64
+
   field :field8271, 17, optional: true, type: :double
+
   field :field8272, 18, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8273, 19, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8274, 20, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8275, 21, optional: true, type: :bool
+
   field :field8276, 22, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8277, 23, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8278, 24, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8279, 25, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8280, 26, optional: true, type: :bool
+
   field :field8281, 27, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8392 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -844,30 +1024,36 @@ defmodule Benchmarks.GoogleMessage3.Message8392 do
           field8403: String.t()
         }
 
-  defstruct [
-    :field8395,
-    :field8396,
-    :field8397,
-    :field8398,
-    :field8399,
-    :field8400,
-    :field8401,
-    :field8402,
-    :field8403
-  ]
+  defstruct field8395: nil,
+            field8396: nil,
+            field8397: nil,
+            field8398: nil,
+            field8399: nil,
+            field8400: nil,
+            field8401: nil,
+            field8402: nil,
+            field8403: nil
 
   field :field8395, 1, optional: true, type: :string
+
   field :field8396, 2, optional: true, type: :string
+
   field :field8397, 3, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   field :field8398, 4, optional: true, type: :string
+
   field :field8399, 5, optional: true, type: :string
+
   field :field8400, 6, optional: true, type: :string
+
   field :field8401, 7, optional: true, type: :string
+
   field :field8402, 8, optional: true, type: :string
+
   field :field8403, 9, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8130 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -899,60 +1085,81 @@ defmodule Benchmarks.GoogleMessage3.Message8130 do
           field8179: [Benchmarks.GoogleMessage3.UnusedEmptyMessage.t()]
         }
 
-  defstruct [
-    :field8156,
-    :field8157,
-    :field8158,
-    :field8159,
-    :field8160,
-    :field8161,
-    :field8162,
-    :field8163,
-    :field8164,
-    :field8165,
-    :field8166,
-    :field8167,
-    :field8168,
-    :field8169,
-    :field8170,
-    :field8171,
-    :field8172,
-    :field8173,
-    :field8174,
-    :field8175,
-    :field8176,
-    :field8177,
-    :field8178,
-    :field8179
-  ]
+  defstruct field8156: nil,
+            field8157: nil,
+            field8158: nil,
+            field8159: nil,
+            field8160: [],
+            field8161: nil,
+            field8162: nil,
+            field8163: nil,
+            field8164: nil,
+            field8165: nil,
+            field8166: nil,
+            field8167: nil,
+            field8168: nil,
+            field8169: nil,
+            field8170: nil,
+            field8171: nil,
+            field8172: nil,
+            field8173: nil,
+            field8174: nil,
+            field8175: nil,
+            field8176: nil,
+            field8177: nil,
+            field8178: [],
+            field8179: []
 
   field :field8156, 1, optional: true, type: :string
+
   field :field8157, 2, optional: true, type: :string
+
   field :field8158, 4, optional: true, type: :string
+
   field :field8159, 6, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8160, 7, repeated: true, type: :string
+
   field :field8161, 8, optional: true, type: :int64
+
   field :field8162, 9, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8163, 10, optional: true, type: :string
+
   field :field8164, 11, optional: true, type: :string
+
   field :field8165, 12, optional: true, type: :string
+
   field :field8166, 13, optional: true, type: :string
+
   field :field8167, 14, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8168, 15, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8169, 16, optional: true, type: :string
+
   field :field8170, 17, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field8171, 18, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field8172, 19, optional: true, type: :bool
+
   field :field8173, 20, optional: true, type: :bool
+
   field :field8174, 21, optional: true, type: :double
+
   field :field8175, 22, optional: true, type: :int32
+
   field :field8176, 23, optional: true, type: :int32
+
   field :field8177, 24, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8178, 25, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8179, 26, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8478 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -968,28 +1175,33 @@ defmodule Benchmarks.GoogleMessage3.Message8478 do
           field8496: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field8489,
-    :field8490,
-    :field8491,
-    :field8492,
-    :field8493,
-    :field8494,
-    :field8495,
-    :field8496
-  ]
+  defstruct field8489: nil,
+            field8490: nil,
+            field8491: nil,
+            field8492: nil,
+            field8493: nil,
+            field8494: [],
+            field8495: nil,
+            field8496: nil
 
   field :field8489, 7, optional: true, type: :string
+
   field :field8490, 1, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   field :field8491, 2, optional: true, type: Benchmarks.GoogleMessage3.Message8476
+
   field :field8492, 3, optional: true, type: :int64
+
   field :field8493, 4, optional: true, type: Benchmarks.GoogleMessage3.Message8476
+
   field :field8494, 5, repeated: true, type: Benchmarks.GoogleMessage3.Message8477
+
   field :field8495, 6, optional: true, type: Benchmarks.GoogleMessage3.Message8454
+
   field :field8496, 8, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8479 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1006,30 +1218,36 @@ defmodule Benchmarks.GoogleMessage3.Message8479 do
           field8505: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field8497,
-    :field8498,
-    :field8499,
-    :field8500,
-    :field8501,
-    :field8502,
-    :field8503,
-    :field8504,
-    :field8505
-  ]
+  defstruct field8497: nil,
+            field8498: nil,
+            field8499: nil,
+            field8500: nil,
+            field8501: nil,
+            field8502: nil,
+            field8503: nil,
+            field8504: nil,
+            field8505: nil
 
   field :field8497, 1, optional: true, type: Benchmarks.GoogleMessage3.Message8475
+
   field :field8498, 2, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   field :field8499, 3, optional: true, type: Benchmarks.GoogleMessage3.Message8476
+
   field :field8500, 4, optional: true, type: Benchmarks.GoogleMessage3.Message8476
+
   field :field8501, 6, optional: true, type: :string
+
   field :field8502, 7, optional: true, type: :string
+
   field :field8503, 8, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   field :field8504, 5, optional: true, type: Benchmarks.GoogleMessage3.Message8455
+
   field :field8505, 9, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10319 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1044,26 +1262,30 @@ defmodule Benchmarks.GoogleMessage3.Message10319 do
           field10346: String.t()
         }
 
-  defstruct [
-    :field10340,
-    :field10341,
-    :field10342,
-    :field10343,
-    :field10344,
-    :field10345,
-    :field10346
-  ]
+  defstruct field10340: nil,
+            field10341: nil,
+            field10342: nil,
+            field10343: nil,
+            field10344: nil,
+            field10345: nil,
+            field10346: nil
 
   field :field10340, 1, optional: true, type: Benchmarks.GoogleMessage3.Enum10325, enum: true
+
   field :field10341, 4, optional: true, type: :int32
+
   field :field10342, 5, optional: true, type: :int32
+
   field :field10343, 3, optional: true, type: :bytes
+
   field :field10344, 2, optional: true, type: :string
+
   field :field10345, 6, optional: true, type: :string
+
   field :field10346, 7, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message4016 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1075,15 +1297,21 @@ defmodule Benchmarks.GoogleMessage3.Message4016 do
           field4020: integer
         }
 
-  defstruct [:field4017, :field4018, :field4019, :field4020]
+  defstruct field4017: 0,
+            field4018: 0,
+            field4019: 0,
+            field4020: 0
 
   field :field4017, 1, required: true, type: :int32
+
   field :field4018, 2, required: true, type: :int32
+
   field :field4019, 3, required: true, type: :int32
+
   field :field4020, 4, required: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message12669 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1095,15 +1323,21 @@ defmodule Benchmarks.GoogleMessage3.Message12669 do
           field12684: Benchmarks.GoogleMessage3.Enum12670.t()
         }
 
-  defstruct [:field12681, :field12682, :field12683, :field12684]
+  defstruct field12681: nil,
+            field12682: nil,
+            field12683: nil,
+            field12684: nil
 
   field :field12681, 1, optional: true, type: Benchmarks.GoogleMessage3.Message12559
+
   field :field12682, 2, optional: true, type: :float
+
   field :field12683, 3, optional: true, type: :bool
+
   field :field12684, 4, optional: true, type: Benchmarks.GoogleMessage3.Enum12670, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message12819 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1117,17 +1351,27 @@ defmodule Benchmarks.GoogleMessage3.Message12819 do
           field12839: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [:field12834, :field12835, :field12836, :field12837, :field12838, :field12839]
+  defstruct field12834: nil,
+            field12835: nil,
+            field12836: nil,
+            field12837: nil,
+            field12838: nil,
+            field12839: nil
 
   field :field12834, 1, optional: true, type: :double
+
   field :field12835, 2, optional: true, type: :double
+
   field :field12836, 3, optional: true, type: :double
+
   field :field12837, 4, optional: true, type: :double
+
   field :field12838, 5, optional: true, type: :double
+
   field :field12839, 6, optional: true, type: :double
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message12820 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1143,28 +1387,33 @@ defmodule Benchmarks.GoogleMessage3.Message12820 do
           field12847: integer
         }
 
-  defstruct [
-    :field12840,
-    :field12841,
-    :field12842,
-    :field12843,
-    :field12844,
-    :field12845,
-    :field12846,
-    :field12847
-  ]
+  defstruct field12840: nil,
+            field12841: nil,
+            field12842: nil,
+            field12843: nil,
+            field12844: nil,
+            field12845: nil,
+            field12846: nil,
+            field12847: nil
 
   field :field12840, 1, optional: true, type: :int32
+
   field :field12841, 2, optional: true, type: :int32
+
   field :field12842, 3, optional: true, type: :int32
+
   field :field12843, 8, optional: true, type: :int32
+
   field :field12844, 4, optional: true, type: :int32
+
   field :field12845, 5, optional: true, type: :int32
+
   field :field12846, 6, optional: true, type: :int32
+
   field :field12847, 7, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message12821 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1177,16 +1426,24 @@ defmodule Benchmarks.GoogleMessage3.Message12821 do
           field12852: integer
         }
 
-  defstruct [:field12848, :field12849, :field12850, :field12851, :field12852]
+  defstruct field12848: nil,
+            field12849: nil,
+            field12850: nil,
+            field12851: nil,
+            field12852: nil
 
   field :field12848, 1, optional: true, type: :int32
+
   field :field12849, 2, optional: true, type: :int32
+
   field :field12850, 3, optional: true, type: :int32
+
   field :field12851, 4, optional: true, type: :int32
+
   field :field12852, 5, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message12818 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1199,16 +1456,24 @@ defmodule Benchmarks.GoogleMessage3.Message12818 do
           field12833: [Benchmarks.GoogleMessage3.Message12817.t()]
         }
 
-  defstruct [:field12829, :field12830, :field12831, :field12832, :field12833]
+  defstruct field12829: nil,
+            field12830: nil,
+            field12831: nil,
+            field12832: nil,
+            field12833: []
 
   field :field12829, 1, optional: true, type: :uint64
+
   field :field12830, 2, optional: true, type: :int32
+
   field :field12831, 3, optional: true, type: :int32
+
   field :field12832, 5, optional: true, type: :int32
+
   field :field12833, 4, repeated: true, type: Benchmarks.GoogleMessage3.Message12817
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16479 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1222,17 +1487,27 @@ defmodule Benchmarks.GoogleMessage3.Message16479 do
           field16489: non_neg_integer
         }
 
-  defstruct [:field16484, :field16485, :field16486, :field16487, :field16488, :field16489]
+  defstruct field16484: nil,
+            field16485: nil,
+            field16486: nil,
+            field16487: nil,
+            field16488: nil,
+            field16489: nil
 
   field :field16484, 1, optional: true, type: Benchmarks.GoogleMessage3.Message16480
+
   field :field16485, 5, optional: true, type: :int32
+
   field :field16486, 2, optional: true, type: :float
+
   field :field16487, 4, optional: true, type: :uint32
+
   field :field16488, 3, optional: true, type: :bool
+
   field :field16489, 6, optional: true, type: :uint32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16722 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1245,16 +1520,24 @@ defmodule Benchmarks.GoogleMessage3.Message16722 do
           field16756: String.t()
         }
 
-  defstruct [:field16752, :field16753, :field16754, :field16755, :field16756]
+  defstruct field16752: nil,
+            field16753: nil,
+            field16754: nil,
+            field16755: nil,
+            field16756: nil
 
   field :field16752, 1, optional: true, type: :string
+
   field :field16753, 2, optional: true, type: :string
+
   field :field16754, 3, optional: true, type: :string
+
   field :field16755, 5, optional: true, type: :int32
+
   field :field16756, 4, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16724 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1275,47 +1558,58 @@ defmodule Benchmarks.GoogleMessage3.Message16724 do
           field16773: boolean
         }
 
-  defstruct [
-    :field16761,
-    :field16762,
-    :field16763,
-    :field16764,
-    :field16765,
-    :field16766,
-    :field16767,
-    :field16768,
-    :field16769,
-    :field16770,
-    :field16771,
-    :field16772,
-    :field16773
-  ]
+  defstruct field16761: nil,
+            field16762: nil,
+            field16763: nil,
+            field16764: nil,
+            field16765: nil,
+            field16766: [],
+            field16767: [],
+            field16768: nil,
+            field16769: nil,
+            field16770: nil,
+            field16771: nil,
+            field16772: [],
+            field16773: nil
 
   field :field16761, 1, optional: true, type: :int64
+
   field :field16762, 2, optional: true, type: :float
+
   field :field16763, 3, optional: true, type: :int64
+
   field :field16764, 4, optional: true, type: :int64
+
   field :field16765, 5, optional: true, type: :bool
+
   field :field16766, 6, repeated: true, type: :string
+
   field :field16767, 7, repeated: true, type: :string
+
   field :field16768, 8, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field16769, 9, optional: true, type: :bool
+
   field :field16770, 10, optional: true, type: :uint32
+
   field :field16771, 11, optional: true, type: Benchmarks.GoogleMessage3.Enum16728, enum: true
+
   field :field16772, 12, repeated: true, type: :int32
+
   field :field16773, 13, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message17728 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24356 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1338,42 +1632,54 @@ defmodule Benchmarks.GoogleMessage3.Message24356 do
           field24573: [String.t()]
         }
 
-  defstruct [
-    :field24559,
-    :field24560,
-    :field24561,
-    :field24562,
-    :field24563,
-    :field24564,
-    :field24565,
-    :field24566,
-    :field24567,
-    :field24568,
-    :field24569,
-    :field24570,
-    :field24571,
-    :field24572,
-    :field24573
-  ]
+  defstruct field24559: nil,
+            field24560: nil,
+            field24561: nil,
+            field24562: nil,
+            field24563: nil,
+            field24564: nil,
+            field24565: nil,
+            field24566: nil,
+            field24567: nil,
+            field24568: nil,
+            field24569: nil,
+            field24570: nil,
+            field24571: [],
+            field24572: [],
+            field24573: []
 
   field :field24559, 1, optional: true, type: :string
+
   field :field24560, 2, optional: true, type: :string
+
   field :field24561, 14, optional: true, type: :int32
+
   field :field24562, 3, optional: true, type: :string
+
   field :field24563, 4, optional: true, type: :string
+
   field :field24564, 5, optional: true, type: :string
+
   field :field24565, 13, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field24566, 6, optional: true, type: :string
+
   field :field24567, 12, optional: true, type: Benchmarks.GoogleMessage3.Enum24361, enum: true
+
   field :field24568, 7, optional: true, type: :string
+
   field :field24569, 8, optional: true, type: :string
+
   field :field24570, 9, optional: true, type: :string
+
   field :field24571, 10, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24572, 11, repeated: true, type: :string
+
   field :field24573, 15, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24376 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1395,40 +1701,51 @@ defmodule Benchmarks.GoogleMessage3.Message24376 do
           field24602: [String.t()]
         }
 
-  defstruct [
-    :field24589,
-    :field24590,
-    :field24591,
-    :field24592,
-    :field24593,
-    :field24594,
-    :field24595,
-    :field24596,
-    :field24597,
-    :field24598,
-    :field24599,
-    :field24600,
-    :field24601,
-    :field24602
-  ]
+  defstruct field24589: nil,
+            field24590: nil,
+            field24591: nil,
+            field24592: nil,
+            field24593: nil,
+            field24594: nil,
+            field24595: nil,
+            field24596: [],
+            field24597: [],
+            field24598: [],
+            field24599: [],
+            field24600: [],
+            field24601: nil,
+            field24602: []
 
   field :field24589, 1, optional: true, type: :string
+
   field :field24590, 2, optional: true, type: :string
+
   field :field24591, 3, optional: true, type: :string
+
   field :field24592, 4, required: true, type: Benchmarks.GoogleMessage3.Message24377
+
   field :field24593, 5, optional: true, type: Benchmarks.GoogleMessage3.Message24317
+
   field :field24594, 6, optional: true, type: :string
+
   field :field24595, 7, optional: true, type: Benchmarks.GoogleMessage3.Message24378
+
   field :field24596, 8, repeated: true, type: :string
+
   field :field24597, 14, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24598, 9, repeated: true, type: :string
+
   field :field24599, 10, repeated: true, type: :string
+
   field :field24600, 11, repeated: true, type: :string
+
   field :field24601, 12, optional: true, type: :string
+
   field :field24602, 13, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24366 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1451,38 +1768,51 @@ defmodule Benchmarks.GoogleMessage3.Message24366 do
           field24588: [String.t()]
         }
 
-  defstruct [
-    :field24574,
-    :field24575,
-    :field24576,
-    :field24577,
-    :field24578,
-    :field24579,
-    :field24580,
-    :field24581,
-    :field24582,
-    :field24583,
-    :field24584,
-    :field24585,
-    :field24586,
-    :field24587,
-    :field24588
-  ]
+  defstruct field24574: nil,
+            field24575: nil,
+            field24576: nil,
+            field24577: nil,
+            field24578: nil,
+            field24579: nil,
+            field24580: nil,
+            field24581: nil,
+            field24582: nil,
+            field24583: nil,
+            field24584: nil,
+            field24585: nil,
+            field24586: [],
+            field24587: [],
+            field24588: []
 
   field :field24574, 1, optional: true, type: :string
+
   field :field24575, 2, optional: true, type: :string
+
   field :field24576, 3, optional: true, type: :string
+
   field :field24577, 10, optional: true, type: :int32
+
   field :field24578, 13, optional: true, type: :string
+
   field :field24579, 4, optional: true, type: :string
+
   field :field24580, 5, optional: true, type: :string
+
   field :field24581, 9, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field24582, 14, optional: true, type: :string
+
   field :field24583, 15, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field24584, 6, optional: true, type: :string
+
   field :field24585, 12, optional: true, type: :string
+
   field :field24586, 7, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24587, 8, repeated: true, type: :string
+
   field :field24588, 11, repeated: true, type: :string
+
   def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message3/benchmark_message3_4.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_4.pb.ex
@@ -1,12 +1,13 @@
 defmodule Benchmarks.GoogleMessage3.Message24346 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24401 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -15,12 +16,12 @@ defmodule Benchmarks.GoogleMessage3.Message24401 do
           field24679: Benchmarks.GoogleMessage3.Message24400.t() | nil
         }
 
-  defstruct [:field24679]
+  defstruct field24679: nil
 
   field :field24679, 1, optional: true, type: Benchmarks.GoogleMessage3.Message24400
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24402 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -29,12 +30,12 @@ defmodule Benchmarks.GoogleMessage3.Message24402 do
           field24680: Benchmarks.GoogleMessage3.Message24400.t() | nil
         }
 
-  defstruct [:field24680]
+  defstruct field24680: nil
 
   field :field24680, 1, optional: true, type: Benchmarks.GoogleMessage3.Message24400
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24379 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -60,48 +61,63 @@ defmodule Benchmarks.GoogleMessage3.Message24379 do
           field24620: [String.t()]
         }
 
-  defstruct [
-    :field24603,
-    :field24604,
-    :field24605,
-    :field24606,
-    :field24607,
-    :field24608,
-    :field24609,
-    :field24610,
-    :field24611,
-    :field24612,
-    :field24613,
-    :field24614,
-    :field24615,
-    :field24616,
-    :field24617,
-    :field24618,
-    :field24619,
-    :field24620
-  ]
+  defstruct field24603: nil,
+            field24604: nil,
+            field24605: nil,
+            field24606: nil,
+            field24607: nil,
+            field24608: nil,
+            field24609: nil,
+            field24610: [],
+            field24611: [],
+            field24612: [],
+            field24613: [],
+            field24614: [],
+            field24615: nil,
+            field24616: nil,
+            field24617: nil,
+            field24618: [],
+            field24619: [],
+            field24620: []
 
   field :field24603, 1, optional: true, type: :string
+
   field :field24604, 2, optional: true, type: :string
+
   field :field24605, 3, optional: true, type: :string
+
   field :field24606, 4, required: true, type: Benchmarks.GoogleMessage3.Message24380
+
   field :field24607, 5, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24608, 6, optional: true, type: :string
+
   field :field24609, 7, optional: true, type: Benchmarks.GoogleMessage3.Message24381
+
   field :field24610, 8, repeated: true, type: :string
+
   field :field24611, 17, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24612, 9, repeated: true, type: :string
+
   field :field24613, 10, repeated: true, type: :string
+
   field :field24614, 11, repeated: true, type: :string
+
   field :field24615, 14, optional: true, type: :string
+
   field :field24616, 12, optional: true, type: :string
+
   field :field24617, 16, optional: true, type: :string
+
   field :field24618, 13, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24619, 15, repeated: true, type: :string
+
   field :field24620, 18, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message27358 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -111,13 +127,15 @@ defmodule Benchmarks.GoogleMessage3.Message27358 do
           field27416: integer
         }
 
-  defstruct [:field27415, :field27416]
+  defstruct field27415: nil,
+            field27416: nil
 
   field :field27415, 1, optional: true, type: :int32
+
   field :field27416, 2, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message34381 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -135,32 +153,39 @@ defmodule Benchmarks.GoogleMessage3.Message34381 do
           field34407: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field34398,
-    :field34399,
-    :field34400,
-    :field34401,
-    :field34402,
-    :field34403,
-    :field34404,
-    :field34405,
-    :field34406,
-    :field34407
-  ]
+  defstruct field34398: nil,
+            field34399: nil,
+            field34400: nil,
+            field34401: nil,
+            field34402: nil,
+            field34403: nil,
+            field34404: nil,
+            field34405: nil,
+            field34406: nil,
+            field34407: nil
 
   field :field34398, 1, optional: true, type: :string
+
   field :field34399, 2, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field34400, 3, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field34401, 4, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field34402, 5, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field34403, 6, optional: true, type: :bool
+
   field :field34404, 7, optional: true, type: :bool
+
   field :field34405, 8, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field34406, 9, optional: true, type: :bool
+
   field :field34407, 10, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message34619 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -175,26 +200,30 @@ defmodule Benchmarks.GoogleMessage3.Message34619 do
           field34647: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field34641,
-    :field34642,
-    :field34643,
-    :field34644,
-    :field34645,
-    :field34646,
-    :field34647
-  ]
+  defstruct field34641: nil,
+            field34642: nil,
+            field34643: nil,
+            field34644: nil,
+            field34645: nil,
+            field34646: nil,
+            field34647: nil
 
   field :field34641, 1, optional: true, type: :double
+
   field :field34642, 2, optional: true, type: :double
+
   field :field34643, 3, optional: true, type: :double
+
   field :field34644, 4, optional: true, type: :double
+
   field :field34645, 11, optional: true, type: :double
+
   field :field34646, 5, optional: true, type: :double
+
   field :field34647, 100, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message730 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -236,81 +265,111 @@ defmodule Benchmarks.GoogleMessage3.Message730 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field897,
-    :field898,
-    :field899,
-    :field900,
-    :field901,
-    :field902,
-    :field903,
-    :field904,
-    :field905,
-    :field906,
-    :field907,
-    :field908,
-    :field909,
-    :field910,
-    :field911,
-    :field912,
-    :field913,
-    :field914,
-    :field915,
-    :field916,
-    :field917,
-    :field918,
-    :field919,
-    :field920,
-    :field921,
-    :field922,
-    :field923,
-    :field924,
-    :field925,
-    :field926,
-    :field927,
-    :field928,
-    :field929,
-    :__pb_extensions__
-  ]
+  defstruct field897: nil,
+            field898: [],
+            field899: [],
+            field900: [],
+            field901: nil,
+            field902: [],
+            field903: [],
+            field904: [],
+            field905: [],
+            field906: [],
+            field907: [],
+            field908: [],
+            field909: [],
+            field910: nil,
+            field911: nil,
+            field912: nil,
+            field913: [],
+            field914: [],
+            field915: [],
+            field916: [],
+            field917: [],
+            field918: [],
+            field919: nil,
+            field920: [],
+            field921: nil,
+            field922: [],
+            field923: [],
+            field924: nil,
+            field925: nil,
+            field926: nil,
+            field927: nil,
+            field928: [],
+            field929: nil,
+            __pb_extensions__: nil
 
   field :field897, 19, optional: true, type: :string
+
   field :field898, 27, repeated: true, type: :string
+
   field :field899, 28, repeated: true, type: :string
+
   field :field900, 21, repeated: true, type: :string
+
   field :field901, 30, optional: true, type: :string
+
   field :field902, 20, repeated: true, type: :uint32
+
   field :field903, 32, repeated: true, type: :uint32
+
   field :field904, 16, repeated: true, type: :string
+
   field :field905, 6, repeated: true, type: Benchmarks.GoogleMessage3.Message697
+
   field :field906, 7, repeated: true, type: Benchmarks.GoogleMessage3.Message704
+
   field :field907, 18, repeated: true, type: :string
+
   field :field908, 8, repeated: true, type: Benchmarks.GoogleMessage3.Message703
+
   field :field909, 9, repeated: true, type: :string
+
   field :field910, 10, optional: true, type: Benchmarks.GoogleMessage3.Message716
+
   field :field911, 11, optional: true, type: Benchmarks.GoogleMessage3.Message718
+
   field :field912, 14, optional: true, type: :bool
+
   field :field913, 4, repeated: true, type: Benchmarks.GoogleMessage3.Message715
+
   field :field914, 17, repeated: true, type: :string
+
   field :field915, 23, repeated: true, type: :string
+
   field :field916, 24, repeated: true, type: Benchmarks.GoogleMessage3.Message719
+
   field :field917, 26, repeated: true, type: Benchmarks.GoogleMessage3.Message728
+
   field :field918, 35, repeated: true, type: Benchmarks.GoogleMessage3.Message702
+
   field :field919, 36, optional: true, type: :string
+
   field :field920, 37, repeated: true, type: :string
+
   field :field921, 38, optional: true, type: :int64
+
   field :field922, 39, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field923, 1, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field924, 2, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field925, 3, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field926, 5, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field927, 13, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field928, 22, repeated: true, type: :string
+
   field :field929, 31, optional: true, type: :bytes
+
   def transform_module(), do: nil
 
   extensions [{25, 26}, {29, 30}, {34, 35}, {15, 16}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message33958.Message33959 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -324,17 +383,27 @@ defmodule Benchmarks.GoogleMessage3.Message33958.Message33959 do
           field33987: Benchmarks.GoogleMessage3.Message0.t() | nil
         }
 
-  defstruct [:field33982, :field33983, :field33984, :field33985, :field33986, :field33987]
+  defstruct field33982: "",
+            field33983: nil,
+            field33984: nil,
+            field33985: nil,
+            field33986: nil,
+            field33987: nil
 
   field :field33982, 3, required: true, type: :string
+
   field :field33983, 4, optional: true, type: :string
+
   field :field33984, 5, optional: true, type: :string
+
   field :field33985, 8, optional: true, type: :fixed64
+
   field :field33986, 10, optional: true, type: :bool
+
   field :field33987, 6, optional: true, type: Benchmarks.GoogleMessage3.Message0
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message33958 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -346,15 +415,21 @@ defmodule Benchmarks.GoogleMessage3.Message33958 do
           field33980: Benchmarks.GoogleMessage3.Enum33960.t()
         }
 
-  defstruct [:field33977, :field33978, :message33959, :field33980]
+  defstruct field33977: nil,
+            field33978: nil,
+            message33959: [],
+            field33980: nil
 
   field :field33977, 1, optional: true, type: :string
+
   field :field33978, 9, optional: true, type: :string
+
   field :message33959, 2, repeated: true, type: :group
+
   field :field33980, 7, optional: true, type: Benchmarks.GoogleMessage3.Enum33960, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6637 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -367,16 +442,24 @@ defmodule Benchmarks.GoogleMessage3.Message6637 do
           field6674: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [:field6670, :field6671, :field6672, :field6673, :field6674]
+  defstruct field6670: nil,
+            field6671: [],
+            field6672: nil,
+            field6673: [],
+            field6674: nil
 
   field :field6670, 2, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6671, 1, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6672, 3, optional: true, type: :int32
+
   field :field6673, 4, repeated: true, type: :string
+
   field :field6674, 5, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6643 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -402,48 +485,63 @@ defmodule Benchmarks.GoogleMessage3.Message6643 do
           field6700: integer
         }
 
-  defstruct [
-    :field6683,
-    :field6684,
-    :field6685,
-    :field6686,
-    :field6687,
-    :field6688,
-    :field6689,
-    :field6690,
-    :field6691,
-    :field6692,
-    :field6693,
-    :field6694,
-    :field6695,
-    :field6696,
-    :field6697,
-    :field6698,
-    :field6699,
-    :field6700
-  ]
+  defstruct field6683: nil,
+            field6684: nil,
+            field6685: nil,
+            field6686: nil,
+            field6687: nil,
+            field6688: nil,
+            field6689: nil,
+            field6690: nil,
+            field6691: nil,
+            field6692: nil,
+            field6693: nil,
+            field6694: nil,
+            field6695: nil,
+            field6696: nil,
+            field6697: [],
+            field6698: nil,
+            field6699: nil,
+            field6700: nil
 
   field :field6683, 3, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6684, 4, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6685, 5, optional: true, type: :double
+
   field :field6686, 6, optional: true, type: :double
+
   field :field6687, 1, optional: true, type: :int32
+
   field :field6688, 2, optional: true, type: :int32
+
   field :field6689, 9, optional: true, type: :double
+
   field :field6690, 10, optional: true, type: :bytes
+
   field :field6691, 11, optional: true, type: :int32
+
   field :field6692, 12, optional: true, type: :bool
+
   field :field6693, 13, optional: true, type: :bool
+
   field :field6694, 15, optional: true, type: Benchmarks.GoogleMessage3.Message6578
+
   field :field6695, 16, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field6696, 17, optional: true, type: :int64
+
   field :field6697, 22, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6698, 19, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6699, 20, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6700, 21, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6126 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -470,50 +568,66 @@ defmodule Benchmarks.GoogleMessage3.Message6126 do
           field6170: integer
         }
 
-  defstruct [
-    :field6152,
-    :field6153,
-    :field6154,
-    :field6155,
-    :field6156,
-    :field6157,
-    :field6158,
-    :field6159,
-    :field6160,
-    :field6161,
-    :field6162,
-    :field6163,
-    :field6164,
-    :field6165,
-    :field6166,
-    :field6167,
-    :field6168,
-    :field6169,
-    :field6170
-  ]
+  defstruct field6152: "",
+            field6153: [],
+            field6154: nil,
+            field6155: nil,
+            field6156: nil,
+            field6157: nil,
+            field6158: nil,
+            field6159: nil,
+            field6160: [],
+            field6161: [],
+            field6162: [],
+            field6163: [],
+            field6164: nil,
+            field6165: [],
+            field6166: nil,
+            field6167: nil,
+            field6168: nil,
+            field6169: [],
+            field6170: nil
 
   field :field6152, 1, required: true, type: :string
+
   field :field6153, 9, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6154, 14, optional: true, type: :int32
+
   field :field6155, 10, optional: true, type: :bytes
+
   field :field6156, 12, optional: true, type: Benchmarks.GoogleMessage3.Message6024
+
   field :field6157, 4, optional: true, type: :int32
+
   field :field6158, 5, optional: true, type: :string
+
   field :field6159, 6, optional: true, type: :int32
+
   field :field6160, 2, repeated: true, type: :int32
+
   field :field6161, 3, repeated: true, type: :int32
+
   field :field6162, 7, repeated: true, type: Benchmarks.GoogleMessage3.Message6052
+
   field :field6163, 11, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6164, 15, optional: true, type: Benchmarks.GoogleMessage3.Enum6065, enum: true
+
   field :field6165, 8, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field6166, 13, optional: true, type: :bool
+
   field :field6167, 16, optional: true, type: :bool
+
   field :field6168, 18, optional: true, type: :bool
+
   field :field6169, 17, repeated: true, type: Benchmarks.GoogleMessage3.Message6054
+
   field :field6170, 19, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13083.Message13084 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -525,42 +639,51 @@ defmodule Benchmarks.GoogleMessage3.Message13083.Message13084 do
           field13110: [Benchmarks.GoogleMessage3.Enum13092.t()]
         }
 
-  defstruct [:field13107, :field13108, :field13109, :field13110]
+  defstruct field13107: 0.0,
+            field13108: 0,
+            field13109: nil,
+            field13110: []
 
   field :field13107, 3, required: true, type: :float
+
   field :field13108, 4, required: true, type: :int32
+
   field :field13109, 5, optional: true, type: :float
+
   field :field13110, 6, repeated: true, type: Benchmarks.GoogleMessage3.Enum13092, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13083.Message13085 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13083.Message13086 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13083.Message13087 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13083 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -578,32 +701,39 @@ defmodule Benchmarks.GoogleMessage3.Message13083 do
           field13105: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field13096,
-    :message13084,
-    :field13098,
-    :field13099,
-    :field13100,
-    :field13101,
-    :message13085,
-    :message13086,
-    :message13087,
-    :field13105
-  ]
+  defstruct field13096: nil,
+            message13084: [],
+            field13098: nil,
+            field13099: nil,
+            field13100: nil,
+            field13101: nil,
+            message13085: nil,
+            message13086: [],
+            message13087: [],
+            field13105: nil
 
   field :field13096, 1, optional: true, type: :float
+
   field :message13084, 2, repeated: true, type: :group
+
   field :field13098, 44, optional: true, type: :float
+
   field :field13099, 45, optional: true, type: :float
+
   field :field13100, 46, optional: true, type: :uint64
+
   field :field13101, 47, optional: true, type: :float
+
   field :message13085, 16, optional: true, type: :group
+
   field :message13086, 23, repeated: true, type: :group
+
   field :message13087, 29, repeated: true, type: :group
+
   field :field13105, 43, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13088.Message13089 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -613,13 +743,15 @@ defmodule Benchmarks.GoogleMessage3.Message13088.Message13089 do
           field13140: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [:field13139, :field13140]
+  defstruct field13139: "",
+            field13140: nil
 
   field :field13139, 2, required: true, type: :string
+
   field :field13140, 3, optional: true, type: :float
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13088 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -630,14 +762,18 @@ defmodule Benchmarks.GoogleMessage3.Message13088 do
           field13137: boolean
         }
 
-  defstruct [:message13089, :field13136, :field13137]
+  defstruct message13089: [],
+            field13136: nil,
+            field13137: nil
 
   field :message13089, 1, repeated: true, type: :group
+
   field :field13136, 4, optional: true, type: :int64
+
   field :field13137, 5, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10391 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -654,30 +790,36 @@ defmodule Benchmarks.GoogleMessage3.Message10391 do
           field10419: boolean
         }
 
-  defstruct [
-    :field10411,
-    :field10412,
-    :field10413,
-    :field10414,
-    :field10415,
-    :field10416,
-    :field10417,
-    :field10418,
-    :field10419
-  ]
+  defstruct field10411: nil,
+            field10412: nil,
+            field10413: nil,
+            field10414: nil,
+            field10415: nil,
+            field10416: nil,
+            field10417: nil,
+            field10418: nil,
+            field10419: nil
 
   field :field10411, 1, optional: true, type: Benchmarks.GoogleMessage3.Enum10392, enum: true
+
   field :field10412, 2, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field10413, 3, optional: true, type: :int64
+
   field :field10414, 4, optional: true, type: :string
+
   field :field10415, 5, optional: true, type: :string
+
   field :field10416, 6, optional: true, type: :bytes
+
   field :field10417, 8, optional: true, type: :bool
+
   field :field10418, 9, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field10419, 10, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message11873 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -698,39 +840,48 @@ defmodule Benchmarks.GoogleMessage3.Message11873 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field11876,
-    :field11877,
-    :field11878,
-    :field11879,
-    :field11880,
-    :field11881,
-    :field11882,
-    :field11883,
-    :field11884,
-    :field11885,
-    :field11886,
-    :field11887,
-    :__pb_extensions__
-  ]
+  defstruct field11876: nil,
+            field11877: nil,
+            field11878: nil,
+            field11879: nil,
+            field11880: nil,
+            field11881: nil,
+            field11882: nil,
+            field11883: nil,
+            field11884: nil,
+            field11885: nil,
+            field11886: nil,
+            field11887: nil,
+            __pb_extensions__: nil
 
   field :field11876, 1, optional: true, type: :string
+
   field :field11877, 4, optional: true, type: :string
+
   field :field11878, 5, optional: true, type: Benchmarks.GoogleMessage3.Message10573
+
   field :field11879, 6, optional: true, type: Benchmarks.GoogleMessage3.Message10582
+
   field :field11880, 7, optional: true, type: Benchmarks.GoogleMessage3.Message10824
+
   field :field11881, 12, optional: true, type: Benchmarks.GoogleMessage3.Message10773
+
   field :field11882, 8, optional: true, type: Benchmarks.GoogleMessage3.Message11866
+
   field :field11883, 13, optional: true, type: Benchmarks.GoogleMessage3.Message10818
+
   field :field11884, 16, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field11885, 11, optional: true, type: Benchmarks.GoogleMessage3.Message10155
+
   field :field11886, 14, optional: true, type: Benchmarks.GoogleMessage3.Message10469
+
   field :field11887, 15, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 
   extensions [{9, 10}, {10, 11}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message35506 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -742,15 +893,21 @@ defmodule Benchmarks.GoogleMessage3.Message35506 do
           field35527: [Benchmarks.GoogleMessage3.UnusedEmptyMessage.t()]
         }
 
-  defstruct [:field35524, :field35525, :field35526, :field35527]
+  defstruct field35524: nil,
+            field35525: nil,
+            field35526: nil,
+            field35527: []
 
   field :field35524, 1, optional: true, type: :int32
+
   field :field35525, 2, optional: true, type: :string
+
   field :field35526, 3, optional: true, type: Benchmarks.GoogleMessage3.Enum35507, enum: true
+
   field :field35527, 4, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13151 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -759,12 +916,12 @@ defmodule Benchmarks.GoogleMessage3.Message13151 do
           field13158: [Benchmarks.GoogleMessage3.Message13145.t()]
         }
 
-  defstruct [:field13158]
+  defstruct field13158: []
 
   field :field13158, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message13145
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message18253.Message18254 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -774,13 +931,15 @@ defmodule Benchmarks.GoogleMessage3.Message18253.Message18254 do
           field18363: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [:field18362, :field18363]
+  defstruct field18362: 0,
+            field18363: 0.0
 
   field :field18362, 2, required: true, type: :fixed64
+
   field :field18363, 3, required: true, type: :double
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message18253 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -789,12 +948,12 @@ defmodule Benchmarks.GoogleMessage3.Message18253 do
           message18254: [any]
         }
 
-  defstruct [:message18254]
+  defstruct message18254: []
 
   field :message18254, 1, repeated: true, type: :group
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16685 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -803,30 +962,32 @@ defmodule Benchmarks.GoogleMessage3.Message16685 do
           field16694: [Benchmarks.GoogleMessage3.Message16686.t()]
         }
 
-  defstruct [:field16694]
+  defstruct field16694: []
 
   field :field16694, 2, repeated: true, type: Benchmarks.GoogleMessage3.Message16686
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16816.Message16817 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16816.Message16818 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16816 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -844,32 +1005,39 @@ defmodule Benchmarks.GoogleMessage3.Message16816 do
           field16835: boolean
         }
 
-  defstruct [
-    :field16826,
-    :field16827,
-    :field16828,
-    :message16817,
-    :field16830,
-    :field16831,
-    :message16818,
-    :field16833,
-    :field16834,
-    :field16835
-  ]
+  defstruct field16826: nil,
+            field16827: nil,
+            field16828: nil,
+            message16817: [],
+            field16830: nil,
+            field16831: nil,
+            message16818: [],
+            field16833: nil,
+            field16834: nil,
+            field16835: nil
 
   field :field16826, 1, optional: true, type: :float
+
   field :field16827, 2, optional: true, type: Benchmarks.GoogleMessage3.Enum16819, enum: true
+
   field :field16828, 3, optional: true, type: :float
+
   field :message16817, 4, repeated: true, type: :group
+
   field :field16830, 7, optional: true, type: :bool
+
   field :field16831, 8, optional: true, type: :bool
+
   field :message16818, 12, repeated: true, type: :group
+
   field :field16833, 10, optional: true, type: :string
+
   field :field16834, 13, optional: true, type: :bool
+
   field :field16835, 14, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13168 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -888,34 +1056,42 @@ defmodule Benchmarks.GoogleMessage3.Message13168 do
           field13222: integer
         }
 
-  defstruct [
-    :field13212,
-    :field13213,
-    :field13214,
-    :field13215,
-    :field13216,
-    :field13217,
-    :field13218,
-    :field13219,
-    :field13220,
-    :field13221,
-    :field13222
-  ]
+  defstruct field13212: 0,
+            field13213: nil,
+            field13214: nil,
+            field13215: nil,
+            field13216: nil,
+            field13217: nil,
+            field13218: 0.0,
+            field13219: false,
+            field13220: nil,
+            field13221: false,
+            field13222: nil
 
   field :field13212, 1, required: true, type: :int32
+
   field :field13213, 7, optional: true, type: :fixed64
+
   field :field13214, 8, optional: true, type: :bool
+
   field :field13215, 10, optional: true, type: :fixed64
+
   field :field13216, 11, optional: true, type: :bool
+
   field :field13217, 9, optional: true, type: Benchmarks.GoogleMessage3.Message12796
+
   field :field13218, 2, required: true, type: :double
+
   field :field13219, 3, required: true, type: :bool
+
   field :field13220, 4, optional: true, type: :int32
+
   field :field13221, 5, required: true, type: :bool
+
   field :field13222, 6, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13167 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -936,38 +1112,48 @@ defmodule Benchmarks.GoogleMessage3.Message13167 do
           field13211: integer
         }
 
-  defstruct [
-    :field13199,
-    :field13200,
-    :field13201,
-    :field13202,
-    :field13203,
-    :field13204,
-    :field13205,
-    :field13206,
-    :field13207,
-    :field13208,
-    :field13209,
-    :field13210,
-    :field13211
-  ]
+  defstruct field13199: 0,
+            field13200: nil,
+            field13201: nil,
+            field13202: nil,
+            field13203: nil,
+            field13204: nil,
+            field13205: nil,
+            field13206: nil,
+            field13207: nil,
+            field13208: [],
+            field13209: nil,
+            field13210: nil,
+            field13211: nil
 
   field :field13199, 1, required: true, type: :int32
+
   field :field13200, 2, optional: true, type: :int32
+
   field :field13201, 3, optional: true, type: :int32
+
   field :field13202, 8, optional: true, type: :bool
+
   field :field13203, 12, optional: true, type: :fixed64
+
   field :field13204, 13, optional: true, type: :bool
+
   field :field13205, 11, optional: true, type: Benchmarks.GoogleMessage3.Message12796
+
   field :field13206, 9, optional: true, type: :fixed64
+
   field :field13207, 10, optional: true, type: :bool
+
   field :field13208, 4, repeated: true, type: :int32
+
   field :field13209, 5, optional: true, type: :int32
+
   field :field13210, 6, optional: true, type: :int32
+
   field :field13211, 7, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message1374 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -977,31 +1163,35 @@ defmodule Benchmarks.GoogleMessage3.Message1374 do
           field1376: String.t()
         }
 
-  defstruct [:field1375, :field1376]
+  defstruct field1375: "",
+            field1376: nil
 
   field :field1375, 1, required: true, type: :string
+
   field :field1376, 2, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message18943 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message18944 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message18856 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1040,74 +1230,102 @@ defmodule Benchmarks.GoogleMessage3.Message18856 do
           field18887: String.t()
         }
 
-  defstruct [
-    :field18857,
-    :field18858,
-    :field18859,
-    :field18860,
-    :field18861,
-    :field18862,
-    :field18863,
-    :field18864,
-    :field18865,
-    :field18866,
-    :field18867,
-    :field18868,
-    :field18869,
-    :field18870,
-    :field18871,
-    :field18872,
-    :field18873,
-    :field18874,
-    :field18875,
-    :field18876,
-    :field18877,
-    :field18878,
-    :field18879,
-    :field18880,
-    :field18881,
-    :field18882,
-    :field18883,
-    :field18884,
-    :field18885,
-    :field18886,
-    :field18887
-  ]
+  defstruct field18857: nil,
+            field18858: nil,
+            field18859: nil,
+            field18860: nil,
+            field18861: nil,
+            field18862: nil,
+            field18863: nil,
+            field18864: nil,
+            field18865: nil,
+            field18866: nil,
+            field18867: nil,
+            field18868: nil,
+            field18869: nil,
+            field18870: nil,
+            field18871: nil,
+            field18872: nil,
+            field18873: nil,
+            field18874: nil,
+            field18875: nil,
+            field18876: nil,
+            field18877: nil,
+            field18878: nil,
+            field18879: nil,
+            field18880: nil,
+            field18881: nil,
+            field18882: nil,
+            field18883: nil,
+            field18884: nil,
+            field18885: [],
+            field18886: nil,
+            field18887: nil
 
   field :field18857, 1, optional: true, type: :string
+
   field :field18858, 2, optional: true, type: :string
+
   field :field18859, 31, optional: true, type: :bool
+
   field :field18860, 26, optional: true, type: :string
+
   field :field18861, 3, optional: true, type: :string
+
   field :field18862, 4, optional: true, type: :string
+
   field :field18863, 5, optional: true, type: :string
+
   field :field18864, 17, optional: true, type: :string
+
   field :field18865, 6, optional: true, type: :string
+
   field :field18866, 7, optional: true, type: :string
+
   field :field18867, 8, optional: true, type: :string
+
   field :field18868, 9, optional: true, type: :string
+
   field :field18869, 10, optional: true, type: :string
+
   field :field18870, 11, optional: true, type: :string
+
   field :field18871, 21, optional: true, type: :string
+
   field :field18872, 18, optional: true, type: :string
+
   field :field18873, 19, optional: true, type: :string
+
   field :field18874, 20, optional: true, type: :string
+
   field :field18875, 22, optional: true, type: :string
+
   field :field18876, 23, optional: true, type: :string
+
   field :field18877, 24, optional: true, type: :string
+
   field :field18878, 25, optional: true, type: :string
+
   field :field18879, 12, optional: true, type: :string
+
   field :field18880, 13, optional: true, type: :string
+
   field :field18881, 29, optional: true, type: :string
+
   field :field18882, 30, optional: true, type: :string
+
   field :field18883, 15, optional: true, type: :string
+
   field :field18884, 16, optional: true, type: :string
+
   field :field18885, 14, repeated: true, type: :string
+
   field :field18886, 27, optional: true, type: :string
+
   field :field18887, 28, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message3850 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1121,17 +1339,27 @@ defmodule Benchmarks.GoogleMessage3.Message3850 do
           field3929: boolean
         }
 
-  defstruct [:field3924, :field3925, :field3926, :field3927, :field3928, :field3929]
+  defstruct field3924: nil,
+            field3925: nil,
+            field3926: nil,
+            field3927: nil,
+            field3928: nil,
+            field3929: nil
 
   field :field3924, 2, optional: true, type: Benchmarks.GoogleMessage3.Enum3851, enum: true
+
   field :field3925, 12, optional: true, type: :bool
+
   field :field3926, 4, optional: true, type: :int32
+
   field :field3927, 10, optional: true, type: :bool
+
   field :field3928, 13, optional: true, type: :bool
+
   field :field3929, 14, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6721 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1143,15 +1371,21 @@ defmodule Benchmarks.GoogleMessage3.Message6721 do
           field6747: boolean
         }
 
-  defstruct [:field6744, :field6745, :field6746, :field6747]
+  defstruct field6744: nil,
+            field6745: nil,
+            field6746: nil,
+            field6747: nil
 
   field :field6744, 1, optional: true, type: Benchmarks.GoogleMessage3.Message6722
+
   field :field6745, 2, optional: true, type: :bool
+
   field :field6746, 3, optional: true, type: :bool
+
   field :field6747, 4, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6742 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1160,12 +1394,12 @@ defmodule Benchmarks.GoogleMessage3.Message6742 do
           field6758: boolean
         }
 
-  defstruct [:field6758]
+  defstruct field6758: nil
 
   field :field6758, 1, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6726 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1175,13 +1409,15 @@ defmodule Benchmarks.GoogleMessage3.Message6726 do
           field6753: [Benchmarks.GoogleMessage3.Message6727.t()]
         }
 
-  defstruct [:field6752, :field6753]
+  defstruct field6752: nil,
+            field6753: []
 
   field :field6752, 1, optional: true, type: :int64
+
   field :field6753, 2, repeated: true, type: Benchmarks.GoogleMessage3.Message6727
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6733 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1192,14 +1428,18 @@ defmodule Benchmarks.GoogleMessage3.Message6733 do
           field6756: boolean
         }
 
-  defstruct [:field6754, :field6755, :field6756]
+  defstruct field6754: nil,
+            field6755: nil,
+            field6756: nil
 
   field :field6754, 1, optional: true, type: :int64
+
   field :field6755, 2, optional: true, type: :int64
+
   field :field6756, 3, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6723 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1209,13 +1449,15 @@ defmodule Benchmarks.GoogleMessage3.Message6723 do
           field6749: [Benchmarks.GoogleMessage3.Message6724.t()]
         }
 
-  defstruct [:field6748, :field6749]
+  defstruct field6748: nil,
+            field6749: []
 
   field :field6748, 1, optional: true, type: :int64
+
   field :field6749, 2, repeated: true, type: Benchmarks.GoogleMessage3.Message6724
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6725 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1225,13 +1467,15 @@ defmodule Benchmarks.GoogleMessage3.Message6725 do
           field6751: integer
         }
 
-  defstruct [:field6750, :field6751]
+  defstruct field6750: nil,
+            field6751: nil
 
   field :field6750, 1, optional: true, type: :int32
+
   field :field6751, 2, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6734 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1240,12 +1484,12 @@ defmodule Benchmarks.GoogleMessage3.Message6734 do
           field6757: [Benchmarks.GoogleMessage3.Message6735.t()]
         }
 
-  defstruct [:field6757]
+  defstruct field6757: []
 
   field :field6757, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message6735
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8184 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1256,14 +1500,18 @@ defmodule Benchmarks.GoogleMessage3.Message8184 do
           field8230: [Benchmarks.GoogleMessage3.Message8183.t()]
         }
 
-  defstruct [:field8228, :field8229, :field8230]
+  defstruct field8228: nil,
+            field8229: nil,
+            field8230: []
 
   field :field8228, 1, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   field :field8229, 2, optional: true, type: :bool
+
   field :field8230, 3, repeated: true, type: Benchmarks.GoogleMessage3.Message8183
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8477 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1274,14 +1522,18 @@ defmodule Benchmarks.GoogleMessage3.Message8477 do
           field8488: String.t()
         }
 
-  defstruct [:field8486, :field8487, :field8488]
+  defstruct field8486: nil,
+            field8487: nil,
+            field8488: nil
 
   field :field8486, 1, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   field :field8487, 2, optional: true, type: :int64
+
   field :field8488, 3, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8454 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1293,15 +1545,21 @@ defmodule Benchmarks.GoogleMessage3.Message8454 do
           field8468: boolean
         }
 
-  defstruct [:field8465, :field8466, :field8467, :field8468]
+  defstruct field8465: nil,
+            field8466: nil,
+            field8467: nil,
+            field8468: nil
 
   field :field8465, 1, optional: true, type: Benchmarks.GoogleMessage3.Message8449
+
   field :field8466, 3, optional: true, type: :int64
+
   field :field8467, 4, optional: true, type: :int32
+
   field :field8468, 5, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8476 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1312,14 +1570,18 @@ defmodule Benchmarks.GoogleMessage3.Message8476 do
           field8485: String.t()
         }
 
-  defstruct [:field8483, :field8484, :field8485]
+  defstruct field8483: nil,
+            field8484: nil,
+            field8485: nil
 
   field :field8483, 1, optional: true, type: :string
+
   field :field8484, 2, optional: true, type: :string
+
   field :field8485, 3, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8455 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1331,15 +1593,21 @@ defmodule Benchmarks.GoogleMessage3.Message8455 do
           field8473: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [:field8470, :field8471, :field8472, :field8473]
+  defstruct field8470: nil,
+            field8471: [],
+            field8472: nil,
+            field8473: nil
 
   field :field8470, 1, optional: true, type: Benchmarks.GoogleMessage3.Message8449
+
   field :field8471, 2, repeated: true, type: Benchmarks.GoogleMessage3.Message8456
+
   field :field8472, 5, optional: true, type: Benchmarks.GoogleMessage3.Message8457
+
   field :field8473, 6, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8475 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1349,22 +1617,25 @@ defmodule Benchmarks.GoogleMessage3.Message8475 do
           field8482: integer
         }
 
-  defstruct [:field8481, :field8482]
+  defstruct field8481: nil,
+            field8482: nil
 
   field :field8481, 1, optional: true, type: :string
+
   field :field8482, 2, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message12559 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message12817 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1375,14 +1646,18 @@ defmodule Benchmarks.GoogleMessage3.Message12817 do
           field12828: integer
         }
 
-  defstruct [:field12826, :field12827, :field12828]
+  defstruct field12826: nil,
+            field12827: nil,
+            field12828: nil
 
   field :field12826, 1, optional: true, type: :int32
+
   field :field12827, 2, optional: true, type: :int32
+
   field :field12828, 3, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16480 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1399,30 +1674,36 @@ defmodule Benchmarks.GoogleMessage3.Message16480 do
           field16498: non_neg_integer
         }
 
-  defstruct [
-    :field16490,
-    :field16491,
-    :field16492,
-    :field16493,
-    :field16494,
-    :field16495,
-    :field16496,
-    :field16497,
-    :field16498
-  ]
+  defstruct field16490: nil,
+            field16491: nil,
+            field16492: nil,
+            field16493: nil,
+            field16494: nil,
+            field16495: nil,
+            field16496: nil,
+            field16497: nil,
+            field16498: nil
 
   field :field16490, 1, optional: true, type: Benchmarks.GoogleMessage3.Message13358
+
   field :field16491, 2, optional: true, type: Benchmarks.GoogleMessage3.Enum16042, enum: true
+
   field :field16492, 3, optional: true, type: Benchmarks.GoogleMessage3.Message13912
+
   field :field16493, 4, optional: true, type: :string
+
   field :field16494, 5, optional: true, type: :string
+
   field :field16495, 6, optional: true, type: :string
+
   field :field16496, 7, optional: true, type: :string
+
   field :field16497, 8, optional: true, type: Benchmarks.GoogleMessage3.Message13358
+
   field :field16498, 9, optional: true, type: :fixed32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24317 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1459,81 +1740,107 @@ defmodule Benchmarks.GoogleMessage3.Message24317 do
           field24474: boolean
         }
 
-  defstruct [
-    :field24446,
-    :field24447,
-    :field24448,
-    :field24449,
-    :field24450,
-    :field24451,
-    :field24452,
-    :field24453,
-    :field24454,
-    :field24455,
-    :field24456,
-    :field24457,
-    :field24458,
-    :field24459,
-    :field24460,
-    :field24461,
-    :field24462,
-    :field24463,
-    :field24464,
-    :field24465,
-    :field24466,
-    :field24467,
-    :field24468,
-    :field24469,
-    :field24470,
-    :field24471,
-    :field24472,
-    :field24473,
-    :field24474
-  ]
+  defstruct field24446: nil,
+            field24447: nil,
+            field24448: [],
+            field24449: [],
+            field24450: [],
+            field24451: [],
+            field24452: nil,
+            field24453: [],
+            field24454: [],
+            field24455: [],
+            field24456: [],
+            field24457: nil,
+            field24458: nil,
+            field24459: nil,
+            field24460: nil,
+            field24461: [],
+            field24462: nil,
+            field24463: [],
+            field24464: [],
+            field24465: [],
+            field24466: [],
+            field24467: [],
+            field24468: [],
+            field24469: [],
+            field24470: [],
+            field24471: nil,
+            field24472: nil,
+            field24473: [],
+            field24474: nil
 
   field :field24446, 1, optional: true, type: :string
+
   field :field24447, 2, optional: true, type: Benchmarks.GoogleMessage3.Message24312
+
   field :field24448, 3, repeated: true, type: Benchmarks.GoogleMessage3.Message24315
+
   field :field24449, 4, repeated: true, type: Benchmarks.GoogleMessage3.Message24313
+
   field :field24450, 5, repeated: true, type: Benchmarks.GoogleMessage3.Message24316
+
   field :field24451, 6, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24452, 7, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field24453, 8, repeated: true, type: :string
+
   field :field24454, 9, repeated: true, type: :string
+
   field :field24455, 10, repeated: true, type: :string
+
   field :field24456, 28, repeated: true, type: :string
+
   field :field24457, 11, optional: true, type: :string
+
   field :field24458, 12, optional: true, type: :string
+
   field :field24459, 13, optional: true, type: :string
+
   field :field24460, 14, optional: true, type: :string
+
   field :field24461, 15, repeated: true, type: :string
+
   field :field24462, 16, optional: true, type: :string
+
   field :field24463, 17, repeated: true, type: :string
+
   field :field24464, 18, repeated: true, type: :string
+
   field :field24465, 19, repeated: true, type: :string
+
   field :field24466, 20, repeated: true, type: :string
+
   field :field24467, 21, repeated: true, type: :string
+
   field :field24468, 22, repeated: true, type: :string
+
   field :field24469, 23, repeated: true, type: :string
+
   field :field24470, 24, repeated: true, type: :string
+
   field :field24471, 25, optional: true, type: :string
+
   field :field24472, 26, optional: true, type: :string
+
   field :field24473, 27, repeated: true, type: :string
+
   field :field24474, 40, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.PbExtension do
   @moduledoc false
   use Protobuf, syntax: :proto2
 
-  extend Benchmarks.GoogleMessage3.Message0, :"Message33958.field33981", 10_747_482,
-    optional: true,
-    type: Benchmarks.GoogleMessage3.Message33958
-
   extend Benchmarks.GoogleMessage3.Message8301, :"Message8454.field8469", 66,
     optional: true,
     type: Benchmarks.GoogleMessage3.Message8454
+
+  extend Benchmarks.GoogleMessage3.Message0, :"Message33958.field33981", 10_747_482,
+    optional: true,
+    type: Benchmarks.GoogleMessage3.Message33958
 
   extend Benchmarks.GoogleMessage3.Message8302, :"Message8455.field8474", 66,
     optional: true,

--- a/bench/lib/datasets/google_message3/benchmark_message3_5.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_5.pb.ex
@@ -1,21 +1,23 @@
 defmodule Benchmarks.GoogleMessage3.Message24377 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24378 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24400 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -28,34 +30,44 @@ defmodule Benchmarks.GoogleMessage3.Message24400 do
           field24678: integer
         }
 
-  defstruct [:field24674, :field24675, :field24676, :field24677, :field24678]
+  defstruct field24674: nil,
+            field24675: nil,
+            field24676: nil,
+            field24677: nil,
+            field24678: nil
 
   field :field24674, 1, optional: true, type: :int32
+
   field :field24675, 2, optional: true, type: :int32
+
   field :field24676, 3, optional: true, type: :int32
+
   field :field24677, 4, optional: true, type: :int32
+
   field :field24678, 5, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24380 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24381 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message719 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -67,15 +79,21 @@ defmodule Benchmarks.GoogleMessage3.Message719 do
           field884: Benchmarks.GoogleMessage3.Enum720.t()
         }
 
-  defstruct [:field881, :field882, :field883, :field884]
+  defstruct field881: [],
+            field882: [],
+            field883: [],
+            field884: nil
 
   field :field881, 1, repeated: true, type: :string
+
   field :field882, 2, repeated: true, type: :string
+
   field :field883, 3, repeated: true, type: :string
+
   field :field884, 4, optional: true, type: Benchmarks.GoogleMessage3.Enum720, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message728 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -93,33 +111,39 @@ defmodule Benchmarks.GoogleMessage3.Message728 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field887,
-    :field888,
-    :field889,
-    :field890,
-    :field891,
-    :field892,
-    :field893,
-    :field894,
-    :field895,
-    :__pb_extensions__
-  ]
+  defstruct field887: "",
+            field888: [],
+            field889: [],
+            field890: [],
+            field891: [],
+            field892: [],
+            field893: nil,
+            field894: nil,
+            field895: [],
+            __pb_extensions__: nil
 
   field :field887, 1, required: true, type: :string
+
   field :field888, 2, repeated: true, type: :string
+
   field :field889, 3, repeated: true, type: Benchmarks.GoogleMessage3.Message703
+
   field :field890, 4, repeated: true, type: Benchmarks.GoogleMessage3.Message715
+
   field :field891, 5, repeated: true, type: :string
+
   field :field892, 6, repeated: true, type: :string
+
   field :field893, 7, optional: true, type: Benchmarks.GoogleMessage3.Message718
+
   field :field894, 8, optional: true, type: Benchmarks.GoogleMessage3.Message716
+
   field :field895, 9, repeated: true, type: :string
+
   def transform_module(), do: nil
 
   extensions [{10, 11}, {11, 12}, {12, 13}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message704 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -134,18 +158,30 @@ defmodule Benchmarks.GoogleMessage3.Message704 do
           field806: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [:field800, :field801, :field802, :field803, :field804, :field805, :field806]
+  defstruct field800: nil,
+            field801: nil,
+            field802: nil,
+            field803: nil,
+            field804: nil,
+            field805: nil,
+            field806: nil
 
   field :field800, 1, optional: true, type: :string
+
   field :field801, 7, optional: true, type: :string
+
   field :field802, 2, optional: true, type: :string
+
   field :field803, 3, optional: true, type: :string
+
   field :field804, 4, optional: true, type: :string
+
   field :field805, 5, optional: true, type: :string
+
   field :field806, 6, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message697 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -190,98 +226,134 @@ defmodule Benchmarks.GoogleMessage3.Message697 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field743,
-    :field744,
-    :field745,
-    :field746,
-    :field747,
-    :field748,
-    :field749,
-    :field750,
-    :field751,
-    :field752,
-    :field753,
-    :field754,
-    :field755,
-    :field756,
-    :field757,
-    :field758,
-    :field759,
-    :field760,
-    :field761,
-    :field762,
-    :field763,
-    :field764,
-    :field765,
-    :field766,
-    :field767,
-    :field768,
-    :field769,
-    :field770,
-    :field771,
-    :field772,
-    :field773,
-    :field774,
-    :field775,
-    :field776,
-    :field777,
-    :field778,
-    :__pb_extensions__
-  ]
+  defstruct field743: nil,
+            field744: [],
+            field745: [],
+            field746: [],
+            field747: [],
+            field748: [],
+            field749: [],
+            field750: [],
+            field751: [],
+            field752: [],
+            field753: [],
+            field754: [],
+            field755: [],
+            field756: [],
+            field757: [],
+            field758: [],
+            field759: [],
+            field760: [],
+            field761: [],
+            field762: [],
+            field763: [],
+            field764: nil,
+            field765: [],
+            field766: [],
+            field767: nil,
+            field768: nil,
+            field769: nil,
+            field770: nil,
+            field771: nil,
+            field772: [],
+            field773: [],
+            field774: [],
+            field775: [],
+            field776: [],
+            field777: [],
+            field778: nil,
+            __pb_extensions__: nil
 
   field :field743, 7, optional: true, type: :string
+
   field :field744, 1, repeated: true, type: :string
+
   field :field745, 2, repeated: true, type: :string
+
   field :field746, 33, repeated: true, type: :string
+
   field :field747, 29, repeated: true, type: :string
+
   field :field748, 30, repeated: true, type: :string
+
   field :field749, 31, repeated: true, type: :string
+
   field :field750, 32, repeated: true, type: :string
+
   field :field751, 13, repeated: true, type: :string
+
   field :field752, 6, repeated: true, type: :string
+
   field :field753, 3, repeated: true, type: :string
+
   field :field754, 14, repeated: true, type: :string
+
   field :field755, 15, repeated: true, type: :string
+
   field :field756, 16, repeated: true, type: :string
+
   field :field757, 4, repeated: true, type: :string
+
   field :field758, 34, repeated: true, type: :string
+
   field :field759, 35, repeated: true, type: :string
+
   field :field760, 5, repeated: true, type: :string
+
   field :field761, 17, repeated: true, type: :string
+
   field :field762, 18, repeated: true, type: :string
+
   field :field763, 19, repeated: true, type: :string
+
   field :field764, 36, optional: true, type: :bool
+
   field :field765, 8, repeated: true, type: :string
+
   field :field766, 9, repeated: true, type: :string
+
   field :field767, 27, optional: true, type: :string
+
   field :field768, 25, optional: true, type: :bool
+
   field :field769, 10, optional: true, type: Benchmarks.GoogleMessage3.Message700
+
   field :field770, 11, optional: true, type: :bool
+
   field :field771, 24, optional: true, type: :bool
+
   field :field772, 12, repeated: true, type: :string
+
   field :field773, 20, repeated: true, type: :string
+
   field :field774, 21, repeated: true, type: :string
+
   field :field775, 22, repeated: true, type: :string
+
   field :field776, 23, repeated: true, type: Benchmarks.GoogleMessage3.Message699
+
   field :field777, 37, repeated: true, type: Benchmarks.GoogleMessage3.Message698
+
   field :field778, 38, optional: true, type: :int64
+
   def transform_module(), do: nil
 
   extensions [{28, 29}, {26, 27}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message0 do
   @moduledoc false
   use Protobuf, syntax: :proto2
-  @type t :: %__MODULE__{__pb_extensions__: map}
-  defstruct [:__pb_extensions__]
+
+  @type t :: %__MODULE__{
+          __pb_extensions__: map
+        }
+
+  defstruct __pb_extensions__: nil
 
   def transform_module(), do: nil
 
   extensions [{4, 2_147_483_647}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6578 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -291,13 +363,15 @@ defmodule Benchmarks.GoogleMessage3.Message6578 do
           field6633: Benchmarks.GoogleMessage3.Enum6588.t()
         }
 
-  defstruct [:field6632, :field6633]
+  defstruct field6632: nil,
+            field6633: nil
 
   field :field6632, 1, optional: true, type: Benchmarks.GoogleMessage3.Enum6579, enum: true
+
   field :field6633, 2, optional: true, type: Benchmarks.GoogleMessage3.Enum6588, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6024 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -308,14 +382,18 @@ defmodule Benchmarks.GoogleMessage3.Message6024 do
           field6050: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [:field6048, :field6049, :field6050]
+  defstruct field6048: nil,
+            field6049: nil,
+            field6050: nil
 
   field :field6048, 1, optional: true, type: Benchmarks.GoogleMessage3.Enum6025, enum: true
+
   field :field6049, 2, optional: true, type: :string
+
   field :field6050, 3, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6052 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -325,13 +403,15 @@ defmodule Benchmarks.GoogleMessage3.Message6052 do
           field6085: binary
         }
 
-  defstruct [:field6084, :field6085]
+  defstruct field6084: "",
+            field6085: ""
 
   field :field6084, 1, required: true, type: :string
+
   field :field6085, 2, required: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6054 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -341,13 +421,15 @@ defmodule Benchmarks.GoogleMessage3.Message6054 do
           field6090: String.t()
         }
 
-  defstruct [:field6089, :field6090]
+  defstruct field6089: "",
+            field6090: nil
 
   field :field6089, 1, required: true, type: :string
+
   field :field6090, 2, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10573 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -358,15 +440,18 @@ defmodule Benchmarks.GoogleMessage3.Message10573 do
           __pb_extensions__: map
         }
 
-  defstruct [:field10580, :field10581, :__pb_extensions__]
+  defstruct field10580: [],
+            field10581: nil,
+            __pb_extensions__: nil
 
   field :field10580, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message10576
+
   field :field10581, 2, optional: true, type: :string
+
   def transform_module(), do: nil
 
   extensions [{10000, 536_870_912}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10824 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -376,13 +461,15 @@ defmodule Benchmarks.GoogleMessage3.Message10824 do
           field10826: integer
         }
 
-  defstruct [:field10825, :field10826]
+  defstruct field10825: "",
+            field10826: nil
 
   field :field10825, 1, required: true, type: :string
+
   field :field10826, 2, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10582 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -396,17 +483,27 @@ defmodule Benchmarks.GoogleMessage3.Message10582 do
           field10588: boolean
         }
 
-  defstruct [:field10583, :field10584, :field10585, :field10586, :field10587, :field10588]
+  defstruct field10583: false,
+            field10584: 0.0,
+            field10585: nil,
+            field10586: nil,
+            field10587: nil,
+            field10588: nil
 
   field :field10583, 1, required: true, type: :bool
+
   field :field10584, 2, required: true, type: :double
+
   field :field10585, 3, optional: true, type: :bool
+
   field :field10586, 4, optional: true, type: :double
+
   field :field10587, 5, optional: true, type: :double
+
   field :field10588, 6, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10155.Message10156 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -418,15 +515,21 @@ defmodule Benchmarks.GoogleMessage3.Message10155.Message10156 do
           field10269: integer
         }
 
-  defstruct [:field10266, :field10267, :field10268, :field10269]
+  defstruct field10266: nil,
+            field10267: nil,
+            field10268: nil,
+            field10269: nil
 
   field :field10266, 51, optional: true, type: Benchmarks.GoogleMessage3.Enum8862, enum: true
+
   field :field10267, 52, optional: true, type: :int32
+
   field :field10268, 53, optional: true, type: :int32
+
   field :field10269, 54, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10155 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -505,119 +608,156 @@ defmodule Benchmarks.GoogleMessage3.Message10155 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field10195,
-    :field10196,
-    :field10197,
-    :field10198,
-    :field10199,
-    :field10200,
-    :message10156,
-    :field10202,
-    :field10203,
-    :field10204,
-    :field10205,
-    :field10206,
-    :field10207,
-    :field10208,
-    :field10209,
-    :field10210,
-    :field10211,
-    :field10212,
-    :field10213,
-    :field10214,
-    :field10215,
-    :field10216,
-    :field10217,
-    :field10218,
-    :field10219,
-    :field10220,
-    :field10221,
-    :field10222,
-    :field10223,
-    :field10224,
-    :field10225,
-    :field10226,
-    :field10227,
-    :field10228,
-    :field10229,
-    :field10230,
-    :field10231,
-    :field10232,
-    :field10233,
-    :field10234,
-    :field10235,
-    :field10236,
-    :field10237,
-    :field10238,
-    :field10239,
-    :field10240,
-    :field10241,
-    :field10242,
-    :field10243,
-    :field10244,
-    :field10245,
-    :field10246,
-    :field10247,
-    :field10248,
-    :field10249,
-    :field10250,
-    :field10251,
-    :field10252,
-    :field10253,
-    :field10254,
-    :field10255,
-    :field10256,
-    :field10257,
-    :field10258,
-    :field10259,
-    :field10260,
-    :field10261,
-    :field10262,
-    :field10263,
-    :field10264,
-    :__pb_extensions__
-  ]
+  defstruct field10195: 0,
+            field10196: 0,
+            field10197: nil,
+            field10198: nil,
+            field10199: nil,
+            field10200: nil,
+            message10156: [],
+            field10202: nil,
+            field10203: nil,
+            field10204: nil,
+            field10205: nil,
+            field10206: nil,
+            field10207: nil,
+            field10208: nil,
+            field10209: nil,
+            field10210: nil,
+            field10211: nil,
+            field10212: nil,
+            field10213: nil,
+            field10214: nil,
+            field10215: nil,
+            field10216: nil,
+            field10217: nil,
+            field10218: nil,
+            field10219: nil,
+            field10220: nil,
+            field10221: [],
+            field10222: nil,
+            field10223: nil,
+            field10224: [],
+            field10225: nil,
+            field10226: nil,
+            field10227: nil,
+            field10228: nil,
+            field10229: nil,
+            field10230: nil,
+            field10231: nil,
+            field10232: nil,
+            field10233: nil,
+            field10234: nil,
+            field10235: [],
+            field10236: nil,
+            field10237: nil,
+            field10238: nil,
+            field10239: [],
+            field10240: nil,
+            field10241: nil,
+            field10242: nil,
+            field10243: nil,
+            field10244: [],
+            field10245: nil,
+            field10246: nil,
+            field10247: nil,
+            field10248: nil,
+            field10249: nil,
+            field10250: nil,
+            field10251: nil,
+            field10252: nil,
+            field10253: nil,
+            field10254: nil,
+            field10255: nil,
+            field10256: nil,
+            field10257: nil,
+            field10258: nil,
+            field10259: nil,
+            field10260: nil,
+            field10261: nil,
+            field10262: nil,
+            field10263: nil,
+            field10264: [],
+            __pb_extensions__: nil
 
   field :field10195, 1, required: true, type: :int32
+
   field :field10196, 2, required: true, type: :int32
+
   field :field10197, 59, optional: true, type: Benchmarks.GoogleMessage3.Enum10157, enum: true
+
   field :field10198, 18, optional: true, type: :int32
+
   field :field10199, 19, optional: true, type: :int32
+
   field :field10200, 21, optional: true, type: :int32
+
   field :message10156, 50, repeated: true, type: :group
+
   field :field10202, 3, optional: true, type: :int32
+
   field :field10203, 4, optional: true, type: :int32
+
   field :field10204, 5, optional: true, type: :int32
+
   field :field10205, 84, optional: true, type: :bool
+
   field :field10206, 33, optional: true, type: :bool
+
   field :field10207, 75, optional: true, type: :int32
+
   field :field10208, 26, optional: true, type: :float
+
   field :field10209, 27, optional: true, type: :int32
+
   field :field10210, 49, optional: true, type: :int32
+
   field :field10211, 10, optional: true, type: :int32
+
   field :field10212, 78, optional: true, type: :float
+
   field :field10213, 91, optional: true, type: Benchmarks.GoogleMessage3.Message9151
+
   field :field10214, 11, optional: true, type: :int32
+
   field :field10215, 12, optional: true, type: :int32
+
   field :field10216, 41, optional: true, type: :float
+
   field :field10217, 61, optional: true, type: Benchmarks.GoogleMessage3.Message10154
+
   field :field10218, 23, optional: true, type: :int32
+
   field :field10219, 24, optional: true, type: :bytes
+
   field :field10220, 65, optional: true, type: :int32
+
   field :field10221, 66, repeated: true, type: :bytes
+
   field :field10222, 70, optional: true, type: :int32
+
   field :field10223, 71, optional: true, type: :bytes
+
   field :field10224, 73, repeated: true, type: :fixed64
+
   field :field10225, 29, optional: true, type: :float
+
   field :field10226, 30, optional: true, type: :int32
+
   field :field10227, 31, optional: true, type: :float
+
   field :field10228, 32, optional: true, type: :int32
+
   field :field10229, 34, optional: true, type: :float
+
   field :field10230, 35, optional: true, type: :int32
+
   field :field10231, 22, optional: true, type: :string
+
   field :field10232, 13, optional: true, type: :fixed64
+
   field :field10233, 20, optional: true, type: :fixed64
+
   field :field10234, 79, optional: true, type: :bool
 
   field :field10235, 80,
@@ -627,39 +767,67 @@ defmodule Benchmarks.GoogleMessage3.Message10155 do
     packed: true
 
   field :field10236, 14, optional: true, type: :int32
+
   field :field10237, 15, optional: true, type: :int32
+
   field :field10238, 28, optional: true, type: :int32
+
   field :field10239, 16, repeated: true, type: :string
+
   field :field10240, 17, optional: true, type: Benchmarks.GoogleMessage3.Message9182
+
   field :field10241, 63, optional: true, type: :int32
+
   field :field10242, 64, optional: true, type: :float
+
   field :field10243, 37, optional: true, type: :float
+
   field :field10244, 43, repeated: true, type: :float
+
   field :field10245, 44, optional: true, type: :int32
+
   field :field10246, 45, optional: true, type: Benchmarks.GoogleMessage3.Message9242
+
   field :field10247, 46, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field10248, 62, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field10249, 48, optional: true, type: Benchmarks.GoogleMessage3.Message8944
+
   field :field10250, 87, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field10251, 58, optional: true, type: :int32
+
   field :field10252, 92, optional: true, type: :int32
+
   field :field10253, 93, optional: true, type: Benchmarks.GoogleMessage3.Message9123
+
   field :field10254, 60, optional: true, type: Benchmarks.GoogleMessage3.Message9160
+
   field :field10255, 67, optional: true, type: Benchmarks.GoogleMessage3.Message8890
+
   field :field10256, 69, optional: true, type: :string
+
   field :field10257, 74, optional: true, type: :int64
+
   field :field10258, 82, optional: true, type: :float
+
   field :field10259, 85, optional: true, type: :float
+
   field :field10260, 86, optional: true, type: :float
+
   field :field10261, 83, optional: true, type: :int64
+
   field :field10262, 77, optional: true, type: :string
+
   field :field10263, 88, optional: true, type: :bool
+
   field :field10264, 94, repeated: true, type: Benchmarks.GoogleMessage3.Message9628
+
   def transform_module(), do: nil
 
   extensions [{57, 58}, {1000, 536_870_912}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message11866 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -672,16 +840,24 @@ defmodule Benchmarks.GoogleMessage3.Message11866 do
           field11872: [Benchmarks.GoogleMessage3.UnusedEmptyMessage.t()]
         }
 
-  defstruct [:field11868, :field11869, :field11870, :field11871, :field11872]
+  defstruct field11868: nil,
+            field11869: nil,
+            field11870: nil,
+            field11871: nil,
+            field11872: []
 
   field :field11868, 1, required: true, type: Benchmarks.GoogleMessage3.Message11014
+
   field :field11869, 2, optional: true, type: :bool
+
   field :field11870, 3, optional: true, type: :double
+
   field :field11871, 4, optional: true, type: :double
+
   field :field11872, 5, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10469 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -698,30 +874,36 @@ defmodule Benchmarks.GoogleMessage3.Message10469 do
           field10481: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [
-    :field10473,
-    :field10474,
-    :field10475,
-    :field10476,
-    :field10477,
-    :field10478,
-    :field10479,
-    :field10480,
-    :field10481
-  ]
+  defstruct field10473: nil,
+            field10474: nil,
+            field10475: nil,
+            field10476: nil,
+            field10477: nil,
+            field10478: nil,
+            field10479: nil,
+            field10480: nil,
+            field10481: nil
 
   field :field10473, 1, optional: true, type: :string
+
   field :field10474, 2, optional: true, type: :float
+
   field :field10475, 3, optional: true, type: :int32
+
   field :field10476, 4, optional: true, type: :int32
+
   field :field10477, 5, optional: true, type: :int32
+
   field :field10478, 6, optional: true, type: :bool
+
   field :field10479, 7, optional: true, type: :bool
+
   field :field10480, 8, optional: true, type: :int32
+
   field :field10481, 9, optional: true, type: :float
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10818 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -731,13 +913,15 @@ defmodule Benchmarks.GoogleMessage3.Message10818 do
           field10820: Benchmarks.GoogleMessage3.Message10801.t() | nil
         }
 
-  defstruct [:field10819, :field10820]
+  defstruct field10819: nil,
+            field10820: nil
 
   field :field10819, 1, optional: true, type: Benchmarks.GoogleMessage3.Message10800
+
   field :field10820, 2, optional: true, type: Benchmarks.GoogleMessage3.Message10801
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10773 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -768,58 +952,78 @@ defmodule Benchmarks.GoogleMessage3.Message10773 do
           field10796: Benchmarks.GoogleMessage3.UnusedEnum.t()
         }
 
-  defstruct [
-    :field10774,
-    :field10775,
-    :field10776,
-    :field10777,
-    :field10778,
-    :field10779,
-    :field10780,
-    :field10781,
-    :field10782,
-    :field10783,
-    :field10784,
-    :field10785,
-    :field10786,
-    :field10787,
-    :field10788,
-    :field10789,
-    :field10790,
-    :field10791,
-    :field10792,
-    :field10793,
-    :field10794,
-    :field10795,
-    :field10796
-  ]
+  defstruct field10774: nil,
+            field10775: nil,
+            field10776: nil,
+            field10777: nil,
+            field10778: nil,
+            field10779: nil,
+            field10780: nil,
+            field10781: nil,
+            field10782: nil,
+            field10783: nil,
+            field10784: nil,
+            field10785: nil,
+            field10786: [],
+            field10787: nil,
+            field10788: nil,
+            field10789: nil,
+            field10790: nil,
+            field10791: nil,
+            field10792: nil,
+            field10793: nil,
+            field10794: nil,
+            field10795: nil,
+            field10796: nil
 
   field :field10774, 9, optional: true, type: :bool
+
   field :field10775, 1, optional: true, type: :bool
+
   field :field10776, 23, optional: true, type: :bool
+
   field :field10777, 2, optional: true, type: :bool
+
   field :field10778, 3, optional: true, type: :bool
+
   field :field10779, 4, optional: true, type: :int32
+
   field :field10780, 5, optional: true, type: :int32
+
   field :field10781, 6, optional: true, type: :int32
+
   field :field10782, 7, optional: true, type: :int32
+
   field :field10783, 8, optional: true, type: :int32
+
   field :field10784, 10, optional: true, type: :int32
+
   field :field10785, 11, optional: true, type: Benchmarks.GoogleMessage3.Message10749
+
   field :field10786, 12, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field10787, 13, optional: true, type: :bool
+
   field :field10788, 15, optional: true, type: :bool
+
   field :field10789, 16, optional: true, type: :bool
+
   field :field10790, 17, optional: true, type: :int32
+
   field :field10791, 18, optional: true, type: :int32
+
   field :field10792, 19, optional: true, type: :bool
+
   field :field10793, 20, optional: true, type: :bool
+
   field :field10794, 21, optional: true, type: :bool
+
   field :field10795, 14, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field10796, 22, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13145 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -831,25 +1035,31 @@ defmodule Benchmarks.GoogleMessage3.Message13145 do
           __pb_extensions__: map
         }
 
-  defstruct [:field13155, :field13156, :field13157, :__pb_extensions__]
+  defstruct field13155: 0,
+            field13156: nil,
+            field13157: nil,
+            __pb_extensions__: nil
 
   field :field13155, 1, required: true, type: Benchmarks.GoogleMessage3.Enum13146, enum: true
+
   field :field13156, 2, optional: true, type: :float
+
   field :field13157, 3, optional: true, type: :float
+
   def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message16686 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message12796 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -859,49 +1069,55 @@ defmodule Benchmarks.GoogleMessage3.Message12796 do
           field12801: non_neg_integer
         }
 
-  defstruct [:field12800, :field12801]
+  defstruct field12800: [],
+            field12801: nil
 
   field :field12800, 1, repeated: true, type: :fixed64
+
   field :field12801, 2, optional: true, type: :uint64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6722 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6727 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6724 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message6735 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8183 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -911,13 +1127,15 @@ defmodule Benchmarks.GoogleMessage3.Message8183 do
           field8227: String.t()
         }
 
-  defstruct [:field8226, :field8227]
+  defstruct field8226: nil,
+            field8227: nil
 
   field :field8226, 1, optional: true, type: :string
+
   field :field8227, 2, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8301 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -937,46 +1155,55 @@ defmodule Benchmarks.GoogleMessage3.Message8301 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field8328,
-    :field8329,
-    :field8330,
-    :field8331,
-    :field8332,
-    :field8333,
-    :field8334,
-    :field8335,
-    :field8336,
-    :field8337,
-    :field8338,
-    :__pb_extensions__
-  ]
+  defstruct field8328: nil,
+            field8329: nil,
+            field8330: nil,
+            field8331: nil,
+            field8332: [],
+            field8333: nil,
+            field8334: [],
+            field8335: nil,
+            field8336: nil,
+            field8337: nil,
+            field8338: nil,
+            __pb_extensions__: nil
 
   field :field8328, 1, optional: true, type: :string
+
   field :field8329, 2, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   field :field8330, 3, optional: true, type: :string
+
   field :field8331, 4, optional: true, type: :string
+
   field :field8332, 5, repeated: true, type: Benchmarks.GoogleMessage3.Message8290
+
   field :field8333, 6, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   field :field8334, 7, repeated: true, type: Benchmarks.GoogleMessage3.Message8298
+
   field :field8335, 8, optional: true, type: Benchmarks.GoogleMessage3.Message8300
+
   field :field8336, 9, optional: true, type: :int64
+
   field :field8337, 10, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8338, 11, optional: true, type: Benchmarks.GoogleMessage3.Message7965
+
   def transform_module(), do: nil
 
   extensions [{64, 536_870_912}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8456 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8302 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1006,66 +1233,85 @@ defmodule Benchmarks.GoogleMessage3.Message8302 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field8339,
-    :field8340,
-    :field8341,
-    :field8342,
-    :field8343,
-    :field8344,
-    :field8345,
-    :field8346,
-    :field8347,
-    :field8348,
-    :field8349,
-    :field8350,
-    :field8351,
-    :field8352,
-    :field8353,
-    :field8354,
-    :field8355,
-    :field8356,
-    :field8357,
-    :field8358,
-    :field8359,
-    :__pb_extensions__
-  ]
+  defstruct field8339: nil,
+            field8340: nil,
+            field8341: nil,
+            field8342: nil,
+            field8343: nil,
+            field8344: nil,
+            field8345: nil,
+            field8346: nil,
+            field8347: nil,
+            field8348: [],
+            field8349: nil,
+            field8350: nil,
+            field8351: nil,
+            field8352: nil,
+            field8353: nil,
+            field8354: nil,
+            field8355: nil,
+            field8356: [],
+            field8357: [],
+            field8358: [],
+            field8359: nil,
+            __pb_extensions__: nil
 
   field :field8339, 1, optional: true, type: :string
+
   field :field8340, 2, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   field :field8341, 3, optional: true, type: :string
+
   field :field8342, 4, optional: true, type: :string
+
   field :field8343, 5, optional: true, type: :string
+
   field :field8344, 6, optional: true, type: :string
+
   field :field8345, 7, optional: true, type: :string
+
   field :field8346, 8, optional: true, type: :int64
+
   field :field8347, 9, optional: true, type: :int64
+
   field :field8348, 10, repeated: true, type: Benchmarks.GoogleMessage3.Message8290
+
   field :field8349, 11, optional: true, type: :string
+
   field :field8350, 12, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8351, 13, optional: true, type: Benchmarks.GoogleMessage3.Message8291
+
   field :field8352, 14, optional: true, type: :int64
+
   field :field8353, 15, optional: true, type: Benchmarks.GoogleMessage3.Message8296
+
   field :field8354, 16, optional: true, type: :string
+
   field :field8355, 17, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8356, 18, repeated: true, type: :int32
+
   field :field8357, 19, repeated: true, type: :int32
+
   field :field8358, 20, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field8359, 21, optional: true, type: Benchmarks.GoogleMessage3.Message7965
+
   def transform_module(), do: nil
 
   extensions [{64, 536_870_912}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8457 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8449 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1080,18 +1326,30 @@ defmodule Benchmarks.GoogleMessage3.Message8449 do
           field8464: Benchmarks.GoogleMessage3.Message7966.t() | nil
         }
 
-  defstruct [:field8458, :field8459, :field8460, :field8461, :field8462, :field8463, :field8464]
+  defstruct field8458: nil,
+            field8459: nil,
+            field8460: nil,
+            field8461: [],
+            field8462: nil,
+            field8463: nil,
+            field8464: nil
 
   field :field8458, 1, optional: true, type: :string
+
   field :field8459, 2, optional: true, type: :bool
+
   field :field8460, 3, optional: true, type: Benchmarks.GoogleMessage3.Enum8450, enum: true
+
   field :field8461, 4, repeated: true, type: :string
+
   field :field8462, 5, optional: true, type: :string
+
   field :field8463, 6, optional: true, type: :string
+
   field :field8464, 7, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13358 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1102,14 +1360,18 @@ defmodule Benchmarks.GoogleMessage3.Message13358 do
           field13361: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [:field13359, :field13360, :field13361]
+  defstruct field13359: 0,
+            field13360: 0,
+            field13361: nil
 
   field :field13359, 1, required: true, type: :fixed64
+
   field :field13360, 2, required: true, type: :fixed64
+
   field :field13361, 3, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message13912 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1121,15 +1383,21 @@ defmodule Benchmarks.GoogleMessage3.Message13912 do
           field13916: Benchmarks.GoogleMessage3.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [:field13913, :field13914, :field13915, :field13916]
+  defstruct field13913: 0,
+            field13914: 0,
+            field13915: nil,
+            field13916: nil
 
   field :field13913, 1, required: true, type: :fixed32
+
   field :field13914, 2, required: true, type: :fixed32
+
   field :field13915, 500, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field13916, 15, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24316 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1140,14 +1408,18 @@ defmodule Benchmarks.GoogleMessage3.Message24316 do
           field24445: [String.t()]
         }
 
-  defstruct [:field24443, :field24444, :field24445]
+  defstruct field24443: [],
+            field24444: [],
+            field24445: []
 
   field :field24443, 1, repeated: true, type: :string
+
   field :field24444, 2, repeated: true, type: :string
+
   field :field24445, 3, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24312 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1161,17 +1433,27 @@ defmodule Benchmarks.GoogleMessage3.Message24312 do
           field24426: [String.t()]
         }
 
-  defstruct [:field24421, :field24422, :field24423, :field24424, :field24425, :field24426]
+  defstruct field24421: nil,
+            field24422: nil,
+            field24423: [],
+            field24424: [],
+            field24425: [],
+            field24426: []
 
   field :field24421, 1, optional: true, type: :string
+
   field :field24422, 2, optional: true, type: :string
+
   field :field24423, 3, repeated: true, type: :string
+
   field :field24424, 4, repeated: true, type: :string
+
   field :field24425, 5, repeated: true, type: :string
+
   field :field24426, 6, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24313 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1189,32 +1471,39 @@ defmodule Benchmarks.GoogleMessage3.Message24313 do
           field24436: [String.t()]
         }
 
-  defstruct [
-    :field24427,
-    :field24428,
-    :field24429,
-    :field24430,
-    :field24431,
-    :field24432,
-    :field24433,
-    :field24434,
-    :field24435,
-    :field24436
-  ]
+  defstruct field24427: nil,
+            field24428: nil,
+            field24429: [],
+            field24430: nil,
+            field24431: nil,
+            field24432: nil,
+            field24433: nil,
+            field24434: [],
+            field24435: nil,
+            field24436: []
 
   field :field24427, 1, optional: true, type: :string
+
   field :field24428, 2, optional: true, type: :string
+
   field :field24429, 3, repeated: true, type: :string
+
   field :field24430, 4, optional: true, type: :string
+
   field :field24431, 5, optional: true, type: :string
+
   field :field24432, 6, optional: true, type: :string
+
   field :field24433, 7, optional: true, type: :string
+
   field :field24434, 8, repeated: true, type: :string
+
   field :field24435, 9, optional: true, type: :string
+
   field :field24436, 10, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message24315 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1225,14 +1514,18 @@ defmodule Benchmarks.GoogleMessage3.Message24315 do
           field24442: [String.t()]
         }
 
-  defstruct [:field24440, :field24441, :field24442]
+  defstruct field24440: "",
+            field24441: [],
+            field24442: []
 
   field :field24440, 1, required: true, type: :string
+
   field :field24441, 2, repeated: true, type: :string
+
   field :field24442, 3, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message716 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1244,15 +1537,21 @@ defmodule Benchmarks.GoogleMessage3.Message716 do
           field875: Benchmarks.GoogleMessage3.Message717.t() | nil
         }
 
-  defstruct [:field872, :field873, :field874, :field875]
+  defstruct field872: "",
+            field873: 0,
+            field874: nil,
+            field875: nil
 
   field :field872, 1, required: true, type: :string
+
   field :field873, 2, required: true, type: :int32
+
   field :field874, 3, optional: true, type: :bool
+
   field :field875, 4, optional: true, type: Benchmarks.GoogleMessage3.Message717
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message718 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1263,14 +1562,18 @@ defmodule Benchmarks.GoogleMessage3.Message718 do
           field880: String.t()
         }
 
-  defstruct [:field878, :field879, :field880]
+  defstruct field878: [],
+            field879: [],
+            field880: nil
 
   field :field878, 1, repeated: true, type: :string
+
   field :field879, 2, repeated: true, type: :string
+
   field :field880, 3, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message703 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1283,16 +1586,24 @@ defmodule Benchmarks.GoogleMessage3.Message703 do
           field799: [String.t()]
         }
 
-  defstruct [:field795, :field796, :field797, :field798, :field799]
+  defstruct field795: "",
+            field796: [],
+            field797: [],
+            field798: nil,
+            field799: []
 
   field :field795, 1, required: true, type: :string
+
   field :field796, 2, repeated: true, type: :string
+
   field :field797, 3, repeated: true, type: :string
+
   field :field798, 4, optional: true, type: :string
+
   field :field799, 5, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message715 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1313,38 +1624,48 @@ defmodule Benchmarks.GoogleMessage3.Message715 do
           field871: [Benchmarks.GoogleMessage3.Message706.t()]
         }
 
-  defstruct [
-    :field859,
-    :field860,
-    :field861,
-    :field862,
-    :field863,
-    :field864,
-    :field865,
-    :field866,
-    :field867,
-    :field868,
-    :field869,
-    :field870,
-    :field871
-  ]
+  defstruct field859: "",
+            field860: nil,
+            field861: [],
+            field862: [],
+            field863: [],
+            field864: [],
+            field865: [],
+            field866: [],
+            field867: [],
+            field868: [],
+            field869: [],
+            field870: [],
+            field871: []
 
   field :field859, 1, required: true, type: :string
+
   field :field860, 7, optional: true, type: :string
+
   field :field861, 2, repeated: true, type: Benchmarks.GoogleMessage3.Message707
+
   field :field862, 3, repeated: true, type: Benchmarks.GoogleMessage3.Message708
+
   field :field863, 4, repeated: true, type: Benchmarks.GoogleMessage3.Message711
+
   field :field864, 5, repeated: true, type: Benchmarks.GoogleMessage3.Message712
+
   field :field865, 6, repeated: true, type: Benchmarks.GoogleMessage3.Message713
+
   field :field866, 8, repeated: true, type: Benchmarks.GoogleMessage3.Message714
+
   field :field867, 9, repeated: true, type: Benchmarks.GoogleMessage3.Message710
+
   field :field868, 10, repeated: true, type: Benchmarks.GoogleMessage3.Message709
+
   field :field869, 11, repeated: true, type: Benchmarks.GoogleMessage3.Message705
+
   field :field870, 12, repeated: true, type: Benchmarks.GoogleMessage3.Message702
+
   field :field871, 13, repeated: true, type: Benchmarks.GoogleMessage3.Message706
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message700 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1354,13 +1675,15 @@ defmodule Benchmarks.GoogleMessage3.Message700 do
           field790: [String.t()]
         }
 
-  defstruct [:field789, :field790]
+  defstruct field789: [],
+            field790: []
 
   field :field789, 1, repeated: true, type: :string
+
   field :field790, 2, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message699 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1370,13 +1693,15 @@ defmodule Benchmarks.GoogleMessage3.Message699 do
           field788: [String.t()]
         }
 
-  defstruct [:field787, :field788]
+  defstruct field787: "",
+            field788: []
 
   field :field787, 1, required: true, type: :string
+
   field :field788, 2, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message698 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1392,24 +1717,30 @@ defmodule Benchmarks.GoogleMessage3.Message698 do
           field786: [String.t()]
         }
 
-  defstruct [
-    :field779,
-    :field780,
-    :field781,
-    :field782,
-    :field783,
-    :field784,
-    :field785,
-    :field786
-  ]
+  defstruct field779: nil,
+            field780: nil,
+            field781: nil,
+            field782: nil,
+            field783: nil,
+            field784: nil,
+            field785: nil,
+            field786: []
 
   field :field779, 1, optional: true, type: :string
+
   field :field780, 2, optional: true, type: :string
+
   field :field781, 3, optional: true, type: :string
+
   field :field782, 4, optional: true, type: :string
+
   field :field783, 5, optional: true, type: :uint64
+
   field :field784, 6, optional: true, type: :uint32
+
   field :field785, 7, optional: true, type: :int64
+
   field :field786, 8, repeated: true, type: :string
+
   def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message3/benchmark_message3_6.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_6.pb.ex
@@ -1,12 +1,13 @@
 defmodule Benchmarks.GoogleMessage3.Message10576 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10154 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -16,13 +17,15 @@ defmodule Benchmarks.GoogleMessage3.Message10154 do
           field10193: integer
         }
 
-  defstruct [:field10192, :field10193]
+  defstruct field10192: nil,
+            field10193: nil
 
   field :field10192, 1, optional: true, type: :bytes
+
   field :field10193, 2, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8944 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -92,136 +95,195 @@ defmodule Benchmarks.GoogleMessage3.Message8944 do
           field9106: integer
         }
 
-  defstruct [
-    :field9045,
-    :field9046,
-    :field9047,
-    :field9048,
-    :field9049,
-    :field9050,
-    :field9051,
-    :field9052,
-    :field9053,
-    :field9054,
-    :field9055,
-    :field9056,
-    :field9057,
-    :field9058,
-    :field9059,
-    :field9060,
-    :field9061,
-    :field9062,
-    :field9063,
-    :field9064,
-    :field9065,
-    :field9066,
-    :field9067,
-    :field9068,
-    :field9069,
-    :field9070,
-    :field9071,
-    :field9072,
-    :field9073,
-    :field9074,
-    :field9075,
-    :field9076,
-    :field9077,
-    :field9078,
-    :field9079,
-    :field9080,
-    :field9081,
-    :field9082,
-    :field9083,
-    :field9084,
-    :field9085,
-    :field9086,
-    :field9087,
-    :field9088,
-    :field9089,
-    :field9090,
-    :field9091,
-    :field9092,
-    :field9093,
-    :field9094,
-    :field9095,
-    :field9096,
-    :field9097,
-    :field9098,
-    :field9099,
-    :field9100,
-    :field9101,
-    :field9102,
-    :field9103,
-    :field9104,
-    :field9105,
-    :field9106
-  ]
+  defstruct field9045: nil,
+            field9046: nil,
+            field9047: nil,
+            field9048: nil,
+            field9049: nil,
+            field9050: nil,
+            field9051: nil,
+            field9052: nil,
+            field9053: nil,
+            field9054: nil,
+            field9055: nil,
+            field9056: nil,
+            field9057: nil,
+            field9058: nil,
+            field9059: nil,
+            field9060: nil,
+            field9061: nil,
+            field9062: nil,
+            field9063: nil,
+            field9064: nil,
+            field9065: nil,
+            field9066: nil,
+            field9067: nil,
+            field9068: nil,
+            field9069: nil,
+            field9070: nil,
+            field9071: nil,
+            field9072: nil,
+            field9073: nil,
+            field9074: nil,
+            field9075: nil,
+            field9076: nil,
+            field9077: nil,
+            field9078: nil,
+            field9079: nil,
+            field9080: nil,
+            field9081: nil,
+            field9082: nil,
+            field9083: nil,
+            field9084: nil,
+            field9085: nil,
+            field9086: nil,
+            field9087: nil,
+            field9088: nil,
+            field9089: nil,
+            field9090: nil,
+            field9091: nil,
+            field9092: nil,
+            field9093: nil,
+            field9094: nil,
+            field9095: nil,
+            field9096: nil,
+            field9097: nil,
+            field9098: nil,
+            field9099: nil,
+            field9100: nil,
+            field9101: nil,
+            field9102: nil,
+            field9103: nil,
+            field9104: nil,
+            field9105: nil,
+            field9106: nil
 
   field :field9045, 2, optional: true, type: :string
+
   field :field9046, 3, optional: true, type: :string
+
   field :field9047, 23, optional: true, type: :string
+
   field :field9048, 52, optional: true, type: :string
+
   field :field9049, 53, optional: true, type: :int32
+
   field :field9050, 54, optional: true, type: :int32
+
   field :field9051, 55, optional: true, type: :float
+
   field :field9052, 56, optional: true, type: :float
+
   field :field9053, 57, optional: true, type: :string
+
   field :field9054, 1, optional: true, type: :int64
+
   field :field9055, 4, optional: true, type: :bool
+
   field :field9056, 5, optional: true, type: :int32
+
   field :field9057, 6, optional: true, type: :int32
+
   field :field9058, 7, optional: true, type: :int32
+
   field :field9059, 8, optional: true, type: :float
+
   field :field9060, 11, optional: true, type: :float
+
   field :field9061, 9, optional: true, type: :float
+
   field :field9062, 10, optional: true, type: :float
+
   field :field9063, 13, optional: true, type: :float
+
   field :field9064, 14, optional: true, type: :bool
+
   field :field9065, 70, optional: true, type: :float
+
   field :field9066, 71, optional: true, type: :int32
+
   field :field9067, 15, optional: true, type: Benchmarks.GoogleMessage3.Enum8945, enum: true
+
   field :field9068, 16, optional: true, type: :int32
+
   field :field9069, 17, optional: true, type: :int32
+
   field :field9070, 18, optional: true, type: :float
+
   field :field9071, 19, optional: true, type: :float
+
   field :field9072, 28, optional: true, type: :int32
+
   field :field9073, 29, optional: true, type: :int32
+
   field :field9074, 60, optional: true, type: :float
+
   field :field9075, 61, optional: true, type: :float
+
   field :field9076, 72, optional: true, type: :int32
+
   field :field9077, 73, optional: true, type: :int32
+
   field :field9078, 62, optional: true, type: Benchmarks.GoogleMessage3.Enum8951, enum: true
+
   field :field9079, 20, optional: true, type: :string
+
   field :field9080, 21, optional: true, type: :string
+
   field :field9081, 22, optional: true, type: :string
+
   field :field9082, 31, optional: true, type: :double
+
   field :field9083, 32, optional: true, type: :double
+
   field :field9084, 33, optional: true, type: :double
+
   field :field9085, 36, optional: true, type: :double
+
   field :field9086, 37, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field9087, 38, optional: true, type: :double
+
   field :field9088, 39, optional: true, type: :double
+
   field :field9089, 63, optional: true, type: :double
+
   field :field9090, 64, optional: true, type: :double
+
   field :field9091, 65, optional: true, type: :double
+
   field :field9092, 34, optional: true, type: :double
+
   field :field9093, 35, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field9094, 66, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field9095, 40, optional: true, type: :string
+
   field :field9096, 41, optional: true, type: :string
+
   field :field9097, 42, optional: true, type: :string
+
   field :field9098, 43, optional: true, type: :string
+
   field :field9099, 44, optional: true, type: :string
+
   field :field9100, 45, optional: true, type: :string
+
   field :field9101, 46, optional: true, type: :string
+
   field :field9102, 47, optional: true, type: :string
+
   field :field9103, 48, optional: true, type: :string
+
   field :field9104, 49, optional: true, type: :string
+
   field :field9105, 100, optional: true, type: Benchmarks.GoogleMessage3.Message8939
+
   field :field9106, 101, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message9182 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -256,67 +318,90 @@ defmodule Benchmarks.GoogleMessage3.Message9182 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field9205,
-    :field9206,
-    :field9207,
-    :field9208,
-    :field9209,
-    :field9210,
-    :field9211,
-    :field9212,
-    :field9213,
-    :field9214,
-    :field9215,
-    :field9216,
-    :field9217,
-    :field9218,
-    :field9219,
-    :field9220,
-    :field9221,
-    :field9222,
-    :field9223,
-    :field9224,
-    :field9225,
-    :field9226,
-    :field9227,
-    :field9228,
-    :field9229,
-    :field9230,
-    :__pb_extensions__
-  ]
+  defstruct field9205: nil,
+            field9206: nil,
+            field9207: nil,
+            field9208: nil,
+            field9209: nil,
+            field9210: nil,
+            field9211: nil,
+            field9212: nil,
+            field9213: nil,
+            field9214: nil,
+            field9215: [],
+            field9216: [],
+            field9217: [],
+            field9218: nil,
+            field9219: nil,
+            field9220: nil,
+            field9221: nil,
+            field9222: nil,
+            field9223: nil,
+            field9224: nil,
+            field9225: nil,
+            field9226: nil,
+            field9227: nil,
+            field9228: nil,
+            field9229: nil,
+            field9230: nil,
+            __pb_extensions__: nil
 
   field :field9205, 1, optional: true, type: :string
+
   field :field9206, 2, optional: true, type: :string
+
   field :field9207, 16, optional: true, type: :float
+
   field :field9208, 17, optional: true, type: :int32
+
   field :field9209, 27, optional: true, type: :int32
+
   field :field9210, 7, optional: true, type: :int32
+
   field :field9211, 8, optional: true, type: :int32
+
   field :field9212, 26, optional: true, type: :float
+
   field :field9213, 22, optional: true, type: :float
+
   field :field9214, 28, optional: true, type: :bool
+
   field :field9215, 21, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field9216, 25, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field9217, 29, repeated: true, type: Benchmarks.GoogleMessage3.Message9181
+
   field :field9218, 18, optional: true, type: :bool
+
   field :field9219, 19, optional: true, type: :bool
+
   field :field9220, 20, optional: true, type: :bool
+
   field :field9221, 30, optional: true, type: Benchmarks.GoogleMessage3.Message9164
+
   field :field9222, 31, optional: true, type: Benchmarks.GoogleMessage3.Message9165
+
   field :field9223, 32, optional: true, type: Benchmarks.GoogleMessage3.Message9166
+
   field :field9224, 33, optional: true, type: :float
+
   field :field9225, 34, optional: true, type: Benchmarks.GoogleMessage3.Message9151
+
   field :field9226, 35, optional: true, type: :float
+
   field :field9227, 36, optional: true, type: :float
+
   field :field9228, 37, optional: true, type: :float
+
   field :field9229, 38, optional: true, type: :float
+
   field :field9230, 39, optional: true, type: :float
+
   def transform_module(), do: nil
 
   extensions [{3, 7}, {9, 16}, {23, 24}, {24, 25}, {1000, 536_870_912}]
 end
-
 defmodule Benchmarks.GoogleMessage3.Message9160 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -326,13 +411,15 @@ defmodule Benchmarks.GoogleMessage3.Message9160 do
           field9162: binary
         }
 
-  defstruct [:field9161, :field9162]
+  defstruct field9161: nil,
+            field9162: nil
 
   field :field9161, 1, optional: true, type: :int32
+
   field :field9162, 2, optional: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message9242 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -341,12 +428,12 @@ defmodule Benchmarks.GoogleMessage3.Message9242 do
           field9327: [Benchmarks.GoogleMessage3.Enum9243.t()]
         }
 
-  defstruct [:field9327]
+  defstruct field9327: []
 
   field :field9327, 1, repeated: true, type: Benchmarks.GoogleMessage3.Enum9243, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8890 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -355,12 +442,12 @@ defmodule Benchmarks.GoogleMessage3.Message8890 do
           field8916: [Benchmarks.GoogleMessage3.Message8888.t()]
         }
 
-  defstruct [:field8916]
+  defstruct field8916: []
 
   field :field8916, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message8888
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message9123 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -369,12 +456,12 @@ defmodule Benchmarks.GoogleMessage3.Message9123 do
           field9135: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [:field9135]
+  defstruct field9135: nil
 
   field :field9135, 1, optional: true, type: :float
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message9628 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -386,15 +473,21 @@ defmodule Benchmarks.GoogleMessage3.Message9628 do
           field9676: integer
         }
 
-  defstruct [:field9673, :field9674, :field9675, :field9676]
+  defstruct field9673: nil,
+            field9674: nil,
+            field9675: [],
+            field9676: nil
 
   field :field9673, 1, optional: true, type: Benchmarks.GoogleMessage3.Message9627
+
   field :field9674, 2, optional: true, type: :string
+
   field :field9675, 3, repeated: true, type: :int32
+
   field :field9676, 4, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message11014 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -467,142 +560,204 @@ defmodule Benchmarks.GoogleMessage3.Message11014 do
           field11844: boolean
         }
 
-  defstruct [
-    :field11780,
-    :field11781,
-    :field11782,
-    :field11783,
-    :field11784,
-    :field11785,
-    :field11786,
-    :field11787,
-    :field11788,
-    :field11789,
-    :field11790,
-    :field11791,
-    :field11792,
-    :field11793,
-    :field11794,
-    :field11795,
-    :field11796,
-    :field11797,
-    :field11798,
-    :field11799,
-    :field11800,
-    :field11801,
-    :field11802,
-    :field11803,
-    :field11804,
-    :field11805,
-    :field11806,
-    :field11807,
-    :field11808,
-    :field11809,
-    :field11810,
-    :field11811,
-    :field11812,
-    :field11813,
-    :field11814,
-    :field11815,
-    :field11816,
-    :field11817,
-    :field11818,
-    :field11819,
-    :field11820,
-    :field11821,
-    :field11822,
-    :field11823,
-    :field11824,
-    :field11825,
-    :field11826,
-    :field11827,
-    :field11828,
-    :field11829,
-    :field11830,
-    :field11831,
-    :field11832,
-    :field11833,
-    :field11834,
-    :field11835,
-    :field11836,
-    :field11837,
-    :field11838,
-    :field11839,
-    :field11840,
-    :field11841,
-    :field11842,
-    :field11843,
-    :field11844
-  ]
+  defstruct field11780: nil,
+            field11781: nil,
+            field11782: nil,
+            field11783: nil,
+            field11784: nil,
+            field11785: nil,
+            field11786: nil,
+            field11787: nil,
+            field11788: nil,
+            field11789: nil,
+            field11790: nil,
+            field11791: nil,
+            field11792: nil,
+            field11793: nil,
+            field11794: nil,
+            field11795: nil,
+            field11796: nil,
+            field11797: nil,
+            field11798: nil,
+            field11799: nil,
+            field11800: nil,
+            field11801: nil,
+            field11802: nil,
+            field11803: nil,
+            field11804: nil,
+            field11805: nil,
+            field11806: nil,
+            field11807: [],
+            field11808: nil,
+            field11809: nil,
+            field11810: nil,
+            field11811: nil,
+            field11812: nil,
+            field11813: nil,
+            field11814: nil,
+            field11815: nil,
+            field11816: nil,
+            field11817: nil,
+            field11818: nil,
+            field11819: nil,
+            field11820: nil,
+            field11821: nil,
+            field11822: nil,
+            field11823: nil,
+            field11824: nil,
+            field11825: nil,
+            field11826: [],
+            field11827: [],
+            field11828: nil,
+            field11829: nil,
+            field11830: nil,
+            field11831: nil,
+            field11832: nil,
+            field11833: nil,
+            field11834: nil,
+            field11835: nil,
+            field11836: nil,
+            field11837: nil,
+            field11838: nil,
+            field11839: nil,
+            field11840: nil,
+            field11841: nil,
+            field11842: nil,
+            field11843: nil,
+            field11844: nil
 
   field :field11780, 40, optional: true, type: :int32
+
   field :field11781, 46, optional: true, type: :string
+
   field :field11782, 47, optional: true, type: :bool
+
   field :field11783, 1, optional: true, type: Benchmarks.GoogleMessage3.Enum11107, enum: true
+
   field :field11784, 2, optional: true, type: :int32
+
   field :field11785, 4, optional: true, type: :double
+
   field :field11786, 5, optional: true, type: :int32
+
   field :field11787, 6, optional: true, type: :int32
+
   field :field11788, 7, optional: true, type: :double
+
   field :field11789, 8, optional: true, type: :double
+
   field :field11790, 9, optional: true, type: :int64
+
   field :field11791, 10, optional: true, type: :bool
+
   field :field11792, 28, optional: true, type: :int64
+
   field :field11793, 37, optional: true, type: :bool
+
   field :field11794, 44, optional: true, type: Benchmarks.GoogleMessage3.Enum11541, enum: true
+
   field :field11795, 49, optional: true, type: :double
+
   field :field11796, 51, optional: true, type: :double
+
   field :field11797, 54, optional: true, type: :int64
+
   field :field11798, 55, optional: true, type: :int64
+
   field :field11799, 57, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field11800, 58, optional: true, type: Benchmarks.GoogleMessage3.Enum11468, enum: true
+
   field :field11801, 59, optional: true, type: :int32
+
   field :field11802, 60, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field11803, 61, optional: true, type: :int32
+
   field :field11804, 62, optional: true, type: :int32
+
   field :field11805, 69, optional: true, type: :int32
+
   field :field11806, 68, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field11807, 71, repeated: true, type: Benchmarks.GoogleMessage3.Message11018
+
   field :field11808, 50, optional: true, type: :bool
+
   field :field11809, 56, optional: true, type: :bool
+
   field :field11810, 66, optional: true, type: :bool
+
   field :field11811, 63, optional: true, type: :bool
+
   field :field11812, 64, optional: true, type: :bool
+
   field :field11813, 65, optional: true, type: :bool
+
   field :field11814, 67, optional: true, type: :bool
+
   field :field11815, 15, optional: true, type: Benchmarks.GoogleMessage3.Enum11107, enum: true
+
   field :field11816, 16, optional: true, type: :int64
+
   field :field11817, 17, optional: true, type: :double
+
   field :field11818, 18, optional: true, type: :int64
+
   field :field11819, 19, optional: true, type: :int32
+
   field :field11820, 20, optional: true, type: :int64
+
   field :field11821, 42, optional: true, type: :int32
+
   field :field11822, 52, optional: true, type: :int64
+
   field :field11823, 53, optional: true, type: :int64
+
   field :field11824, 41, optional: true, type: :int64
+
   field :field11825, 48, optional: true, type: :double
+
   field :field11826, 70, repeated: true, type: Benchmarks.GoogleMessage3.Message11020
+
   field :field11827, 72, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field11828, 25, optional: true, type: :double
+
   field :field11829, 26, optional: true, type: :string
+
   field :field11830, 27, optional: true, type: :int64
+
   field :field11831, 32, optional: true, type: :int64
+
   field :field11832, 33, optional: true, type: :uint64
+
   field :field11833, 29, optional: true, type: :bool
+
   field :field11834, 34, optional: true, type: :bool
+
   field :field11835, 30, optional: true, type: :string
+
   field :field11836, 3, optional: true, type: :int32
+
   field :field11837, 31, optional: true, type: :int32
+
   field :field11838, 73, optional: true, type: :int32
+
   field :field11839, 35, optional: true, type: :int32
+
   field :field11840, 36, optional: true, type: Benchmarks.GoogleMessage3.Enum11022, enum: true
+
   field :field11841, 38, optional: true, type: Benchmarks.GoogleMessage3.Message11013
+
   field :field11842, 39, optional: true, type: :double
+
   field :field11843, 45, optional: true, type: :int32
+
   field :field11844, 74, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10801 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -613,14 +768,18 @@ defmodule Benchmarks.GoogleMessage3.Message10801 do
           field10814: integer
         }
 
-  defstruct [:field10812, :field10813, :field10814]
+  defstruct field10812: nil,
+            field10813: [],
+            field10814: nil
 
   field :field10812, 1, optional: true, type: Benchmarks.GoogleMessage3.Message10800
+
   field :field10813, 2, repeated: true, type: Benchmarks.GoogleMessage3.Message10802
+
   field :field10814, 3, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10749 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -629,12 +788,12 @@ defmodule Benchmarks.GoogleMessage3.Message10749 do
           field10754: [Benchmarks.GoogleMessage3.Message10748.t()]
         }
 
-  defstruct [:field10754]
+  defstruct field10754: []
 
   field :field10754, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message10748
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8298 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -645,14 +804,18 @@ defmodule Benchmarks.GoogleMessage3.Message8298 do
           field8323: String.t()
         }
 
-  defstruct [:field8321, :field8322, :field8323]
+  defstruct field8321: nil,
+            field8322: nil,
+            field8323: nil
 
   field :field8321, 1, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   field :field8322, 2, optional: true, type: :int64
+
   field :field8323, 3, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8300 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -662,13 +825,15 @@ defmodule Benchmarks.GoogleMessage3.Message8300 do
           field8327: Benchmarks.GoogleMessage3.Message7966.t() | nil
         }
 
-  defstruct [:field8326, :field8327]
+  defstruct field8326: nil,
+            field8327: nil
 
   field :field8326, 1, optional: true, type: :string
+
   field :field8327, 2, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8291 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -681,16 +846,24 @@ defmodule Benchmarks.GoogleMessage3.Message8291 do
           field8310: Benchmarks.GoogleMessage3.Enum8292.t()
         }
 
-  defstruct [:field8306, :field8307, :field8308, :field8309, :field8310]
+  defstruct field8306: nil,
+            field8307: nil,
+            field8308: nil,
+            field8309: nil,
+            field8310: nil
 
   field :field8306, 1, optional: true, type: :string
+
   field :field8307, 2, optional: true, type: :int32
+
   field :field8308, 3, optional: true, type: :string
+
   field :field8309, 4, optional: true, type: :string
+
   field :field8310, 5, optional: true, type: Benchmarks.GoogleMessage3.Enum8292, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8296 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -704,17 +877,27 @@ defmodule Benchmarks.GoogleMessage3.Message8296 do
           field8316: String.t()
         }
 
-  defstruct [:field8311, :field8312, :field8313, :field8314, :field8315, :field8316]
+  defstruct field8311: nil,
+            field8312: nil,
+            field8313: nil,
+            field8314: nil,
+            field8315: nil,
+            field8316: nil
 
   field :field8311, 1, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   field :field8312, 2, optional: true, type: :string
+
   field :field8313, 3, optional: true, type: Benchmarks.GoogleMessage3.Message7966
+
   field :field8314, 4, optional: true, type: :int32
+
   field :field8315, 5, optional: true, type: :int32
+
   field :field8316, 6, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7965 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -724,13 +907,15 @@ defmodule Benchmarks.GoogleMessage3.Message7965 do
           field7968: integer
         }
 
-  defstruct [:field7967, :field7968]
+  defstruct field7967: nil,
+            field7968: nil
 
   field :field7967, 1, optional: true, type: :int32
+
   field :field7968, 2, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8290 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -740,13 +925,15 @@ defmodule Benchmarks.GoogleMessage3.Message8290 do
           field8305: String.t()
         }
 
-  defstruct [:field8304, :field8305]
+  defstruct field8304: nil,
+            field8305: nil
 
   field :field8304, 1, optional: true, type: :string
+
   field :field8305, 2, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message717 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -756,13 +943,15 @@ defmodule Benchmarks.GoogleMessage3.Message717 do
           field877: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [:field876, :field877]
+  defstruct field876: [],
+            field877: nil
 
   field :field876, 1, repeated: true, type: :string
+
   field :field877, 2, optional: true, type: :double
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message713 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -772,13 +961,15 @@ defmodule Benchmarks.GoogleMessage3.Message713 do
           field853: [String.t()]
         }
 
-  defstruct [:field852, :field853]
+  defstruct field852: nil,
+            field853: []
 
   field :field852, 1, required: true, type: Benchmarks.GoogleMessage3.Message708
+
   field :field853, 2, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message705 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -793,18 +984,30 @@ defmodule Benchmarks.GoogleMessage3.Message705 do
           field813: [String.t()]
         }
 
-  defstruct [:field807, :field808, :field809, :field810, :field811, :field812, :field813]
+  defstruct field807: "",
+            field808: nil,
+            field809: nil,
+            field810: nil,
+            field811: nil,
+            field812: nil,
+            field813: []
 
   field :field807, 1, required: true, type: :string
+
   field :field808, 2, optional: true, type: :string
+
   field :field809, 3, optional: true, type: :string
+
   field :field810, 4, optional: true, type: :bool
+
   field :field811, 5, optional: true, type: :string
+
   field :field812, 6, optional: true, type: :string
+
   field :field813, 7, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message709 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -817,16 +1020,24 @@ defmodule Benchmarks.GoogleMessage3.Message709 do
           field833: [String.t()]
         }
 
-  defstruct [:field829, :field830, :field831, :field832, :field833]
+  defstruct field829: [],
+            field830: [],
+            field831: [],
+            field832: [],
+            field833: []
 
   field :field829, 1, repeated: true, type: :string
+
   field :field830, 2, repeated: true, type: :string
+
   field :field831, 3, repeated: true, type: :string
+
   field :field832, 4, repeated: true, type: :string
+
   field :field833, 5, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message702 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -836,13 +1047,15 @@ defmodule Benchmarks.GoogleMessage3.Message702 do
           field794: String.t()
         }
 
-  defstruct [:field793, :field794]
+  defstruct field793: nil,
+            field794: nil
 
   field :field793, 1, optional: true, type: :string
+
   field :field794, 2, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message714 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -855,16 +1068,24 @@ defmodule Benchmarks.GoogleMessage3.Message714 do
           field858: non_neg_integer
         }
 
-  defstruct [:field854, :field855, :field856, :field857, :field858]
+  defstruct field854: nil,
+            field855: nil,
+            field856: nil,
+            field857: nil,
+            field858: nil
 
   field :field854, 1, optional: true, type: :string
+
   field :field855, 2, optional: true, type: :string
+
   field :field856, 3, optional: true, type: :string
+
   field :field857, 4, optional: true, type: :string
+
   field :field858, 5, optional: true, type: :uint32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message710 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -877,16 +1098,24 @@ defmodule Benchmarks.GoogleMessage3.Message710 do
           field838: [String.t()]
         }
 
-  defstruct [:field834, :field835, :field836, :field837, :field838]
+  defstruct field834: [],
+            field835: nil,
+            field836: nil,
+            field837: [],
+            field838: []
 
   field :field834, 1, repeated: true, type: :string
+
   field :field835, 2, optional: true, type: :string
+
   field :field836, 3, optional: true, type: :string
+
   field :field837, 4, repeated: true, type: :string
+
   field :field838, 5, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message706 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -898,15 +1127,21 @@ defmodule Benchmarks.GoogleMessage3.Message706 do
           field817: [String.t()]
         }
 
-  defstruct [:field814, :field815, :field816, :field817]
+  defstruct field814: [],
+            field815: nil,
+            field816: [],
+            field817: []
 
   field :field814, 1, repeated: true, type: :string
+
   field :field815, 2, optional: true, type: :string
+
   field :field816, 3, repeated: true, type: :string
+
   field :field817, 4, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message707 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -919,16 +1154,24 @@ defmodule Benchmarks.GoogleMessage3.Message707 do
           field822: [String.t()]
         }
 
-  defstruct [:field818, :field819, :field820, :field821, :field822]
+  defstruct field818: "",
+            field819: "",
+            field820: "",
+            field821: nil,
+            field822: []
 
   field :field818, 1, required: true, type: :string
+
   field :field819, 2, required: true, type: :string
+
   field :field820, 3, required: true, type: :string
+
   field :field821, 4, optional: true, type: :bool
+
   field :field822, 5, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message711 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -940,15 +1183,21 @@ defmodule Benchmarks.GoogleMessage3.Message711 do
           field842: [String.t()]
         }
 
-  defstruct [:field839, :field840, :field841, :field842]
+  defstruct field839: nil,
+            field840: [],
+            field841: [],
+            field842: []
 
   field :field839, 1, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field840, 4, repeated: true, type: :string
+
   field :field841, 2, repeated: true, type: :string
+
   field :field842, 3, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message712 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -965,39 +1214,46 @@ defmodule Benchmarks.GoogleMessage3.Message712 do
           field851: String.t()
         }
 
-  defstruct [
-    :field843,
-    :field844,
-    :field845,
-    :field846,
-    :field847,
-    :field848,
-    :field849,
-    :field850,
-    :field851
-  ]
+  defstruct field843: [],
+            field844: "",
+            field845: nil,
+            field846: [],
+            field847: [],
+            field848: nil,
+            field849: [],
+            field850: nil,
+            field851: nil
 
   field :field843, 1, repeated: true, type: :string
+
   field :field844, 2, required: true, type: :string
+
   field :field845, 3, optional: true, type: :string
+
   field :field846, 4, repeated: true, type: :string
+
   field :field847, 5, repeated: true, type: :string
+
   field :field848, 6, optional: true, type: :string
+
   field :field849, 7, repeated: true, type: :string
+
   field :field850, 8, optional: true, type: :string
+
   field :field851, 9, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8939.Message8940 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8939.Message8941 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1011,17 +1267,27 @@ defmodule Benchmarks.GoogleMessage3.Message8939.Message8941 do
           field9038: String.t()
         }
 
-  defstruct [:field9033, :field9034, :field9035, :field9036, :field9037, :field9038]
+  defstruct field9033: nil,
+            field9034: nil,
+            field9035: nil,
+            field9036: nil,
+            field9037: nil,
+            field9038: nil
 
   field :field9033, 32, optional: true, type: :string
+
   field :field9034, 33, optional: true, type: :string
+
   field :field9035, 34, optional: true, type: :string
+
   field :field9036, 35, optional: true, type: :string
+
   field :field9037, 36, optional: true, type: :string
+
   field :field9038, 37, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8939.Message8943 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1035,17 +1301,27 @@ defmodule Benchmarks.GoogleMessage3.Message8939.Message8943 do
           field9044: String.t()
         }
 
-  defstruct [:field9039, :field9040, :field9041, :field9042, :field9043, :field9044]
+  defstruct field9039: nil,
+            field9040: nil,
+            field9041: nil,
+            field9042: nil,
+            field9043: nil,
+            field9044: nil
 
   field :field9039, 1, optional: true, type: :string
+
   field :field9040, 2, optional: true, type: :string
+
   field :field9041, 3, optional: true, type: :string
+
   field :field9042, 4, optional: true, type: :string
+
   field :field9043, 5, optional: true, type: :string
+
   field :field9044, 6, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8939 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1075,56 +1351,75 @@ defmodule Benchmarks.GoogleMessage3.Message8939 do
           message8943: any
         }
 
-  defstruct [
-    :field9010,
-    :field9011,
-    :field9012,
-    :field9013,
-    :field9014,
-    :message8940,
-    :field9016,
-    :field9017,
-    :field9018,
-    :message8941,
-    :field9020,
-    :field9021,
-    :field9022,
-    :field9023,
-    :field9024,
-    :field9025,
-    :field9026,
-    :field9027,
-    :field9028,
-    :field9029,
-    :field9030,
-    :message8943
-  ]
+  defstruct field9010: nil,
+            field9011: nil,
+            field9012: nil,
+            field9013: [],
+            field9014: nil,
+            message8940: [],
+            field9016: nil,
+            field9017: nil,
+            field9018: nil,
+            message8941: nil,
+            field9020: nil,
+            field9021: [],
+            field9022: [],
+            field9023: nil,
+            field9024: nil,
+            field9025: nil,
+            field9026: nil,
+            field9027: nil,
+            field9028: nil,
+            field9029: nil,
+            field9030: nil,
+            message8943: nil
 
   field :field9010, 1, optional: true, type: :string
+
   field :field9011, 2, optional: true, type: :string
+
   field :field9012, 3, optional: true, type: :string
+
   field :field9013, 4, repeated: true, type: :string
+
   field :field9014, 5, optional: true, type: :string
+
   field :message8940, 11, repeated: true, type: :group
+
   field :field9016, 21, optional: true, type: :int64
+
   field :field9017, 22, optional: true, type: :int64
+
   field :field9018, 23, optional: true, type: :int64
+
   field :message8941, 31, optional: true, type: :group
+
   field :field9020, 38, optional: true, type: Benchmarks.GoogleMessage3.Message8942
+
   field :field9021, 39, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field9022, 41, repeated: true, type: :string
+
   field :field9023, 42, optional: true, type: :string
+
   field :field9024, 43, optional: true, type: :string
+
   field :field9025, 44, optional: true, type: :string
+
   field :field9026, 45, optional: true, type: :string
+
   field :field9027, 46, optional: true, type: :string
+
   field :field9028, 47, optional: true, type: :string
+
   field :field9029, 48, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :field9030, 49, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
+
   field :message8943, 51, optional: true, type: :group
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message9181 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1133,12 +1428,12 @@ defmodule Benchmarks.GoogleMessage3.Message9181 do
           field9204: String.t()
         }
 
-  defstruct [:field9204]
+  defstruct field9204: nil
 
   field :field9204, 1, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message9164 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1149,14 +1444,18 @@ defmodule Benchmarks.GoogleMessage3.Message9164 do
           field9170: integer
         }
 
-  defstruct [:field9168, :field9169, :field9170]
+  defstruct field9168: nil,
+            field9169: nil,
+            field9170: nil
 
   field :field9168, 1, optional: true, type: :int32
+
   field :field9169, 2, optional: true, type: :int32
+
   field :field9170, 3, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message9165 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1166,13 +1465,15 @@ defmodule Benchmarks.GoogleMessage3.Message9165 do
           field9172: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [:field9171, :field9172]
+  defstruct field9171: nil,
+            field9172: nil
 
   field :field9171, 1, optional: true, type: :float
+
   field :field9172, 2, optional: true, type: :float
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message9166 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1182,13 +1483,15 @@ defmodule Benchmarks.GoogleMessage3.Message9166 do
           field9174: integer
         }
 
-  defstruct [:field9173, :field9174]
+  defstruct field9173: nil,
+            field9174: nil
 
   field :field9173, 1, optional: true, type: :float
+
   field :field9174, 2, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message9151 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1204,28 +1507,33 @@ defmodule Benchmarks.GoogleMessage3.Message9151 do
           field9159: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [
-    :field9152,
-    :field9153,
-    :field9154,
-    :field9155,
-    :field9156,
-    :field9157,
-    :field9158,
-    :field9159
-  ]
+  defstruct field9152: nil,
+            field9153: nil,
+            field9154: nil,
+            field9155: nil,
+            field9156: nil,
+            field9157: nil,
+            field9158: nil,
+            field9159: nil
 
   field :field9152, 1, optional: true, type: :double
+
   field :field9153, 2, optional: true, type: :double
+
   field :field9154, 3, optional: true, type: :float
+
   field :field9155, 4, optional: true, type: :float
+
   field :field9156, 5, optional: true, type: :float
+
   field :field9157, 6, optional: true, type: :float
+
   field :field9158, 7, optional: true, type: :float
+
   field :field9159, 8, optional: true, type: :float
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8888 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1237,15 +1545,21 @@ defmodule Benchmarks.GoogleMessage3.Message8888 do
           field8911: binary
         }
 
-  defstruct [:field8908, :field8909, :field8910, :field8911]
+  defstruct field8908: nil,
+            field8909: nil,
+            field8910: [],
+            field8911: nil
 
   field :field8908, 1, optional: true, type: :int32
+
   field :field8909, 4, optional: true, type: Benchmarks.GoogleMessage3.Enum8900, enum: true
+
   field :field8910, 2, repeated: true, type: :int32, packed: true
+
   field :field8911, 3, optional: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message9627 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1258,25 +1572,34 @@ defmodule Benchmarks.GoogleMessage3.Message9627 do
           field9672: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [:field9668, :field9669, :field9670, :field9671, :field9672]
+  defstruct field9668: 0,
+            field9669: 0,
+            field9670: 0,
+            field9671: 0,
+            field9672: nil
 
   field :field9668, 1, required: true, type: :int32
+
   field :field9669, 2, required: true, type: :int32
+
   field :field9670, 3, required: true, type: :int32
+
   field :field9671, 4, required: true, type: :int32
+
   field :field9672, 5, optional: true, type: :float
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message11020 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message11013 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1307,54 +1630,75 @@ defmodule Benchmarks.GoogleMessage3.Message11013 do
           field11779: [Benchmarks.GoogleMessage3.Message11011.t()]
         }
 
-  defstruct [
-    :field11757,
-    :field11758,
-    :field11759,
-    :field11760,
-    :field11761,
-    :field11762,
-    :field11763,
-    :field11764,
-    :field11765,
-    :field11766,
-    :field11767,
-    :field11768,
-    :field11769,
-    :field11770,
-    :field11771,
-    :field11772,
-    :field11773,
-    :field11774,
-    :field11775,
-    :field11776,
-    :field11777,
-    :field11778,
-    :field11779
-  ]
+  defstruct field11757: nil,
+            field11758: nil,
+            field11759: nil,
+            field11760: nil,
+            field11761: nil,
+            field11762: nil,
+            field11763: nil,
+            field11764: nil,
+            field11765: nil,
+            field11766: nil,
+            field11767: nil,
+            field11768: nil,
+            field11769: nil,
+            field11770: nil,
+            field11771: nil,
+            field11772: nil,
+            field11773: nil,
+            field11774: nil,
+            field11775: nil,
+            field11776: nil,
+            field11777: nil,
+            field11778: nil,
+            field11779: []
 
   field :field11757, 19, optional: true, type: :bytes
+
   field :field11758, 1, optional: true, type: :bytes
+
   field :field11759, 2, optional: true, type: :bytes
+
   field :field11760, 3, optional: true, type: :bytes
+
   field :field11761, 4, optional: true, type: :bytes
+
   field :field11762, 5, optional: true, type: :bytes
+
   field :field11763, 6, optional: true, type: :bytes
+
   field :field11764, 7, optional: true, type: :bytes
+
   field :field11765, 8, optional: true, type: :bytes
+
   field :field11766, 9, optional: true, type: :bytes
+
   field :field11767, 10, optional: true, type: :bytes
+
   field :field11768, 11, optional: true, type: :bytes
+
   field :field11769, 12, optional: true, type: :bytes
+
   field :field11770, 13, optional: true, type: :bytes
+
   field :field11771, 14, optional: true, type: :bytes
+
   field :field11772, 15, optional: true, type: :bytes
+
   field :field11773, 16, optional: true, type: :bytes
+
   field :field11774, 17, optional: true, type: :bytes
+
   field :field11775, 18, optional: true, type: :bytes
+
   field :field11776, 20, optional: true, type: :bytes
+
   field :field11777, 21, optional: true, type: :bytes
+
   field :field11778, 23, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
+
   field :field11779, 22, repeated: true, type: Benchmarks.GoogleMessage3.Message11011
+
   def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message3/benchmark_message3_7.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_7.pb.ex
@@ -1,12 +1,13 @@
 defmodule Benchmarks.GoogleMessage3.Message11018 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10800 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -18,24 +19,31 @@ defmodule Benchmarks.GoogleMessage3.Message10800 do
           field10811: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [:field10808, :field10809, :field10810, :field10811]
+  defstruct field10808: nil,
+            field10809: nil,
+            field10810: nil,
+            field10811: nil
 
   field :field10808, 1, optional: true, type: :string
+
   field :field10809, 2, optional: true, type: :int64
+
   field :field10810, 3, optional: true, type: :bool
+
   field :field10811, 4, optional: true, type: :float
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10802 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message10748 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -47,15 +55,21 @@ defmodule Benchmarks.GoogleMessage3.Message10748 do
           field10753: integer
         }
 
-  defstruct [:field10750, :field10751, :field10752, :field10753]
+  defstruct field10750: nil,
+            field10751: nil,
+            field10752: nil,
+            field10753: nil
 
   field :field10750, 1, optional: true, type: :string
+
   field :field10751, 2, optional: true, type: :int32
+
   field :field10752, 3, optional: true, type: :int32
+
   field :field10753, 4, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message7966 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -65,13 +79,15 @@ defmodule Benchmarks.GoogleMessage3.Message7966 do
           field7970: boolean
         }
 
-  defstruct [:field7969, :field7970]
+  defstruct field7969: nil,
+            field7970: nil
 
   field :field7969, 1, optional: true, type: :string
+
   field :field7970, 2, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message708 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -85,26 +101,37 @@ defmodule Benchmarks.GoogleMessage3.Message708 do
           field828: [String.t()]
         }
 
-  defstruct [:field823, :field824, :field825, :field826, :field827, :field828]
+  defstruct field823: nil,
+            field824: [],
+            field825: nil,
+            field826: nil,
+            field827: [],
+            field828: []
 
   field :field823, 1, optional: true, type: Benchmarks.GoogleMessage3.Message741
+
   field :field824, 6, repeated: true, type: :string
+
   field :field825, 2, optional: true, type: :string
+
   field :field826, 3, optional: true, type: :string
+
   field :field827, 4, repeated: true, type: :string
+
   field :field828, 5, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message8942 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message11011 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -114,22 +141,25 @@ defmodule Benchmarks.GoogleMessage3.Message11011 do
           field11753: binary
         }
 
-  defstruct [:field11752, :field11753]
+  defstruct field11752: "",
+            field11753: ""
 
   field :field11752, 1, required: true, type: :bytes
+
   field :field11753, 2, required: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.UnusedEmptyMessage do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage3.Message741 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -138,8 +168,9 @@ defmodule Benchmarks.GoogleMessage3.Message741 do
           field936: [String.t()]
         }
 
-  defstruct [:field936]
+  defstruct field936: []
 
   field :field936, 1, repeated: true, type: :string
+
   def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message3/benchmark_message3_8.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_8.pb.ex
@@ -1,12 +1,12 @@
 defmodule Benchmarks.GoogleMessage3.Enum720 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE721 | :ENUM_VALUE722
 
   field :ENUM_VALUE721, 1
   field :ENUM_VALUE722, 2
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum3476 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -383,7 +383,6 @@ defmodule Benchmarks.GoogleMessage3.Enum3476 do
   field :ENUM_VALUE3659, 182
   field :ENUM_VALUE3660, 183
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum3805 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -416,7 +415,6 @@ defmodule Benchmarks.GoogleMessage3.Enum3805 do
   field :ENUM_VALUE3816, 11
   field :ENUM_VALUE3817, 10
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum3783 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -465,7 +463,6 @@ defmodule Benchmarks.GoogleMessage3.Enum3783 do
   field :ENUM_VALUE3802, 21
   field :ENUM_VALUE3803, 50
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum3851 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -510,16 +507,15 @@ defmodule Benchmarks.GoogleMessage3.Enum3851 do
   field :ENUM_VALUE3868, 16
   field :ENUM_VALUE3869, 17
 end
-
 defmodule Benchmarks.GoogleMessage3.UnusedEnum do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :UNUSED_ENUM_VALUE1 | :UNUSED_ENUM_VALUE2
 
   field :UNUSED_ENUM_VALUE1, 0
   field :UNUSED_ENUM_VALUE2, 1
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum4146 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -538,16 +534,15 @@ defmodule Benchmarks.GoogleMessage3.Enum4146 do
   field :ENUM_VALUE4150, 3
   field :ENUM_VALUE4151, 4
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum4160 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE4161 | :ENUM_VALUE4162
 
   field :ENUM_VALUE4161, 0
   field :ENUM_VALUE4162, 1
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum4152 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -570,7 +565,6 @@ defmodule Benchmarks.GoogleMessage3.Enum4152 do
   field :ENUM_VALUE4158, 5
   field :ENUM_VALUE4159, 6
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum6025 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -623,7 +617,6 @@ defmodule Benchmarks.GoogleMessage3.Enum6025 do
   field :ENUM_VALUE6046, 20
   field :ENUM_VALUE6047, 21
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum6065 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -662,7 +655,6 @@ defmodule Benchmarks.GoogleMessage3.Enum6065 do
   field :ENUM_VALUE6079, 13
   field :ENUM_VALUE6080, 14
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum6579 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -687,7 +679,6 @@ defmodule Benchmarks.GoogleMessage3.Enum6579 do
   field :ENUM_VALUE6586, 25
   field :ENUM_VALUE6587, 30
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum6588 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -764,17 +755,16 @@ defmodule Benchmarks.GoogleMessage3.Enum6588 do
   field :ENUM_VALUE6621, 33
   field :ENUM_VALUE6622, 34
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum6769 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE6770 | :ENUM_VALUE6771 | :ENUM_VALUE6772
 
   field :ENUM_VALUE6770, 0
   field :ENUM_VALUE6771, 1
   field :ENUM_VALUE6772, 2
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum6774 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -797,7 +787,6 @@ defmodule Benchmarks.GoogleMessage3.Enum6774 do
   field :ENUM_VALUE6780, 5
   field :ENUM_VALUE6781, 6
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum6782 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -818,10 +807,10 @@ defmodule Benchmarks.GoogleMessage3.Enum6782 do
   field :ENUM_VALUE6787, 4
   field :ENUM_VALUE6788, 5
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum6858 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE6859 | :ENUM_VALUE6860 | :ENUM_VALUE6861 | :ENUM_VALUE6862
 
   field :ENUM_VALUE6859, 1
@@ -829,7 +818,6 @@ defmodule Benchmarks.GoogleMessage3.Enum6858 do
   field :ENUM_VALUE6861, 3
   field :ENUM_VALUE6862, 4
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum6815 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -850,10 +838,10 @@ defmodule Benchmarks.GoogleMessage3.Enum6815 do
   field :ENUM_VALUE6820, 4
   field :ENUM_VALUE6821, 5
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum6822 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE6823 | :ENUM_VALUE6824 | :ENUM_VALUE6825 | :ENUM_VALUE6826
 
   field :ENUM_VALUE6823, 0
@@ -861,37 +849,36 @@ defmodule Benchmarks.GoogleMessage3.Enum6822 do
   field :ENUM_VALUE6825, 2
   field :ENUM_VALUE6826, 3
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum7654 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE7655 | :ENUM_VALUE7656 | :ENUM_VALUE7657
 
   field :ENUM_VALUE7655, 1
   field :ENUM_VALUE7656, 2
   field :ENUM_VALUE7657, 3
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum8292 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE8293 | :ENUM_VALUE8294 | :ENUM_VALUE8295
 
   field :ENUM_VALUE8293, 0
   field :ENUM_VALUE8294, 1
   field :ENUM_VALUE8295, 2
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum8450 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE8451 | :ENUM_VALUE8452 | :ENUM_VALUE8453
 
   field :ENUM_VALUE8451, 0
   field :ENUM_VALUE8452, 1
   field :ENUM_VALUE8453, 2
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum8900 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -910,7 +897,6 @@ defmodule Benchmarks.GoogleMessage3.Enum8900 do
   field :ENUM_VALUE8904, 3
   field :ENUM_VALUE8905, 4
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum8945 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -929,7 +915,6 @@ defmodule Benchmarks.GoogleMessage3.Enum8945 do
   field :ENUM_VALUE8949, 3
   field :ENUM_VALUE8950, 4
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum8951 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -954,7 +939,6 @@ defmodule Benchmarks.GoogleMessage3.Enum8951 do
   field :ENUM_VALUE8958, 7
   field :ENUM_VALUE8959, 8
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum9243 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -1129,7 +1113,6 @@ defmodule Benchmarks.GoogleMessage3.Enum9243 do
   field :ENUM_VALUE9325, 1007
   field :ENUM_VALUE9326, 65
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum10157 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -1156,7 +1139,6 @@ defmodule Benchmarks.GoogleMessage3.Enum10157 do
   field :ENUM_VALUE10165, 7
   field :ENUM_VALUE10166, 8
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum10167 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -1183,7 +1165,6 @@ defmodule Benchmarks.GoogleMessage3.Enum10167 do
   field :ENUM_VALUE10175, 7
   field :ENUM_VALUE10176, 8
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum8862 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -1224,7 +1205,6 @@ defmodule Benchmarks.GoogleMessage3.Enum8862 do
   field :ENUM_VALUE8877, 12
   field :ENUM_VALUE8878, 15
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum10325 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -1251,24 +1231,23 @@ defmodule Benchmarks.GoogleMessage3.Enum10325 do
   field :ENUM_VALUE10333, 7
   field :ENUM_VALUE10334, 8
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum10335 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE10336
 
   field :ENUM_VALUE10336, 0
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum10337 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE10338 | :ENUM_VALUE10339
 
   field :ENUM_VALUE10338, 0
   field :ENUM_VALUE10339, 1
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum10392 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -1313,7 +1292,6 @@ defmodule Benchmarks.GoogleMessage3.Enum10392 do
   field :ENUM_VALUE10409, 101
   field :ENUM_VALUE10410, 102
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum11107 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -2042,7 +2020,6 @@ defmodule Benchmarks.GoogleMessage3.Enum11107 do
   field :ENUM_VALUE11466, 135_168
   field :ENUM_VALUE11467, 9_439_507
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum11541 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -2433,7 +2410,6 @@ defmodule Benchmarks.GoogleMessage3.Enum11541 do
   field :ENUM_VALUE11731, 188
   field :ENUM_VALUE11732, 16_777_215
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum11468 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -2490,7 +2466,6 @@ defmodule Benchmarks.GoogleMessage3.Enum11468 do
   field :ENUM_VALUE11491, 2292
   field :ENUM_VALUE11492, 44
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum11022 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -2667,17 +2642,16 @@ defmodule Benchmarks.GoogleMessage3.Enum11022 do
   field :ENUM_VALUE11105, 82
   field :ENUM_VALUE11106, 83
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum12670 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE12671 | :ENUM_VALUE12672 | :ENUM_VALUE12673
 
   field :ENUM_VALUE12671, 0
   field :ENUM_VALUE12672, 1
   field :ENUM_VALUE12673, 2
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum12871 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -2698,20 +2672,20 @@ defmodule Benchmarks.GoogleMessage3.Enum12871 do
   field :ENUM_VALUE12876, 5
   field :ENUM_VALUE12877, 6
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum13092 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE13093 | :ENUM_VALUE13094 | :ENUM_VALUE13095
 
   field :ENUM_VALUE13093, 1
   field :ENUM_VALUE13094, 2
   field :ENUM_VALUE13095, 3
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum13146 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE13147 | :ENUM_VALUE13148 | :ENUM_VALUE13149 | :ENUM_VALUE13150
 
   field :ENUM_VALUE13147, 0
@@ -2719,7 +2693,6 @@ defmodule Benchmarks.GoogleMessage3.Enum13146 do
   field :ENUM_VALUE13149, 2
   field :ENUM_VALUE13150, 3
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum16042 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -3452,7 +3425,6 @@ defmodule Benchmarks.GoogleMessage3.Enum16042 do
   field :ENUM_VALUE16403, 254
   field :ENUM_VALUE16404, 255
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum16553 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -3481,17 +3453,16 @@ defmodule Benchmarks.GoogleMessage3.Enum16553 do
   field :ENUM_VALUE16562, 8
   field :ENUM_VALUE16563, 9
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum16728 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE16729 | :ENUM_VALUE16730 | :ENUM_VALUE16731
 
   field :ENUM_VALUE16729, 1
   field :ENUM_VALUE16730, 2
   field :ENUM_VALUE16731, 3
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum16732 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -3510,7 +3481,6 @@ defmodule Benchmarks.GoogleMessage3.Enum16732 do
   field :ENUM_VALUE16736, 4
   field :ENUM_VALUE16737, 5
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum16738 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -3533,7 +3503,6 @@ defmodule Benchmarks.GoogleMessage3.Enum16738 do
   field :ENUM_VALUE16744, 6
   field :ENUM_VALUE16745, 7
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum16698 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -3588,7 +3557,6 @@ defmodule Benchmarks.GoogleMessage3.Enum16698 do
   field :ENUM_VALUE16720, 19
   field :ENUM_VALUE16721, 20
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum16819 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -3609,7 +3577,6 @@ defmodule Benchmarks.GoogleMessage3.Enum16819 do
   field :ENUM_VALUE16824, 4
   field :ENUM_VALUE16825, 5
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum16925 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -3646,19 +3613,19 @@ defmodule Benchmarks.GoogleMessage3.Enum16925 do
   field :ENUM_VALUE16938, 12
   field :ENUM_VALUE16939, 13
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum22854 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE22855 | :ENUM_VALUE22856
 
   field :ENUM_VALUE22855, 0
   field :ENUM_VALUE22856, 1
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum24361 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE24362 | :ENUM_VALUE24363 | :ENUM_VALUE24364 | :ENUM_VALUE24365
 
   field :ENUM_VALUE24362, 0
@@ -3666,7 +3633,6 @@ defmodule Benchmarks.GoogleMessage3.Enum24361 do
   field :ENUM_VALUE24364, 2
   field :ENUM_VALUE24365, 3
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum16891 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -3739,7 +3705,6 @@ defmodule Benchmarks.GoogleMessage3.Enum16891 do
   field :ENUM_VALUE16922, 30
   field :ENUM_VALUE16923, 31
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum27361 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -3758,7 +3723,6 @@ defmodule Benchmarks.GoogleMessage3.Enum27361 do
   field :ENUM_VALUE27365, 3
   field :ENUM_VALUE27366, 4
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum33960 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -3781,15 +3745,14 @@ defmodule Benchmarks.GoogleMessage3.Enum33960 do
   field :ENUM_VALUE33966, 5
   field :ENUM_VALUE33967, 6
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum34388 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE34389
 
   field :ENUM_VALUE34389, 1
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum35477 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -3808,7 +3771,6 @@ defmodule Benchmarks.GoogleMessage3.Enum35477 do
   field :ENUM_VALUE35481, 1
   field :ENUM_VALUE35482, 0
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum35507 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -3837,7 +3799,6 @@ defmodule Benchmarks.GoogleMessage3.Enum35507 do
   field :ENUM_VALUE35516, 8
   field :ENUM_VALUE35517, 9
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum36860 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -3862,10 +3823,10 @@ defmodule Benchmarks.GoogleMessage3.Enum36860 do
   field :ENUM_VALUE36867, 6
   field :ENUM_VALUE36868, 7
 end
-
 defmodule Benchmarks.GoogleMessage3.Enum36890 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE36891 | :ENUM_VALUE36892
 
   field :ENUM_VALUE36891, 0

--- a/bench/lib/datasets/google_message4/benchmark_message4.pb.ex
+++ b/bench/lib/datasets/google_message4/benchmark_message4.pb.ex
@@ -21,44 +21,57 @@ defmodule Benchmarks.GoogleMessage4.GoogleMessage4 do
           field37518: Benchmarks.GoogleMessage4.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field37503,
-    :field37504,
-    :field37505,
-    :field37506,
-    :field37507,
-    :field37508,
-    :field37509,
-    :field37510,
-    :field37511,
-    :field37512,
-    :field37513,
-    :field37514,
-    :field37515,
-    :field37516,
-    :field37517,
-    :field37518
-  ]
+  defstruct field37503: nil,
+            field37504: nil,
+            field37505: nil,
+            field37506: nil,
+            field37507: nil,
+            field37508: nil,
+            field37509: nil,
+            field37510: nil,
+            field37511: nil,
+            field37512: nil,
+            field37513: nil,
+            field37514: nil,
+            field37515: nil,
+            field37516: nil,
+            field37517: nil,
+            field37518: nil
 
   field :field37503, 1, optional: true, type: :int32
+
   field :field37504, 2, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37505, 3, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37506, 4, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37507, 5, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37508, 6, optional: true, type: Benchmarks.GoogleMessage4.Message37489
+
   field :field37509, 7, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37510, 8, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37511, 9, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37512, 10, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37513, 11, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37514, 12, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37515, 13, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37516, 14, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37517, 15, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37518, 16, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message37489 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -87,54 +100,72 @@ defmodule Benchmarks.GoogleMessage4.Message37489 do
           field37554: Benchmarks.GoogleMessage4.Message37335.t() | nil
         }
 
-  defstruct [
-    :field37534,
-    :field37535,
-    :field37536,
-    :field37537,
-    :field37538,
-    :field37539,
-    :field37540,
-    :field37541,
-    :field37542,
-    :field37543,
-    :field37544,
-    :field37545,
-    :field37546,
-    :field37547,
-    :field37548,
-    :field37549,
-    :field37550,
-    :field37551,
-    :field37552,
-    :field37553,
-    :field37554
-  ]
+  defstruct field37534: nil,
+            field37535: nil,
+            field37536: nil,
+            field37537: nil,
+            field37538: nil,
+            field37539: nil,
+            field37540: nil,
+            field37541: nil,
+            field37542: nil,
+            field37543: nil,
+            field37544: nil,
+            field37545: nil,
+            field37546: nil,
+            field37547: nil,
+            field37548: nil,
+            field37549: nil,
+            field37550: nil,
+            field37551: nil,
+            field37552: nil,
+            field37553: nil,
+            field37554: nil
 
   field :field37534, 3, optional: true, type: Benchmarks.GoogleMessage4.Message2517
+
   field :field37535, 4, optional: true, type: Benchmarks.GoogleMessage4.Message7330
+
   field :field37536, 6, optional: true, type: Benchmarks.GoogleMessage4.Message8815
+
   field :field37537, 7, optional: true, type: Benchmarks.GoogleMessage4.Message8817
+
   field :field37538, 8, optional: true, type: Benchmarks.GoogleMessage4.Message8835
+
   field :field37539, 9, optional: true, type: Benchmarks.GoogleMessage4.Message8848
+
   field :field37540, 11, optional: true, type: Benchmarks.GoogleMessage4.Message8856
+
   field :field37541, 15, optional: true, type: Benchmarks.GoogleMessage4.Message12717
+
   field :field37542, 20, optional: true, type: Benchmarks.GoogleMessage4.Message12748
+
   field :field37543, 22, optional: true, type: Benchmarks.GoogleMessage4.Message7319
+
   field :field37544, 24, optional: true, type: Benchmarks.GoogleMessage4.Message12908
+
   field :field37545, 25, optional: true, type: Benchmarks.GoogleMessage4.Message12910
+
   field :field37546, 30, optional: true, type: Benchmarks.GoogleMessage4.Message12960
+
   field :field37547, 33, optional: true, type: Benchmarks.GoogleMessage4.Message176
+
   field :field37548, 34, optional: true, type: Benchmarks.GoogleMessage4.Message13000
+
   field :field37549, 35, optional: true, type: Benchmarks.GoogleMessage4.Message13035
+
   field :field37550, 36, optional: true, type: Benchmarks.GoogleMessage4.Message37331
+
   field :field37551, 37, optional: true, type: Benchmarks.GoogleMessage4.Message37329
+
   field :field37552, 38, optional: true, type: Benchmarks.GoogleMessage4.Message37327
+
   field :field37553, 39, optional: true, type: Benchmarks.GoogleMessage4.Message37333
+
   field :field37554, 40, optional: true, type: Benchmarks.GoogleMessage4.Message37335
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7319 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -144,13 +175,15 @@ defmodule Benchmarks.GoogleMessage4.Message7319 do
           field7322: Benchmarks.GoogleMessage4.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [:field7321, :field7322]
+  defstruct field7321: nil,
+            field7322: nil
 
   field :field7321, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7322, 7, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12717 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -167,30 +200,36 @@ defmodule Benchmarks.GoogleMessage4.Message12717 do
           field12727: integer
         }
 
-  defstruct [
-    :field12719,
-    :field12720,
-    :field12721,
-    :field12722,
-    :field12723,
-    :field12724,
-    :field12725,
-    :field12726,
-    :field12727
-  ]
+  defstruct field12719: nil,
+            field12720: nil,
+            field12721: nil,
+            field12722: nil,
+            field12723: [],
+            field12724: nil,
+            field12725: nil,
+            field12726: [],
+            field12727: nil
 
   field :field12719, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field12720, 2, optional: true, type: :string
+
   field :field12721, 3, optional: true, type: :uint32
+
   field :field12722, 4, optional: true, type: Benchmarks.GoogleMessage4.Message11976
+
   field :field12723, 5, repeated: true, type: Benchmarks.GoogleMessage4.Message11948
+
   field :field12724, 6, optional: true, type: Benchmarks.GoogleMessage4.Message11947
+
   field :field12725, 7, optional: true, type: Benchmarks.GoogleMessage4.Message12687
+
   field :field12726, 8, repeated: true, type: Benchmarks.GoogleMessage4.Message11948
+
   field :field12727, 9, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message37331 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -202,15 +241,21 @@ defmodule Benchmarks.GoogleMessage4.Message37331 do
           field37370: binary
         }
 
-  defstruct [:field37367, :field37368, :field37369, :field37370]
+  defstruct field37367: nil,
+            field37368: nil,
+            field37369: 0,
+            field37370: ""
 
   field :field37367, 4, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37368, 1, required: true, type: Benchmarks.GoogleMessage4.Message37326
+
   field :field37369, 2, required: true, type: :int64
+
   field :field37370, 3, required: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message8815 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -221,14 +266,18 @@ defmodule Benchmarks.GoogleMessage4.Message8815 do
           field8821: boolean
         }
 
-  defstruct [:field8819, :field8820, :field8821]
+  defstruct field8819: nil,
+            field8820: [],
+            field8821: nil
 
   field :field8819, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8820, 2, repeated: true, type: Benchmarks.GoogleMessage4.Message8768
+
   field :field8821, 3, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7330 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -242,17 +291,27 @@ defmodule Benchmarks.GoogleMessage4.Message7330 do
           field7337: integer
         }
 
-  defstruct [:field7332, :field7333, :field7334, :field7335, :field7336, :field7337]
+  defstruct field7332: nil,
+            field7333: nil,
+            field7334: nil,
+            field7335: nil,
+            field7336: nil,
+            field7337: nil
 
   field :field7332, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7333, 2, optional: true, type: Benchmarks.GoogleMessage4.Message3069
+
   field :field7334, 3, optional: true, type: Benchmarks.GoogleMessage4.Message7320
+
   field :field7335, 4, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7336, 5, optional: true, type: :bool
+
   field :field7337, 6, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12960 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -262,22 +321,25 @@ defmodule Benchmarks.GoogleMessage4.Message12960 do
           field12963: Benchmarks.GoogleMessage4.Message12948.t() | nil
         }
 
-  defstruct [:field12962, :field12963]
+  defstruct field12962: nil,
+            field12963: nil
 
   field :field12962, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field12963, 2, optional: true, type: Benchmarks.GoogleMessage4.Message12948
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message176.Message178 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message176 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -344,130 +406,186 @@ defmodule Benchmarks.GoogleMessage4.Message176 do
           field466: Benchmarks.GoogleMessage4.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field408,
-    :field409,
-    :field410,
-    :field411,
-    :field412,
-    :field413,
-    :field414,
-    :field415,
-    :field416,
-    :field417,
-    :field418,
-    :field419,
-    :field420,
-    :field421,
-    :field422,
-    :field423,
-    :field424,
-    :field425,
-    :field426,
-    :field427,
-    :field428,
-    :field429,
-    :field430,
-    :field431,
-    :field432,
-    :field433,
-    :field434,
-    :field435,
-    :field436,
-    :field437,
-    :field438,
-    :field439,
-    :field440,
-    :field441,
-    :field442,
-    :field443,
-    :field444,
-    :field445,
-    :field446,
-    :field447,
-    :field448,
-    :field449,
-    :field450,
-    :field451,
-    :field452,
-    :field453,
-    :field454,
-    :field455,
-    :field456,
-    :field457,
-    :message178,
-    :field459,
-    :field460,
-    :field461,
-    :field462,
-    :field463,
-    :field464,
-    :field465,
-    :field466
-  ]
+  defstruct field408: "",
+            field409: nil,
+            field410: nil,
+            field411: nil,
+            field412: nil,
+            field413: nil,
+            field414: nil,
+            field415: nil,
+            field416: nil,
+            field417: nil,
+            field418: nil,
+            field419: nil,
+            field420: nil,
+            field421: nil,
+            field422: nil,
+            field423: [],
+            field424: nil,
+            field425: nil,
+            field426: nil,
+            field427: nil,
+            field428: nil,
+            field429: nil,
+            field430: nil,
+            field431: nil,
+            field432: nil,
+            field433: nil,
+            field434: nil,
+            field435: nil,
+            field436: nil,
+            field437: nil,
+            field438: nil,
+            field439: nil,
+            field440: nil,
+            field441: nil,
+            field442: nil,
+            field443: nil,
+            field444: nil,
+            field445: nil,
+            field446: nil,
+            field447: nil,
+            field448: nil,
+            field449: nil,
+            field450: nil,
+            field451: [],
+            field452: nil,
+            field453: nil,
+            field454: nil,
+            field455: nil,
+            field456: nil,
+            field457: nil,
+            message178: [],
+            field459: nil,
+            field460: nil,
+            field461: nil,
+            field462: nil,
+            field463: nil,
+            field464: nil,
+            field465: [],
+            field466: nil
 
   field :field408, 1, required: true, type: :string
+
   field :field409, 4, optional: true, type: :int32
+
   field :field410, 50, optional: true, type: :string
+
   field :field411, 2, optional: true, type: :int32
+
   field :field412, 47, optional: true, type: :uint64
+
   field :field413, 56, optional: true, type: :string
+
   field :field414, 24, optional: true, type: :int32
+
   field :field415, 21, optional: true, type: :string
+
   field :field416, 3, optional: true, type: :bytes
+
   field :field417, 57, optional: true, type: :string
+
   field :field418, 51, optional: true, type: :int32
+
   field :field419, 7, optional: true, type: :float
+
   field :field420, 5, optional: true, type: :bool
+
   field :field421, 28, optional: true, type: :bool
+
   field :field422, 6, optional: true, type: :int32
+
   field :field423, 40, repeated: true, type: :int32
+
   field :field424, 41, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field425, 25, optional: true, type: :bool
+
   field :field426, 26, optional: true, type: :uint64
+
   field :field427, 38, optional: true, type: :int32
+
   field :field428, 15, optional: true, type: :bytes
+
   field :field429, 55, optional: true, type: :bytes
+
   field :field430, 16, optional: true, type: :bytes
+
   field :field431, 23, optional: true, type: :bytes
+
   field :field432, 33, optional: true, type: :bool
+
   field :field433, 31, optional: true, type: :bytes
+
   field :field434, 32, optional: true, type: :bytes
+
   field :field435, 36, optional: true, type: :int32
+
   field :field436, 17, optional: true, type: :uint64
+
   field :field437, 45, optional: true, type: :int32
+
   field :field438, 18, optional: true, type: :uint64
+
   field :field439, 46, optional: true, type: :string
+
   field :field440, 64, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field441, 39, optional: true, type: :int32
+
   field :field442, 48, optional: true, type: :uint64
+
   field :field443, 19, optional: true, type: :bytes
+
   field :field444, 42, optional: true, type: :bytes
+
   field :field445, 43, optional: true, type: :bytes
+
   field :field446, 44, optional: true, type: :string
+
   field :field447, 49, optional: true, type: :string
+
   field :field448, 20, optional: true, type: :int64
+
   field :field449, 53, optional: true, type: :bool
+
   field :field450, 54, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field451, 22, repeated: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field452, 27, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
+
   field :field453, 29, optional: true, type: :int32
+
   field :field454, 30, optional: true, type: :int32
+
   field :field455, 37, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
+
   field :field456, 34, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
+
   field :field457, 35, optional: true, type: :int32
+
   field :message178, 101, repeated: true, type: :group
+
   field :field459, 52, optional: true, type: :bool
+
   field :field460, 58, optional: true, type: :uint64
+
   field :field461, 59, optional: true, type: :uint64
+
   field :field462, 60, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field463, 61, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field464, 62, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
+
   field :field465, 63, repeated: true, type: :string
+
   field :field466, 65, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message8817 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -478,14 +596,18 @@ defmodule Benchmarks.GoogleMessage4.Message8817 do
           field8827: String.t()
         }
 
-  defstruct [:field8825, :field8826, :field8827]
+  defstruct field8825: nil,
+            field8826: [],
+            field8827: nil
 
   field :field8825, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8826, 2, repeated: true, type: Benchmarks.GoogleMessage4.Message8768
+
   field :field8827, 3, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message8835 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -496,14 +618,18 @@ defmodule Benchmarks.GoogleMessage4.Message8835 do
           field8839: Benchmarks.GoogleMessage4.UnusedEnum.t()
         }
 
-  defstruct [:field8837, :field8838, :field8839]
+  defstruct field8837: nil,
+            field8838: [],
+            field8839: nil
 
   field :field8837, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8838, 2, repeated: true, type: :string
+
   field :field8839, 3, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message37333 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -514,14 +640,18 @@ defmodule Benchmarks.GoogleMessage4.Message37333 do
           field37374: non_neg_integer
         }
 
-  defstruct [:field37372, :field37373, :field37374]
+  defstruct field37372: nil,
+            field37373: nil,
+            field37374: nil
 
   field :field37372, 3, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37373, 1, required: true, type: Benchmarks.GoogleMessage4.Message37326
+
   field :field37374, 2, optional: true, type: :uint64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message13000 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -531,13 +661,15 @@ defmodule Benchmarks.GoogleMessage4.Message13000 do
           field13016: [Benchmarks.GoogleMessage4.Message12979.t()]
         }
 
-  defstruct [:field13015, :field13016]
+  defstruct field13015: nil,
+            field13016: []
 
   field :field13015, 1, optional: true, type: :int64
+
   field :field13016, 2, repeated: true, type: Benchmarks.GoogleMessage4.Message12979
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message37335 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -549,15 +681,21 @@ defmodule Benchmarks.GoogleMessage4.Message37335 do
           field37379: non_neg_integer
         }
 
-  defstruct [:field37376, :field37377, :field37378, :field37379]
+  defstruct field37376: nil,
+            field37377: nil,
+            field37378: nil,
+            field37379: nil
 
   field :field37376, 4, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37377, 1, required: true, type: Benchmarks.GoogleMessage4.Message37326
+
   field :field37378, 2, required: true, type: Benchmarks.GoogleMessage4.Message37173
+
   field :field37379, 3, optional: true, type: :uint64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message8848 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -568,14 +706,18 @@ defmodule Benchmarks.GoogleMessage4.Message8848 do
           field8852: binary
         }
 
-  defstruct [:field8850, :field8851, :field8852]
+  defstruct field8850: nil,
+            field8851: nil,
+            field8852: nil
 
   field :field8850, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8851, 2, optional: true, type: :string
+
   field :field8852, 3, optional: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message13035 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -585,13 +727,15 @@ defmodule Benchmarks.GoogleMessage4.Message13035 do
           field13059: [integer]
         }
 
-  defstruct [:field13058, :field13059]
+  defstruct field13058: nil,
+            field13059: []
 
   field :field13058, 1, optional: true, type: :int64
+
   field :field13059, 2, repeated: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message8856 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -601,13 +745,15 @@ defmodule Benchmarks.GoogleMessage4.Message8856 do
           field8859: String.t()
         }
 
-  defstruct [:field8858, :field8859]
+  defstruct field8858: nil,
+            field8859: nil
 
   field :field8858, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8859, 2, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12908 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -621,17 +767,27 @@ defmodule Benchmarks.GoogleMessage4.Message12908 do
           field12917: Benchmarks.GoogleMessage4.Message12870.t() | nil
         }
 
-  defstruct [:field12912, :field12913, :field12914, :field12915, :field12916, :field12917]
+  defstruct field12912: nil,
+            field12913: nil,
+            field12914: nil,
+            field12915: nil,
+            field12916: nil,
+            field12917: nil
 
   field :field12912, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field12913, 2, optional: true, type: :string
+
   field :field12914, 3, optional: true, type: Benchmarks.GoogleMessage4.Message12799
+
   field :field12915, 4, optional: true, type: :int64
+
   field :field12916, 5, optional: true, type: Benchmarks.GoogleMessage4.Message3804
+
   field :field12917, 6, optional: true, type: Benchmarks.GoogleMessage4.Message12870
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12910 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -642,14 +798,18 @@ defmodule Benchmarks.GoogleMessage4.Message12910 do
           field12922: [Benchmarks.GoogleMessage4.Message12903.t()]
         }
 
-  defstruct [:field12920, :field12921, :field12922]
+  defstruct field12920: nil,
+            field12921: nil,
+            field12922: []
 
   field :field12920, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field12921, 2, optional: true, type: Benchmarks.GoogleMessage4.Message12818
+
   field :field12922, 3, repeated: true, type: Benchmarks.GoogleMessage4.Message12903
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message37327 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -668,34 +828,42 @@ defmodule Benchmarks.GoogleMessage4.Message37327 do
           field37357: boolean
         }
 
-  defstruct [
-    :field37347,
-    :field37348,
-    :field37349,
-    :field37350,
-    :field37351,
-    :field37352,
-    :field37353,
-    :field37354,
-    :field37355,
-    :field37356,
-    :field37357
-  ]
+  defstruct field37347: nil,
+            field37348: nil,
+            field37349: nil,
+            field37350: nil,
+            field37351: nil,
+            field37352: nil,
+            field37353: nil,
+            field37354: nil,
+            field37355: nil,
+            field37356: nil,
+            field37357: nil
 
   field :field37347, 11, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37348, 1, required: true, type: Benchmarks.GoogleMessage4.Message37326
+
   field :field37349, 2, optional: true, type: :bool
+
   field :field37350, 3, optional: true, type: :bool
+
   field :field37351, 4, optional: true, type: :bool
+
   field :field37352, 5, optional: true, type: :bool
+
   field :field37353, 6, optional: true, type: :bool
+
   field :field37354, 7, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37355, 8, optional: true, type: :uint64
+
   field :field37356, 9, optional: true, type: :bool
+
   field :field37357, 10, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message37329 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -708,16 +876,24 @@ defmodule Benchmarks.GoogleMessage4.Message37329 do
           field37363: boolean
         }
 
-  defstruct [:field37359, :field37360, :field37361, :field37362, :field37363]
+  defstruct field37359: nil,
+            field37360: nil,
+            field37361: 0,
+            field37362: 0,
+            field37363: nil
 
   field :field37359, 6, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37360, 1, required: true, type: Benchmarks.GoogleMessage4.Message37326
+
   field :field37361, 2, required: true, type: :int64
+
   field :field37362, 3, required: true, type: :int64
+
   field :field37363, 4, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message2517 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -730,16 +906,24 @@ defmodule Benchmarks.GoogleMessage4.Message2517 do
           field2523: [Benchmarks.GoogleMessage4.Message971.t()]
         }
 
-  defstruct [:field2519, :field2520, :field2521, :field2522, :field2523]
+  defstruct field2519: nil,
+            field2520: nil,
+            field2521: nil,
+            field2522: nil,
+            field2523: []
 
   field :field2519, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field2520, 2, optional: true, type: Benchmarks.GoogleMessage4.Message2356
+
   field :field2521, 3, optional: true, type: Benchmarks.GoogleMessage4.Message0
+
   field :field2522, 4, optional: true, type: Benchmarks.GoogleMessage4.Message2463
+
   field :field2523, 5, repeated: true, type: Benchmarks.GoogleMessage4.Message971
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12748 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -751,15 +935,21 @@ defmodule Benchmarks.GoogleMessage4.Message12748 do
           field12757: Benchmarks.GoogleMessage4.Enum12735.t()
         }
 
-  defstruct [:field12754, :field12755, :field12756, :field12757]
+  defstruct field12754: nil,
+            field12755: nil,
+            field12756: nil,
+            field12757: nil
 
   field :field12754, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field12755, 2, optional: true, type: :string
+
   field :field12756, 3, optional: true, type: :string
+
   field :field12757, 4, optional: true, type: Benchmarks.GoogleMessage4.Enum12735, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12687 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -768,12 +958,12 @@ defmodule Benchmarks.GoogleMessage4.Message12687 do
           field12701: [Benchmarks.GoogleMessage4.Message12686.t()]
         }
 
-  defstruct [:field12701]
+  defstruct field12701: []
 
   field :field12701, 1, repeated: true, type: Benchmarks.GoogleMessage4.Message12686
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message11948 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -784,14 +974,18 @@ defmodule Benchmarks.GoogleMessage4.Message11948 do
           field11956: boolean
         }
 
-  defstruct [:field11954, :field11955, :field11956]
+  defstruct field11954: nil,
+            field11955: [],
+            field11956: nil
 
   field :field11954, 1, optional: true, type: :string
+
   field :field11955, 2, repeated: true, type: Benchmarks.GoogleMessage4.Message11949
+
   field :field11956, 3, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message11976 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -800,12 +994,12 @@ defmodule Benchmarks.GoogleMessage4.Message11976 do
           field12002: [Benchmarks.GoogleMessage4.Message11975.t()]
         }
 
-  defstruct [:field12002]
+  defstruct field12002: []
 
   field :field12002, 1, repeated: true, type: Benchmarks.GoogleMessage4.Message11975
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7320 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -815,13 +1009,15 @@ defmodule Benchmarks.GoogleMessage4.Message7320 do
           field7324: Benchmarks.GoogleMessage4.Message7287.t() | nil
         }
 
-  defstruct [:field7323, :field7324]
+  defstruct field7323: nil,
+            field7324: nil
 
   field :field7323, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7324, 8, optional: true, type: Benchmarks.GoogleMessage4.Message7287
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3069.Message3070 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -831,13 +1027,15 @@ defmodule Benchmarks.GoogleMessage4.Message3069.Message3070 do
           field3379: binary
         }
 
-  defstruct [:field3378, :field3379]
+  defstruct field3378: 0,
+            field3379: ""
 
   field :field3378, 4, required: true, type: Benchmarks.GoogleMessage4.Enum3071, enum: true
+
   field :field3379, 5, required: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3069 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -849,16 +1047,21 @@ defmodule Benchmarks.GoogleMessage4.Message3069 do
           __pb_extensions__: map
         }
 
-  defstruct [:field3374, :field3375, :message3070, :__pb_extensions__]
+  defstruct field3374: nil,
+            field3375: nil,
+            message3070: [],
+            __pb_extensions__: nil
 
   field :field3374, 1, optional: true, type: Benchmarks.GoogleMessage4.Message3061
+
   field :field3375, 2, optional: true, type: :bytes
+
   field :message3070, 3, repeated: true, type: :group
+
   def transform_module(), do: nil
 
   extensions [{10000, 536_870_912}]
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12948 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -867,12 +1070,12 @@ defmodule Benchmarks.GoogleMessage4.Message12948 do
           field12958: [Benchmarks.GoogleMessage4.Message12949.t()]
         }
 
-  defstruct [:field12958]
+  defstruct field12958: []
 
   field :field12958, 1, repeated: true, type: Benchmarks.GoogleMessage4.Message12949
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message8768 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -887,18 +1090,30 @@ defmodule Benchmarks.GoogleMessage4.Message8768 do
           field8788: String.t()
         }
 
-  defstruct [:field8782, :field8783, :field8784, :field8785, :field8786, :field8787, :field8788]
+  defstruct field8782: nil,
+            field8783: nil,
+            field8784: nil,
+            field8785: [],
+            field8786: nil,
+            field8787: nil,
+            field8788: nil
 
   field :field8782, 1, optional: true, type: :string
+
   field :field8783, 2, optional: true, type: Benchmarks.GoogleMessage4.Message8572
+
   field :field8784, 3, optional: true, type: :bool
+
   field :field8785, 4, repeated: true, type: Benchmarks.GoogleMessage4.Message8774
+
   field :field8786, 5, optional: true, type: :int64
+
   field :field8787, 6, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8788, 7, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12979 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -913,26 +1128,30 @@ defmodule Benchmarks.GoogleMessage4.Message12979 do
           field12987: Benchmarks.GoogleMessage4.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field12981,
-    :field12982,
-    :field12983,
-    :field12984,
-    :field12985,
-    :field12986,
-    :field12987
-  ]
+  defstruct field12981: "",
+            field12982: [],
+            field12983: nil,
+            field12984: nil,
+            field12985: nil,
+            field12986: nil,
+            field12987: nil
 
   field :field12981, 1, required: true, type: :bytes
+
   field :field12982, 2, repeated: true, type: :string
+
   field :field12983, 3, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field12984, 4, optional: true, type: :int64
+
   field :field12985, 5, optional: true, type: :string
+
   field :field12986, 6, optional: true, type: :int32
+
   field :field12987, 7, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message37173 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -965,62 +1184,84 @@ defmodule Benchmarks.GoogleMessage4.Message37173 do
           field37276: boolean
         }
 
-  defstruct [
-    :field37252,
-    :field37253,
-    :field37254,
-    :field37255,
-    :field37256,
-    :field37257,
-    :field37258,
-    :field37259,
-    :field37260,
-    :field37261,
-    :field37262,
-    :field37263,
-    :field37264,
-    :field37265,
-    :field37266,
-    :field37267,
-    :field37268,
-    :field37269,
-    :field37270,
-    :field37271,
-    :field37272,
-    :field37273,
-    :field37274,
-    :field37275,
-    :field37276
-  ]
+  defstruct field37252: nil,
+            field37253: nil,
+            field37254: nil,
+            field37255: nil,
+            field37256: nil,
+            field37257: nil,
+            field37258: nil,
+            field37259: nil,
+            field37260: nil,
+            field37261: nil,
+            field37262: nil,
+            field37263: nil,
+            field37264: nil,
+            field37265: nil,
+            field37266: nil,
+            field37267: nil,
+            field37268: nil,
+            field37269: nil,
+            field37270: nil,
+            field37271: nil,
+            field37272: nil,
+            field37273: nil,
+            field37274: nil,
+            field37275: nil,
+            field37276: nil
 
   field :field37252, 1, optional: true, type: :string
+
   field :field37253, 2, optional: true, type: :int64
+
   field :field37254, 4, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
+
   field :field37255, 5, optional: true, type: :bool
+
   field :field37256, 6, optional: true, type: :bool
+
   field :field37257, 7, optional: true, type: :bool
+
   field :field37258, 8, optional: true, type: :string
+
   field :field37259, 9, optional: true, type: :string
+
   field :field37260, 10, optional: true, type: :uint32
+
   field :field37261, 11, optional: true, type: :fixed32
+
   field :field37262, 12, optional: true, type: :string
+
   field :field37263, 13, optional: true, type: :string
+
   field :field37264, 14, optional: true, type: :string
+
   field :field37265, 15, optional: true, type: :int32
+
   field :field37266, 16, optional: true, type: :int64
+
   field :field37267, 17, optional: true, type: :int64
+
   field :field37268, 18, optional: true, type: :int32
+
   field :field37269, 19, optional: true, type: :int32
+
   field :field37270, 20, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37271, 21, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37272, 22, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37273, 23, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37274, 24, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field37275, 25, optional: true, type: :string
+
   field :field37276, 26, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12799 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1036,28 +1277,33 @@ defmodule Benchmarks.GoogleMessage4.Message12799 do
           field12816: Benchmarks.GoogleMessage4.Message12797.t() | nil
         }
 
-  defstruct [
-    :field12809,
-    :field12810,
-    :field12811,
-    :field12812,
-    :field12813,
-    :field12814,
-    :field12815,
-    :field12816
-  ]
+  defstruct field12809: "",
+            field12810: [],
+            field12811: [],
+            field12812: [],
+            field12813: [],
+            field12814: 0,
+            field12815: nil,
+            field12816: nil
 
   field :field12809, 1, required: true, type: :string
+
   field :field12810, 2, repeated: true, type: :fixed64
+
   field :field12811, 8, repeated: true, type: Benchmarks.GoogleMessage4.Message12776
+
   field :field12812, 4, repeated: true, type: :int32
+
   field :field12813, 5, repeated: true, type: Benchmarks.GoogleMessage4.Message12798
+
   field :field12814, 3, required: true, type: :int32
+
   field :field12815, 6, optional: true, type: :int32
+
   field :field12816, 7, optional: true, type: Benchmarks.GoogleMessage4.Message12797
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12870 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1085,52 +1331,69 @@ defmodule Benchmarks.GoogleMessage4.Message12870 do
           field12898: integer
         }
 
-  defstruct [
-    :field12879,
-    :field12880,
-    :field12881,
-    :field12882,
-    :field12883,
-    :field12884,
-    :field12885,
-    :field12886,
-    :field12887,
-    :field12888,
-    :field12889,
-    :field12890,
-    :field12891,
-    :field12892,
-    :field12893,
-    :field12894,
-    :field12895,
-    :field12896,
-    :field12897,
-    :field12898
-  ]
+  defstruct field12879: 0,
+            field12880: nil,
+            field12881: 0,
+            field12882: nil,
+            field12883: nil,
+            field12884: nil,
+            field12885: [],
+            field12886: nil,
+            field12887: nil,
+            field12888: [],
+            field12889: nil,
+            field12890: nil,
+            field12891: nil,
+            field12892: nil,
+            field12893: nil,
+            field12894: nil,
+            field12895: nil,
+            field12896: nil,
+            field12897: nil,
+            field12898: nil
 
   field :field12879, 1, required: true, type: :int32
+
   field :field12880, 7, optional: true, type: :int32
+
   field :field12881, 2, required: true, type: :int32
+
   field :field12882, 3, optional: true, type: :uint64
+
   field :field12883, 2001, optional: true, type: :string
+
   field :field12884, 4, optional: true, type: :fixed64
+
   field :field12885, 14, repeated: true, type: :fixed64
+
   field :field12886, 9, optional: true, type: :int32
+
   field :field12887, 18, optional: true, type: :int64
+
   field :field12888, 8, repeated: true, type: Benchmarks.GoogleMessage4.Message12870
+
   field :field12889, 5, optional: true, type: :int32
+
   field :field12890, 6, optional: true, type: :uint64
+
   field :field12891, 10, optional: true, type: :int32
+
   field :field12892, 11, optional: true, type: :int32
+
   field :field12893, 12, optional: true, type: :double
+
   field :field12894, 13, optional: true, type: Benchmarks.GoogleMessage4.Message12825
+
   field :field12895, 15, optional: true, type: :double
+
   field :field12896, 16, optional: true, type: :string
+
   field :field12897, 17, optional: true, type: Benchmarks.GoogleMessage4.Enum12871, enum: true
+
   field :field12898, 19, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3804 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1145,18 +1408,30 @@ defmodule Benchmarks.GoogleMessage4.Message3804 do
           field3824: Benchmarks.GoogleMessage4.Enum3783.t()
         }
 
-  defstruct [:field3818, :field3819, :field3820, :field3821, :field3822, :field3823, :field3824]
+  defstruct field3818: 0,
+            field3819: false,
+            field3820: [],
+            field3821: nil,
+            field3822: nil,
+            field3823: nil,
+            field3824: nil
 
   field :field3818, 1, required: true, type: :int64
+
   field :field3819, 2, required: true, type: :bool
+
   field :field3820, 4, repeated: true, type: Benchmarks.GoogleMessage4.Enum3805, enum: true
+
   field :field3821, 5, optional: true, type: :int32
+
   field :field3822, 6, optional: true, type: :bool
+
   field :field3823, 7, optional: true, type: :int64
+
   field :field3824, 8, optional: true, type: Benchmarks.GoogleMessage4.Enum3783, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12903 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1167,14 +1442,18 @@ defmodule Benchmarks.GoogleMessage4.Message12903 do
           field12907: [Benchmarks.GoogleMessage4.Message8590.t()]
         }
 
-  defstruct [:field12905, :field12906, :field12907]
+  defstruct field12905: nil,
+            field12906: nil,
+            field12907: []
 
   field :field12905, 1, optional: true, type: :string
+
   field :field12906, 2, optional: true, type: Benchmarks.GoogleMessage4.Message8587
+
   field :field12907, 3, repeated: true, type: Benchmarks.GoogleMessage4.Message8590
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message37326 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1184,13 +1463,15 @@ defmodule Benchmarks.GoogleMessage4.Message37326 do
           field37346: String.t()
         }
 
-  defstruct [:field37345, :field37346]
+  defstruct field37345: "",
+            field37346: nil
 
   field :field37345, 1, required: true, type: :string
+
   field :field37346, 2, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message2356.Message2357 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1210,54 +1491,65 @@ defmodule Benchmarks.GoogleMessage4.Message2356.Message2357 do
           field2410: binary
         }
 
-  defstruct [
-    :field2399,
-    :field2400,
-    :field2401,
-    :field2402,
-    :field2403,
-    :field2404,
-    :field2405,
-    :field2406,
-    :field2407,
-    :field2408,
-    :field2409,
-    :field2410
-  ]
+  defstruct field2399: nil,
+            field2400: nil,
+            field2401: nil,
+            field2402: nil,
+            field2403: nil,
+            field2404: nil,
+            field2405: nil,
+            field2406: "",
+            field2407: nil,
+            field2408: nil,
+            field2409: nil,
+            field2410: nil
 
   field :field2399, 9, optional: true, type: :int64
+
   field :field2400, 10, optional: true, type: :int32
+
   field :field2401, 11, optional: true, type: :int32
+
   field :field2402, 12, optional: true, type: :int32
+
   field :field2403, 13, optional: true, type: :int32
+
   field :field2404, 116, optional: true, type: :int32
+
   field :field2405, 106, optional: true, type: :int32
+
   field :field2406, 14, required: true, type: :bytes
+
   field :field2407, 45, optional: true, type: :int32
+
   field :field2408, 112, optional: true, type: :int32
+
   field :field2409, 122, optional: true, type: :bool
+
   field :field2410, 124, optional: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message2356.Message2358 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message2356.Message2359 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message2356 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1296,85 +1588,116 @@ defmodule Benchmarks.GoogleMessage4.Message2356 do
           field2398: String.t()
         }
 
-  defstruct [
-    :field2368,
-    :field2369,
-    :field2370,
-    :field2371,
-    :field2372,
-    :field2373,
-    :field2374,
-    :field2375,
-    :field2376,
-    :field2377,
-    :field2378,
-    :field2379,
-    :field2380,
-    :field2381,
-    :field2382,
-    :field2383,
-    :field2384,
-    :field2385,
-    :field2386,
-    :field2387,
-    :message2357,
-    :field2389,
-    :message2358,
-    :message2359,
-    :field2392,
-    :field2393,
-    :field2394,
-    :field2395,
-    :field2396,
-    :field2397,
-    :field2398
-  ]
+  defstruct field2368: nil,
+            field2369: nil,
+            field2370: nil,
+            field2371: nil,
+            field2372: "",
+            field2373: nil,
+            field2374: nil,
+            field2375: nil,
+            field2376: nil,
+            field2377: nil,
+            field2378: nil,
+            field2379: nil,
+            field2380: nil,
+            field2381: nil,
+            field2382: nil,
+            field2383: nil,
+            field2384: nil,
+            field2385: nil,
+            field2386: nil,
+            field2387: nil,
+            message2357: nil,
+            field2389: nil,
+            message2358: nil,
+            message2359: [],
+            field2392: nil,
+            field2393: nil,
+            field2394: nil,
+            field2395: nil,
+            field2396: nil,
+            field2397: nil,
+            field2398: nil
 
   field :field2368, 121, optional: true, type: Benchmarks.GoogleMessage4.Message1374
+
   field :field2369, 1, optional: true, type: :uint64
+
   field :field2370, 2, optional: true, type: :int32
+
   field :field2371, 17, optional: true, type: :int32
+
   field :field2372, 3, required: true, type: :string
+
   field :field2373, 7, optional: true, type: :int32
+
   field :field2374, 8, optional: true, type: :bytes
+
   field :field2375, 4, optional: true, type: :string
+
   field :field2376, 101, optional: true, type: :string
+
   field :field2377, 102, optional: true, type: :int32
+
   field :field2378, 103, optional: true, type: :int32
+
   field :field2379, 104, optional: true, type: :int32
+
   field :field2380, 113, optional: true, type: :int32
+
   field :field2381, 114, optional: true, type: :int32
+
   field :field2382, 115, optional: true, type: :int32
+
   field :field2383, 117, optional: true, type: :int32
+
   field :field2384, 118, optional: true, type: :int32
+
   field :field2385, 119, optional: true, type: :int32
+
   field :field2386, 105, optional: true, type: :int32
+
   field :field2387, 5, optional: true, type: :bytes
+
   field :message2357, 6, optional: true, type: :group
+
   field :field2389, 120, optional: true, type: :string
+
   field :message2358, 107, optional: true, type: :group
+
   field :message2359, 40, repeated: true, type: :group
+
   field :field2392, 50, optional: true, type: :int32
+
   field :field2393, 60, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field2394, 70, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field2395, 80, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field2396, 90, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field2397, 100, optional: true, type: :string
+
   field :field2398, 123, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message0 do
   @moduledoc false
   use Protobuf, syntax: :proto2
-  @type t :: %__MODULE__{__pb_extensions__: map}
-  defstruct [:__pb_extensions__]
+
+  @type t :: %__MODULE__{
+          __pb_extensions__: map
+        }
+
+  defstruct __pb_extensions__: nil
 
   def transform_module(), do: nil
 
   extensions [{4, 2_147_483_647}]
 end
-
 defmodule Benchmarks.GoogleMessage4.Message971 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1385,10 +1708,15 @@ defmodule Benchmarks.GoogleMessage4.Message971 do
           field974: boolean
         }
 
-  defstruct [:field972, :field973, :field974]
+  defstruct field972: nil,
+            field973: nil,
+            field974: nil
 
   field :field972, 1, optional: true, type: :string
+
   field :field973, 2, optional: true, type: :int32
+
   field :field974, 3, optional: true, type: :bool
+
   def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message4/benchmark_message4_1.pb.ex
+++ b/bench/lib/datasets/google_message4/benchmark_message4_1.pb.ex
@@ -6,12 +6,12 @@ defmodule Benchmarks.GoogleMessage4.Message2463 do
           field2498: [Benchmarks.GoogleMessage4.Message2462.t()]
         }
 
-  defstruct [:field2498]
+  defstruct field2498: []
 
   field :field2498, 1, repeated: true, type: Benchmarks.GoogleMessage4.Message2462
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12686 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -21,22 +21,25 @@ defmodule Benchmarks.GoogleMessage4.Message12686 do
           field12700: Benchmarks.GoogleMessage4.Message12685.t() | nil
         }
 
-  defstruct [:field12699, :field12700]
+  defstruct field12699: nil,
+            field12700: nil
 
   field :field12699, 1, optional: true, type: :string
+
   field :field12700, 2, optional: true, type: Benchmarks.GoogleMessage4.Message12685
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message11949 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message11975 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -54,32 +57,39 @@ defmodule Benchmarks.GoogleMessage4.Message11975 do
           field12001: integer
         }
 
-  defstruct [
-    :field11992,
-    :field11993,
-    :field11994,
-    :field11995,
-    :field11996,
-    :field11997,
-    :field11998,
-    :field11999,
-    :field12000,
-    :field12001
-  ]
+  defstruct field11992: nil,
+            field11993: nil,
+            field11994: [],
+            field11995: nil,
+            field11996: nil,
+            field11997: nil,
+            field11998: [],
+            field11999: nil,
+            field12000: [],
+            field12001: nil
 
   field :field11992, 1, optional: true, type: :string
+
   field :field11993, 2, optional: true, type: :int32
+
   field :field11994, 3, repeated: true, type: Benchmarks.GoogleMessage4.Message10320
+
   field :field11995, 4, optional: true, type: Benchmarks.GoogleMessage4.Message11947
+
   field :field11996, 5, optional: true, type: Benchmarks.GoogleMessage4.Message11920
+
   field :field11997, 6, optional: true, type: :bool
+
   field :field11998, 7, repeated: true, type: :string
+
   field :field11999, 8, optional: true, type: :float
+
   field :field12000, 9, repeated: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
+
   field :field12001, 11, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7287 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -95,28 +105,33 @@ defmodule Benchmarks.GoogleMessage4.Message7287 do
           field7318: Benchmarks.GoogleMessage4.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field7311,
-    :field7312,
-    :field7313,
-    :field7314,
-    :field7315,
-    :field7316,
-    :field7317,
-    :field7318
-  ]
+  defstruct field7311: nil,
+            field7312: nil,
+            field7313: nil,
+            field7314: nil,
+            field7315: nil,
+            field7316: nil,
+            field7317: nil,
+            field7318: nil
 
   field :field7311, 1, optional: true, type: Benchmarks.GoogleMessage4.Message6133
+
   field :field7312, 8, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7313, 3, optional: true, type: :string
+
   field :field7314, 4, optional: true, type: Benchmarks.GoogleMessage4.Message6643
+
   field :field7315, 5, optional: true, type: Benchmarks.GoogleMessage4.Enum7288, enum: true
+
   field :field7316, 6, optional: true, type: :bytes
+
   field :field7317, 7, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7318, 9, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3061.Message3062 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -127,14 +142,18 @@ defmodule Benchmarks.GoogleMessage4.Message3061.Message3062 do
           field3337: integer
         }
 
-  defstruct [:field3335, :field3336, :field3337]
+  defstruct field3335: 0,
+            field3336: nil,
+            field3337: nil
 
   field :field3335, 5, required: true, type: :int32
+
   field :field3336, 6, optional: true, type: :int32
+
   field :field3337, 7, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3061.Message3063 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -146,15 +165,21 @@ defmodule Benchmarks.GoogleMessage4.Message3061.Message3063 do
           field3341: integer
         }
 
-  defstruct [:field3338, :field3339, :field3340, :field3341]
+  defstruct field3338: 0,
+            field3339: nil,
+            field3340: nil,
+            field3341: nil
 
   field :field3338, 14, required: true, type: :int32
+
   field :field3339, 18, optional: true, type: Benchmarks.GoogleMessage4.Enum2851, enum: true
+
   field :field3340, 15, optional: true, type: :int64
+
   field :field3341, 23, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3061.Message3064 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -181,59 +206,76 @@ defmodule Benchmarks.GoogleMessage4.Message3061.Message3064 do
           field3360: Benchmarks.GoogleMessage4.Enum2834.t()
         }
 
-  defstruct [
-    :field3342,
-    :field3343,
-    :field3344,
-    :field3345,
-    :field3346,
-    :field3347,
-    :field3348,
-    :field3349,
-    :field3350,
-    :field3351,
-    :field3352,
-    :field3353,
-    :field3354,
-    :field3355,
-    :field3356,
-    :field3357,
-    :field3358,
-    :field3359,
-    :field3360
-  ]
+  defstruct field3342: 0,
+            field3343: nil,
+            field3344: nil,
+            field3345: nil,
+            field3346: nil,
+            field3347: nil,
+            field3348: nil,
+            field3349: nil,
+            field3350: nil,
+            field3351: nil,
+            field3352: nil,
+            field3353: nil,
+            field3354: nil,
+            field3355: nil,
+            field3356: nil,
+            field3357: nil,
+            field3358: nil,
+            field3359: nil,
+            field3360: nil
 
   field :field3342, 9, required: true, type: Benchmarks.GoogleMessage4.Enum2602, enum: true
+
   field :field3343, 92, optional: true, type: :int32
+
   field :field3344, 10, optional: true, type: :string
+
   field :field3345, 11, optional: true, type: :bytes
+
   field :field3346, 12, optional: true, type: :int32
+
   field :field3347, 98, optional: true, type: Benchmarks.GoogleMessage4.Message3060
+
   field :field3348, 82, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field3349, 80, optional: true, type: Benchmarks.GoogleMessage4.Message3050
+
   field :field3350, 52, optional: true, type: :fixed64
+
   field :field3351, 33, optional: true, type: :int32
+
   field :field3352, 42, optional: true, type: :string
+
   field :field3353, 69, optional: true, type: :string
+
   field :field3354, 43, optional: true, type: :bytes
+
   field :field3355, 73, optional: true, type: Benchmarks.GoogleMessage4.Enum2806, enum: true
+
   field :field3356, 74, optional: true, type: :int32
+
   field :field3357, 90, optional: true, type: :int32
+
   field :field3358, 79, optional: true, type: :bytes
+
   field :field3359, 19, optional: true, type: :int32
+
   field :field3360, 95, optional: true, type: Benchmarks.GoogleMessage4.Enum2834, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3061.Message3065 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3061.Message3066 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -249,28 +291,33 @@ defmodule Benchmarks.GoogleMessage4.Message3061.Message3066 do
           field3373: Benchmarks.GoogleMessage4.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [
-    :field3366,
-    :field3367,
-    :field3368,
-    :field3369,
-    :field3370,
-    :field3371,
-    :field3372,
-    :field3373
-  ]
+  defstruct field3366: nil,
+            field3367: nil,
+            field3368: nil,
+            field3369: nil,
+            field3370: nil,
+            field3371: nil,
+            field3372: nil,
+            field3373: nil
 
   field :field3366, 22, optional: true, type: :int32
+
   field :field3367, 55, optional: true, type: :int32
+
   field :field3368, 88, optional: true, type: :int32
+
   field :field3369, 56, optional: true, type: :int32
+
   field :field3370, 75, optional: true, type: :int32
+
   field :field3371, 57, optional: true, type: :int32
+
   field :field3372, 85, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field3373, 96, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3061 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -326,117 +373,163 @@ defmodule Benchmarks.GoogleMessage4.Message3061 do
           field3333: integer
         }
 
-  defstruct [
-    :field3286,
-    :field3287,
-    :field3288,
-    :field3289,
-    :field3290,
-    :message3062,
-    :field3292,
-    :field3293,
-    :field3294,
-    :message3063,
-    :field3296,
-    :field3297,
-    :field3298,
-    :field3299,
-    :field3300,
-    :field3301,
-    :field3302,
-    :field3303,
-    :field3304,
-    :field3305,
-    :field3306,
-    :field3307,
-    :field3308,
-    :field3309,
-    :field3310,
-    :field3311,
-    :field3312,
-    :field3313,
-    :message3064,
-    :field3315,
-    :field3316,
-    :message3065,
-    :field3318,
-    :field3319,
-    :field3320,
-    :field3321,
-    :field3322,
-    :field3323,
-    :field3324,
-    :field3325,
-    :field3326,
-    :message3066,
-    :field3328,
-    :field3329,
-    :field3330,
-    :field3331,
-    :field3332,
-    :field3333
-  ]
+  defstruct field3286: nil,
+            field3287: nil,
+            field3288: nil,
+            field3289: nil,
+            field3290: nil,
+            message3062: nil,
+            field3292: nil,
+            field3293: nil,
+            field3294: nil,
+            message3063: nil,
+            field3296: nil,
+            field3297: nil,
+            field3298: nil,
+            field3299: nil,
+            field3300: nil,
+            field3301: nil,
+            field3302: nil,
+            field3303: nil,
+            field3304: nil,
+            field3305: nil,
+            field3306: nil,
+            field3307: nil,
+            field3308: nil,
+            field3309: nil,
+            field3310: nil,
+            field3311: nil,
+            field3312: nil,
+            field3313: nil,
+            message3064: [],
+            field3315: nil,
+            field3316: nil,
+            message3065: nil,
+            field3318: nil,
+            field3319: nil,
+            field3320: [],
+            field3321: nil,
+            field3322: nil,
+            field3323: nil,
+            field3324: nil,
+            field3325: [],
+            field3326: [],
+            message3066: nil,
+            field3328: nil,
+            field3329: nil,
+            field3330: nil,
+            field3331: nil,
+            field3332: nil,
+            field3333: nil
 
   field :field3286, 2, optional: true, type: :string
+
   field :field3287, 77, optional: true, type: :int32
+
   field :field3288, 49, optional: true, type: :string
+
   field :field3289, 3, required: true, type: Benchmarks.GoogleMessage4.Message3046
+
   field :field3290, 58, optional: true, type: Benchmarks.GoogleMessage4.Message3046
+
   field :message3062, 4, optional: true, type: :group
+
   field :field3292, 104, optional: true, type: Benchmarks.GoogleMessage4.Message3060
+
   field :field3293, 32, optional: true, type: :int64
+
   field :field3294, 41, optional: true, type: :int32
+
   field :message3063, 13, optional: true, type: :group
+
   field :field3296, 94, optional: true, type: Benchmarks.GoogleMessage4.Enum2834, enum: true
+
   field :field3297, 25, optional: true, type: :bool
+
   field :field3298, 50, optional: true, type: :bool
+
   field :field3299, 89, optional: true, type: :string
+
   field :field3300, 91, optional: true, type: :string
+
   field :field3301, 105, optional: true, type: :string
+
   field :field3302, 53, optional: true, type: Benchmarks.GoogleMessage4.Message3050
+
   field :field3303, 51, optional: true, type: :fixed64
+
   field :field3304, 106, optional: true, type: :fixed64
+
   field :field3305, 60, optional: true, type: :int32
+
   field :field3306, 44, optional: true, type: :string
+
   field :field3307, 81, optional: true, type: :bytes
+
   field :field3308, 70, optional: true, type: :string
+
   field :field3309, 45, optional: true, type: :bytes
+
   field :field3310, 71, optional: true, type: Benchmarks.GoogleMessage4.Enum2806, enum: true
+
   field :field3311, 72, optional: true, type: :int32
+
   field :field3312, 78, optional: true, type: :bytes
+
   field :field3313, 20, optional: true, type: :int32
+
   field :message3064, 8, repeated: true, type: :group
+
   field :field3315, 39, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field3316, 76, optional: true, type: :int32
+
   field :message3065, 63, optional: true, type: :group
+
   field :field3318, 54, optional: true, type: Benchmarks.GoogleMessage4.Enum2806, enum: true
+
   field :field3319, 46, optional: true, type: :int32
+
   field :field3320, 24, repeated: true, type: :string
+
   field :field3321, 38, optional: true, type: :fixed32
+
   field :field3322, 99, optional: true, type: :bytes
+
   field :field3323, 1, optional: true, type: :fixed64
+
   field :field3324, 97, optional: true, type: :fixed64
+
   field :field3325, 16, repeated: true, type: Benchmarks.GoogleMessage4.Message3040
+
   field :field3326, 61, repeated: true, type: Benchmarks.GoogleMessage4.Message3041
+
   field :message3066, 21, optional: true, type: :group
+
   field :field3328, 47, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field3329, 48, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field3330, 40, optional: true, type: :fixed64
+
   field :field3331, 86, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field3332, 59, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field3333, 17, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12949 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message8572 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -494,112 +587,159 @@ defmodule Benchmarks.GoogleMessage4.Message8572 do
           field8696: Benchmarks.GoogleMessage4.Message8575.t() | nil
         }
 
-  defstruct [
-    :field8647,
-    :field8648,
-    :field8649,
-    :field8650,
-    :field8651,
-    :field8652,
-    :field8653,
-    :field8654,
-    :field8655,
-    :field8656,
-    :field8657,
-    :field8658,
-    :field8659,
-    :field8660,
-    :field8661,
-    :field8662,
-    :field8663,
-    :field8664,
-    :field8665,
-    :field8666,
-    :field8667,
-    :field8668,
-    :field8669,
-    :field8670,
-    :field8671,
-    :field8672,
-    :field8673,
-    :field8674,
-    :field8675,
-    :field8676,
-    :field8677,
-    :field8678,
-    :field8679,
-    :field8680,
-    :field8681,
-    :field8682,
-    :field8683,
-    :field8684,
-    :field8685,
-    :field8686,
-    :field8687,
-    :field8688,
-    :field8689,
-    :field8690,
-    :field8691,
-    :field8692,
-    :field8693,
-    :field8694,
-    :field8695,
-    :field8696
-  ]
+  defstruct field8647: nil,
+            field8648: nil,
+            field8649: nil,
+            field8650: nil,
+            field8651: nil,
+            field8652: nil,
+            field8653: nil,
+            field8654: nil,
+            field8655: nil,
+            field8656: nil,
+            field8657: nil,
+            field8658: nil,
+            field8659: nil,
+            field8660: nil,
+            field8661: nil,
+            field8662: nil,
+            field8663: nil,
+            field8664: nil,
+            field8665: nil,
+            field8666: nil,
+            field8667: nil,
+            field8668: nil,
+            field8669: nil,
+            field8670: nil,
+            field8671: nil,
+            field8672: nil,
+            field8673: nil,
+            field8674: nil,
+            field8675: nil,
+            field8676: nil,
+            field8677: nil,
+            field8678: nil,
+            field8679: nil,
+            field8680: nil,
+            field8681: nil,
+            field8682: nil,
+            field8683: nil,
+            field8684: nil,
+            field8685: nil,
+            field8686: nil,
+            field8687: nil,
+            field8688: nil,
+            field8689: nil,
+            field8690: nil,
+            field8691: nil,
+            field8692: nil,
+            field8693: nil,
+            field8694: nil,
+            field8695: nil,
+            field8696: nil
 
   field :field8647, 1, optional: true, type: :bytes
+
   field :field8648, 3, optional: true, type: :bytes
+
   field :field8649, 4, optional: true, type: Benchmarks.GoogleMessage4.Message3886
+
   field :field8650, 57, optional: true, type: Benchmarks.GoogleMessage4.Message3919
+
   field :field8651, 5, optional: true, type: :bool
+
   field :field8652, 6, optional: true, type: :int32
+
   field :field8653, 49, optional: true, type: :int32
+
   field :field8654, 7, optional: true, type: Benchmarks.GoogleMessage4.Message7905
+
   field :field8655, 10, optional: true, type: :int32
+
   field :field8656, 11, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8657, 35, optional: true, type: :bool
+
   field :field8658, 12, optional: true, type: :bytes
+
   field :field8659, 14, optional: true, type: :string
+
   field :field8660, 13, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8661, 15, optional: true, type: :bytes
+
   field :field8662, 17, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8663, 18, optional: true, type: :int32
+
   field :field8664, 19, optional: true, type: :int32
+
   field :field8665, 20, optional: true, type: :bool
+
   field :field8666, 31, optional: true, type: Benchmarks.GoogleMessage4.Enum3476, enum: true
+
   field :field8667, 36, optional: true, type: :bool
+
   field :field8668, 39, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8669, 22, optional: true, type: :bytes
+
   field :field8670, 24, optional: true, type: :int32
+
   field :field8671, 25, optional: true, type: Benchmarks.GoogleMessage4.Message3052
+
   field :field8672, 26, optional: true, type: :bytes
+
   field :field8673, 28, optional: true, type: :bytes
+
   field :field8674, 29, optional: true, type: :int32
+
   field :field8675, 30, optional: true, type: :bytes
+
   field :field8676, 32, optional: true, type: :bytes
+
   field :field8677, 33, optional: true, type: :string
+
   field :field8678, 34, optional: true, type: :int32
+
   field :field8679, 37, optional: true, type: :int32
+
   field :field8680, 38, optional: true, type: :double
+
   field :field8681, 42, optional: true, type: :double
+
   field :field8682, 40, optional: true, type: Benchmarks.GoogleMessage4.Message3922
+
   field :field8683, 43, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8684, 44, optional: true, type: :int64
+
   field :field8685, 45, optional: true, type: Benchmarks.GoogleMessage4.Message7929
+
   field :field8686, 46, optional: true, type: :uint64
+
   field :field8687, 48, optional: true, type: :uint32
+
   field :field8688, 47, optional: true, type: Benchmarks.GoogleMessage4.Message7843
+
   field :field8689, 50, optional: true, type: Benchmarks.GoogleMessage4.Message7864
+
   field :field8690, 52, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8691, 58, optional: true, type: :bool
+
   field :field8692, 54, optional: true, type: :bool
+
   field :field8693, 55, optional: true, type: :string
+
   field :field8694, 41, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8695, 53, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field8696, 61, optional: true, type: Benchmarks.GoogleMessage4.Message8575
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message8774 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -612,16 +752,24 @@ defmodule Benchmarks.GoogleMessage4.Message8774 do
           field8814: String.t()
         }
 
-  defstruct [:field8810, :field8811, :field8812, :field8813, :field8814]
+  defstruct field8810: nil,
+            field8811: nil,
+            field8812: nil,
+            field8813: nil,
+            field8814: nil
 
   field :field8810, 1, optional: true, type: :string
+
   field :field8811, 2, optional: true, type: :string
+
   field :field8812, 3, optional: true, type: :string
+
   field :field8813, 4, optional: true, type: :string
+
   field :field8814, 5, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12776 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -640,35 +788,42 @@ defmodule Benchmarks.GoogleMessage4.Message12776 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field12786,
-    :field12787,
-    :field12788,
-    :field12789,
-    :field12790,
-    :field12791,
-    :field12792,
-    :field12793,
-    :field12794,
-    :field12795,
-    :__pb_extensions__
-  ]
+  defstruct field12786: nil,
+            field12787: nil,
+            field12788: nil,
+            field12789: nil,
+            field12790: nil,
+            field12791: nil,
+            field12792: nil,
+            field12793: nil,
+            field12794: nil,
+            field12795: nil,
+            __pb_extensions__: nil
 
   field :field12786, 1, optional: true, type: :string
+
   field :field12787, 11, optional: true, type: :fixed64
+
   field :field12788, 6, optional: true, type: :int32
+
   field :field12789, 13, optional: true, type: :int32
+
   field :field12790, 14, optional: true, type: :int32
+
   field :field12791, 15, optional: true, type: :int32
+
   field :field12792, 16, optional: true, type: :int32
+
   field :field12793, 8, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field12794, 10, optional: true, type: Benchmarks.GoogleMessage4.Message12774
+
   field :field12795, 12, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   def transform_module(), do: nil
 
   extensions [{2, 3}, {3, 4}, {4, 5}, {5, 6}, {7, 8}, {9, 10}]
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12798 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -680,15 +835,21 @@ defmodule Benchmarks.GoogleMessage4.Message12798 do
           field12808: boolean
         }
 
-  defstruct [:field12805, :field12806, :field12807, :field12808]
+  defstruct field12805: nil,
+            field12806: nil,
+            field12807: nil,
+            field12808: nil
 
   field :field12805, 1, optional: true, type: :int32
+
   field :field12806, 2, optional: true, type: :int32
+
   field :field12807, 6, optional: true, type: Benchmarks.GoogleMessage4.Message12774
+
   field :field12808, 7, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12797 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -699,14 +860,18 @@ defmodule Benchmarks.GoogleMessage4.Message12797 do
           field12804: String.t()
         }
 
-  defstruct [:field12802, :field12803, :field12804]
+  defstruct field12802: nil,
+            field12803: [],
+            field12804: nil
 
   field :field12802, 1, optional: true, type: Benchmarks.GoogleMessage4.Message12796
+
   field :field12803, 2, repeated: true, type: Benchmarks.GoogleMessage4.Message12796
+
   field :field12804, 3, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12825 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -721,44 +886,50 @@ defmodule Benchmarks.GoogleMessage4.Message12825 do
           field12868: [Benchmarks.GoogleMessage4.UnusedEmptyMessage.t()]
         }
 
-  defstruct [
-    :field12862,
-    :field12863,
-    :field12864,
-    :field12865,
-    :field12866,
-    :field12867,
-    :field12868
-  ]
+  defstruct field12862: [],
+            field12863: nil,
+            field12864: nil,
+            field12865: nil,
+            field12866: nil,
+            field12867: [],
+            field12868: []
 
   field :field12862, 1, repeated: true, type: Benchmarks.GoogleMessage4.Message12818
+
   field :field12863, 2, optional: true, type: :int32
+
   field :field12864, 3, optional: true, type: Benchmarks.GoogleMessage4.Message12819
+
   field :field12865, 4, optional: true, type: Benchmarks.GoogleMessage4.Message12820
+
   field :field12866, 5, optional: true, type: :int32
+
   field :field12867, 6, repeated: true, type: Benchmarks.GoogleMessage4.Message12821
+
   field :field12868, 7, repeated: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message8590 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message8587 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message1374 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -768,13 +939,15 @@ defmodule Benchmarks.GoogleMessage4.Message1374 do
           field1376: String.t()
         }
 
-  defstruct [:field1375, :field1376]
+  defstruct field1375: "",
+            field1376: nil
 
   field :field1375, 1, required: true, type: :string
+
   field :field1376, 2, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message2462 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -784,13 +957,15 @@ defmodule Benchmarks.GoogleMessage4.Message2462 do
           field2497: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [:field2496, :field2497]
+  defstruct field2496: "",
+            field2497: 0.0
 
   field :field2496, 1, required: true, type: :bytes
+
   field :field2497, 2, required: true, type: :double
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12685 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -805,26 +980,30 @@ defmodule Benchmarks.GoogleMessage4.Message12685 do
           field12698: String.t()
         }
 
-  defstruct [
-    :field12692,
-    :field12693,
-    :field12694,
-    :field12695,
-    :field12696,
-    :field12697,
-    :field12698
-  ]
+  defstruct field12692: [],
+            field12693: [],
+            field12694: nil,
+            field12695: nil,
+            field12696: [],
+            field12697: nil,
+            field12698: nil
 
   field :field12692, 1, repeated: true, type: :string
+
   field :field12693, 2, repeated: true, type: :string
+
   field :field12694, 3, optional: true, type: :int64
+
   field :field12695, 4, optional: true, type: :uint32
+
   field :field12696, 5, repeated: true, type: :string
+
   field :field12697, 6, optional: true, type: :string
+
   field :field12698, 7, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message10320 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -839,26 +1018,30 @@ defmodule Benchmarks.GoogleMessage4.Message10320 do
           field10353: Benchmarks.GoogleMessage4.Enum10337.t()
         }
 
-  defstruct [
-    :field10347,
-    :field10348,
-    :field10349,
-    :field10350,
-    :field10351,
-    :field10352,
-    :field10353
-  ]
+  defstruct field10347: nil,
+            field10348: [],
+            field10349: nil,
+            field10350: nil,
+            field10351: nil,
+            field10352: nil,
+            field10353: nil
 
   field :field10347, 1, optional: true, type: Benchmarks.GoogleMessage4.Enum10335, enum: true
+
   field :field10348, 2, repeated: true, type: Benchmarks.GoogleMessage4.Message10319
+
   field :field10349, 3, optional: true, type: :int32
+
   field :field10350, 4, optional: true, type: :int32
+
   field :field10351, 5, optional: true, type: :int32
+
   field :field10352, 6, optional: true, type: :int32
+
   field :field10353, 7, optional: true, type: Benchmarks.GoogleMessage4.Enum10337, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message11947 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -869,14 +1052,18 @@ defmodule Benchmarks.GoogleMessage4.Message11947 do
           field11953: integer
         }
 
-  defstruct [:field11951, :field11952, :field11953]
+  defstruct field11951: nil,
+            field11952: nil,
+            field11953: nil
 
   field :field11951, 1, optional: true, type: :uint32
+
   field :field11952, 2, optional: true, type: :bool
+
   field :field11953, 3, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message11920 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -886,13 +1073,15 @@ defmodule Benchmarks.GoogleMessage4.Message11920 do
           field11946: Benchmarks.GoogleMessage4.UnusedEnum.t()
         }
 
-  defstruct [:field11945, :field11946]
+  defstruct field11945: nil,
+            field11946: nil
 
   field :field11945, 1, optional: true, type: Benchmarks.GoogleMessage4.Enum11901, enum: true
+
   field :field11946, 2, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message6643 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -918,48 +1107,63 @@ defmodule Benchmarks.GoogleMessage4.Message6643 do
           field6700: integer
         }
 
-  defstruct [
-    :field6683,
-    :field6684,
-    :field6685,
-    :field6686,
-    :field6687,
-    :field6688,
-    :field6689,
-    :field6690,
-    :field6691,
-    :field6692,
-    :field6693,
-    :field6694,
-    :field6695,
-    :field6696,
-    :field6697,
-    :field6698,
-    :field6699,
-    :field6700
-  ]
+  defstruct field6683: nil,
+            field6684: nil,
+            field6685: nil,
+            field6686: nil,
+            field6687: nil,
+            field6688: nil,
+            field6689: nil,
+            field6690: nil,
+            field6691: nil,
+            field6692: nil,
+            field6693: nil,
+            field6694: nil,
+            field6695: nil,
+            field6696: nil,
+            field6697: [],
+            field6698: nil,
+            field6699: nil,
+            field6700: nil
 
   field :field6683, 3, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field6684, 4, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field6685, 5, optional: true, type: :double
+
   field :field6686, 6, optional: true, type: :double
+
   field :field6687, 1, optional: true, type: :int32
+
   field :field6688, 2, optional: true, type: :int32
+
   field :field6689, 9, optional: true, type: :double
+
   field :field6690, 10, optional: true, type: :bytes
+
   field :field6691, 11, optional: true, type: :int32
+
   field :field6692, 12, optional: true, type: :bool
+
   field :field6693, 13, optional: true, type: :bool
+
   field :field6694, 15, optional: true, type: Benchmarks.GoogleMessage4.Message6578
+
   field :field6695, 16, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
+
   field :field6696, 17, optional: true, type: :int64
+
   field :field6697, 22, repeated: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field6698, 19, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field6699, 20, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field6700, 21, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message6133 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -987,52 +1191,69 @@ defmodule Benchmarks.GoogleMessage4.Message6133 do
           field6192: [Benchmarks.GoogleMessage4.Message5881.t()]
         }
 
-  defstruct [
-    :field6173,
-    :field6174,
-    :field6175,
-    :field6176,
-    :field6177,
-    :field6178,
-    :field6179,
-    :field6180,
-    :field6181,
-    :field6182,
-    :field6183,
-    :field6184,
-    :field6185,
-    :field6186,
-    :field6187,
-    :field6188,
-    :field6189,
-    :field6190,
-    :field6191,
-    :field6192
-  ]
+  defstruct field6173: nil,
+            field6174: nil,
+            field6175: "",
+            field6176: "",
+            field6177: "",
+            field6178: nil,
+            field6179: nil,
+            field6180: [],
+            field6181: [],
+            field6182: [],
+            field6183: [],
+            field6184: [],
+            field6185: nil,
+            field6186: nil,
+            field6187: nil,
+            field6188: nil,
+            field6189: nil,
+            field6190: nil,
+            field6191: nil,
+            field6192: []
 
   field :field6173, 12, optional: true, type: Benchmarks.GoogleMessage4.Message4016
+
   field :field6174, 16, optional: true, type: :double
+
   field :field6175, 1, required: true, type: :string
+
   field :field6176, 2, required: true, type: :string
+
   field :field6177, 3, required: true, type: :string
+
   field :field6178, 4, optional: true, type: :string
+
   field :field6179, 8, optional: true, type: :string
+
   field :field6180, 5, repeated: true, type: Benchmarks.GoogleMessage4.Message6109
+
   field :field6181, 13, repeated: true, type: Benchmarks.GoogleMessage4.Message5908
+
   field :field6182, 7, repeated: true, type: Benchmarks.GoogleMessage4.Message6107
+
   field :field6183, 9, repeated: true, type: Benchmarks.GoogleMessage4.Message6126
+
   field :field6184, 15, repeated: true, type: Benchmarks.GoogleMessage4.Message6129
+
   field :field6185, 10, optional: true, type: :int32
+
   field :field6186, 11, optional: true, type: :int32
+
   field :field6187, 17, optional: true, type: Benchmarks.GoogleMessage4.Message4016
+
   field :field6188, 14, optional: true, type: :double
+
   field :field6189, 18, optional: true, type: :double
+
   field :field6190, 19, optional: true, type: :string
+
   field :field6191, 20, optional: true, type: :string
+
   field :field6192, 21, repeated: true, type: Benchmarks.GoogleMessage4.Message5881
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message6109 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1053,39 +1274,48 @@ defmodule Benchmarks.GoogleMessage4.Message6109 do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :field6140,
-    :field6141,
-    :field6142,
-    :field6143,
-    :field6144,
-    :field6145,
-    :field6146,
-    :field6147,
-    :field6148,
-    :field6149,
-    :field6150,
-    :field6151,
-    :__pb_extensions__
-  ]
+  defstruct field6140: nil,
+            field6141: 0,
+            field6142: nil,
+            field6143: nil,
+            field6144: [],
+            field6145: [],
+            field6146: [],
+            field6147: nil,
+            field6148: [],
+            field6149: nil,
+            field6150: nil,
+            field6151: nil,
+            __pb_extensions__: nil
 
   field :field6140, 1, optional: true, type: :string
+
   field :field6141, 2, required: true, type: Benchmarks.GoogleMessage4.Enum6111, enum: true
+
   field :field6142, 9, optional: true, type: :int32
+
   field :field6143, 3, optional: true, type: :string
+
   field :field6144, 4, repeated: true, type: Benchmarks.GoogleMessage4.Message6110
+
   field :field6145, 7, repeated: true, type: :int32
+
   field :field6146, 8, repeated: true, type: :int32
+
   field :field6147, 10, optional: true, type: Benchmarks.GoogleMessage4.Message6133
+
   field :field6148, 11, repeated: true, type: :int32
+
   field :field6149, 12, optional: true, type: :string
+
   field :field6150, 13, optional: true, type: :string
+
   field :field6151, 14, optional: true, type: :bool
+
   def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3046 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1095,13 +1325,15 @@ defmodule Benchmarks.GoogleMessage4.Message3046 do
           field3223: integer
         }
 
-  defstruct [:field3222, :field3223]
+  defstruct field3222: 0,
+            field3223: nil
 
   field :field3222, 1, required: true, type: Benchmarks.GoogleMessage4.Enum2593, enum: true
+
   field :field3223, 4, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3060 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1112,14 +1344,18 @@ defmodule Benchmarks.GoogleMessage4.Message3060 do
           field3285: integer
         }
 
-  defstruct [:field3283, :field3284, :field3285]
+  defstruct field3283: nil,
+            field3284: nil,
+            field3285: nil
 
   field :field3283, 1, optional: true, type: :int64
+
   field :field3284, 2, optional: true, type: :int64
+
   field :field3285, 3, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3041 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1129,13 +1365,15 @@ defmodule Benchmarks.GoogleMessage4.Message3041 do
           field3215: integer
         }
 
-  defstruct [:field3214, :field3215]
+  defstruct field3214: nil,
+            field3215: nil
 
   field :field3214, 1, optional: true, type: :string
+
   field :field3215, 2, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3040 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1148,16 +1386,24 @@ defmodule Benchmarks.GoogleMessage4.Message3040 do
           field3213: String.t()
         }
 
-  defstruct [:field3209, :field3210, :field3211, :field3212, :field3213]
+  defstruct field3209: 0,
+            field3210: [],
+            field3211: nil,
+            field3212: nil,
+            field3213: ""
 
   field :field3209, 1, required: true, type: :fixed64
+
   field :field3210, 4, repeated: true, type: :fixed64
+
   field :field3211, 5, optional: true, type: :int32
+
   field :field3212, 2, optional: true, type: :fixed64
+
   field :field3213, 3, required: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3050 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1171,17 +1417,27 @@ defmodule Benchmarks.GoogleMessage4.Message3050 do
           field3250: non_neg_integer
         }
 
-  defstruct [:field3245, :field3246, :field3247, :field3248, :field3249, :field3250]
+  defstruct field3245: nil,
+            field3246: nil,
+            field3247: nil,
+            field3248: nil,
+            field3249: nil,
+            field3250: nil
 
   field :field3245, 5, optional: true, type: :bytes
+
   field :field3246, 2, optional: true, type: :int32
+
   field :field3247, 6, optional: true, type: :bytes
+
   field :field3248, 4, optional: true, type: :int32
+
   field :field3249, 1, optional: true, type: :fixed32
+
   field :field3250, 3, optional: true, type: :fixed32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7905 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1196,18 +1452,30 @@ defmodule Benchmarks.GoogleMessage4.Message7905 do
           field7917: integer
         }
 
-  defstruct [:field7911, :field7912, :field7913, :field7914, :field7915, :field7916, :field7917]
+  defstruct field7911: nil,
+            field7912: nil,
+            field7913: nil,
+            field7914: nil,
+            field7915: nil,
+            field7916: nil,
+            field7917: nil
 
   field :field7911, 1, optional: true, type: :int32
+
   field :field7912, 2, optional: true, type: :bool
+
   field :field7913, 3, optional: true, type: :bytes
+
   field :field7914, 4, optional: true, type: :int32
+
   field :field7915, 5, optional: true, type: :int32
+
   field :field7916, 6, optional: true, type: :bytes
+
   field :field7917, 7, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3886.Message3887 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1219,15 +1487,21 @@ defmodule Benchmarks.GoogleMessage4.Message3886.Message3887 do
           field3935: binary
         }
 
-  defstruct [:field3932, :field3933, :field3934, :field3935]
+  defstruct field3932: "",
+            field3933: nil,
+            field3934: nil,
+            field3935: nil
 
   field :field3932, 2, required: true, type: :string
+
   field :field3933, 9, optional: true, type: :string
+
   field :field3934, 3, optional: true, type: Benchmarks.GoogleMessage4.Message3850
+
   field :field3935, 8, optional: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3886 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1236,12 +1510,12 @@ defmodule Benchmarks.GoogleMessage4.Message3886 do
           message3887: [any]
         }
 
-  defstruct [:message3887]
+  defstruct message3887: []
 
   field :message3887, 1, repeated: true, type: :group
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7864 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1255,17 +1529,27 @@ defmodule Benchmarks.GoogleMessage4.Message7864 do
           field7871: [Benchmarks.GoogleMessage4.UnusedEmptyMessage.t()]
         }
 
-  defstruct [:field7866, :field7867, :field7868, :field7869, :field7870, :field7871]
+  defstruct field7866: nil,
+            field7867: nil,
+            field7868: [],
+            field7869: [],
+            field7870: [],
+            field7871: []
 
   field :field7866, 1, optional: true, type: :string
+
   field :field7867, 2, optional: true, type: :string
+
   field :field7868, 5, repeated: true, type: Benchmarks.GoogleMessage4.Message7865
+
   field :field7869, 6, repeated: true, type: Benchmarks.GoogleMessage4.Message7865
+
   field :field7870, 7, repeated: true, type: Benchmarks.GoogleMessage4.Message7865
+
   field :field7871, 8, repeated: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3922 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1274,12 +1558,12 @@ defmodule Benchmarks.GoogleMessage4.Message3922 do
           field4012: non_neg_integer
         }
 
-  defstruct [:field4012]
+  defstruct field4012: nil
 
   field :field4012, 1, optional: true, type: :uint64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3052 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1296,39 +1580,46 @@ defmodule Benchmarks.GoogleMessage4.Message3052 do
           field3262: String.t()
         }
 
-  defstruct [
-    :field3254,
-    :field3255,
-    :field3256,
-    :field3257,
-    :field3258,
-    :field3259,
-    :field3260,
-    :field3261,
-    :field3262
-  ]
+  defstruct field3254: [],
+            field3255: [],
+            field3256: [],
+            field3257: [],
+            field3258: nil,
+            field3259: nil,
+            field3260: nil,
+            field3261: nil,
+            field3262: nil
 
   field :field3254, 1, repeated: true, type: :string
+
   field :field3255, 2, repeated: true, type: :string
+
   field :field3256, 3, repeated: true, type: :bytes
+
   field :field3257, 4, repeated: true, type: :string
+
   field :field3258, 5, optional: true, type: :bool
+
   field :field3259, 6, optional: true, type: :int32
+
   field :field3260, 7, optional: true, type: :int32
+
   field :field3261, 8, optional: true, type: :string
+
   field :field3262, 9, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message8575 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7843 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1352,44 +1643,57 @@ defmodule Benchmarks.GoogleMessage4.Message7843 do
           field7859: integer
         }
 
-  defstruct [
-    :field7844,
-    :field7845,
-    :field7846,
-    :field7847,
-    :field7848,
-    :field7849,
-    :field7850,
-    :field7851,
-    :field7852,
-    :field7853,
-    :field7854,
-    :field7855,
-    :field7856,
-    :field7857,
-    :field7858,
-    :field7859
-  ]
+  defstruct field7844: nil,
+            field7845: nil,
+            field7846: nil,
+            field7847: [],
+            field7848: [],
+            field7849: nil,
+            field7850: nil,
+            field7851: nil,
+            field7852: nil,
+            field7853: nil,
+            field7854: nil,
+            field7855: nil,
+            field7856: nil,
+            field7857: nil,
+            field7858: nil,
+            field7859: nil
 
   field :field7844, 5, optional: true, type: :bool
+
   field :field7845, 1, optional: true, type: :int32
+
   field :field7846, 22, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7847, 3, repeated: true, type: :int32
+
   field :field7848, 11, repeated: true, type: :string
+
   field :field7849, 15, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
+
   field :field7850, 6, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7851, 14, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7852, 10, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7853, 13, optional: true, type: Benchmarks.GoogleMessage4.Message7511
+
   field :field7854, 16, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7855, 17, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7856, 19, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7857, 18, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7858, 20, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
+
   field :field7859, 2, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3919 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1398,12 +1702,12 @@ defmodule Benchmarks.GoogleMessage4.Message3919 do
           field4009: [Benchmarks.GoogleMessage4.Message3920.t()]
         }
 
-  defstruct [:field4009]
+  defstruct field4009: []
 
   field :field4009, 1, repeated: true, type: Benchmarks.GoogleMessage4.Message3920
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7929 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -1431,48 +1735,66 @@ defmodule Benchmarks.GoogleMessage4.Message7929 do
           field7961: integer
         }
 
-  defstruct [
-    :field7942,
-    :field7943,
-    :field7944,
-    :field7945,
-    :field7946,
-    :field7947,
-    :field7948,
-    :field7949,
-    :field7950,
-    :field7951,
-    :field7952,
-    :field7953,
-    :field7954,
-    :field7955,
-    :field7956,
-    :field7957,
-    :field7958,
-    :field7959,
-    :field7960,
-    :field7961
-  ]
+  defstruct field7942: nil,
+            field7943: nil,
+            field7944: nil,
+            field7945: nil,
+            field7946: nil,
+            field7947: nil,
+            field7948: nil,
+            field7949: nil,
+            field7950: [],
+            field7951: [],
+            field7952: [],
+            field7953: [],
+            field7954: [],
+            field7955: nil,
+            field7956: nil,
+            field7957: nil,
+            field7958: nil,
+            field7959: [],
+            field7960: [],
+            field7961: nil
 
   field :field7942, 1, optional: true, type: :int64
+
   field :field7943, 4, optional: true, type: :int64
+
   field :field7944, 5, optional: true, type: :int64
+
   field :field7945, 12, optional: true, type: :int64
+
   field :field7946, 13, optional: true, type: :int64
+
   field :field7947, 18, optional: true, type: :int64
+
   field :field7948, 6, optional: true, type: :int64
+
   field :field7949, 7, optional: true, type: :int64
+
   field :field7950, 8, repeated: true, type: Benchmarks.GoogleMessage4.Message7919
+
   field :field7951, 20, repeated: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7952, 14, repeated: true, type: Benchmarks.GoogleMessage4.Message7920
+
   field :field7953, 15, repeated: true, type: Benchmarks.GoogleMessage4.Message7921
+
   field :field7954, 17, repeated: true, type: Benchmarks.GoogleMessage4.Message7928
+
   field :field7955, 19, optional: true, type: :int64
+
   field :field7956, 2, optional: true, type: :bool
+
   field :field7957, 3, optional: true, type: :int64
+
   field :field7958, 9, optional: true, type: :int64
+
   field :field7959, 10, repeated: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field7960, 11, repeated: true, type: :bytes
+
   field :field7961, 16, optional: true, type: :int64
+
   def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message4/benchmark_message4_2.pb.ex
+++ b/bench/lib/datasets/google_message4/benchmark_message4_2.pb.ex
@@ -11,17 +11,27 @@ defmodule Benchmarks.GoogleMessage4.Message12774 do
           field12782: boolean
         }
 
-  defstruct [:field12777, :field12778, :field12779, :field12780, :field12781, :field12782]
+  defstruct field12777: nil,
+            field12778: nil,
+            field12779: nil,
+            field12780: nil,
+            field12781: nil,
+            field12782: nil
 
   field :field12777, 1, optional: true, type: :uint32
+
   field :field12778, 2, optional: true, type: :uint32
+
   field :field12779, 3, optional: true, type: :uint32
+
   field :field12780, 4, optional: true, type: :uint32
+
   field :field12781, 5, optional: true, type: :uint32
+
   field :field12782, 6, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12796 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -31,13 +41,15 @@ defmodule Benchmarks.GoogleMessage4.Message12796 do
           field12801: non_neg_integer
         }
 
-  defstruct [:field12800, :field12801]
+  defstruct field12800: [],
+            field12801: nil
 
   field :field12800, 1, repeated: true, type: :fixed64
+
   field :field12801, 2, optional: true, type: :uint64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12821 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -50,16 +62,24 @@ defmodule Benchmarks.GoogleMessage4.Message12821 do
           field12852: integer
         }
 
-  defstruct [:field12848, :field12849, :field12850, :field12851, :field12852]
+  defstruct field12848: nil,
+            field12849: nil,
+            field12850: nil,
+            field12851: nil,
+            field12852: nil
 
   field :field12848, 1, optional: true, type: :int32
+
   field :field12849, 2, optional: true, type: :int32
+
   field :field12850, 3, optional: true, type: :int32
+
   field :field12851, 4, optional: true, type: :int32
+
   field :field12852, 5, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12820 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -75,28 +95,33 @@ defmodule Benchmarks.GoogleMessage4.Message12820 do
           field12847: integer
         }
 
-  defstruct [
-    :field12840,
-    :field12841,
-    :field12842,
-    :field12843,
-    :field12844,
-    :field12845,
-    :field12846,
-    :field12847
-  ]
+  defstruct field12840: nil,
+            field12841: nil,
+            field12842: nil,
+            field12843: nil,
+            field12844: nil,
+            field12845: nil,
+            field12846: nil,
+            field12847: nil
 
   field :field12840, 1, optional: true, type: :int32
+
   field :field12841, 2, optional: true, type: :int32
+
   field :field12842, 3, optional: true, type: :int32
+
   field :field12843, 8, optional: true, type: :int32
+
   field :field12844, 4, optional: true, type: :int32
+
   field :field12845, 5, optional: true, type: :int32
+
   field :field12846, 6, optional: true, type: :int32
+
   field :field12847, 7, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12819 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -110,17 +135,27 @@ defmodule Benchmarks.GoogleMessage4.Message12819 do
           field12839: float | :infinity | :negative_infinity | :nan
         }
 
-  defstruct [:field12834, :field12835, :field12836, :field12837, :field12838, :field12839]
+  defstruct field12834: nil,
+            field12835: nil,
+            field12836: nil,
+            field12837: nil,
+            field12838: nil,
+            field12839: nil
 
   field :field12834, 1, optional: true, type: :double
+
   field :field12835, 2, optional: true, type: :double
+
   field :field12836, 3, optional: true, type: :double
+
   field :field12837, 4, optional: true, type: :double
+
   field :field12838, 5, optional: true, type: :double
+
   field :field12839, 6, optional: true, type: :double
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12818 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -133,16 +168,24 @@ defmodule Benchmarks.GoogleMessage4.Message12818 do
           field12833: [Benchmarks.GoogleMessage4.Message12817.t()]
         }
 
-  defstruct [:field12829, :field12830, :field12831, :field12832, :field12833]
+  defstruct field12829: nil,
+            field12830: nil,
+            field12831: nil,
+            field12832: nil,
+            field12833: []
 
   field :field12829, 1, optional: true, type: :uint64
+
   field :field12830, 2, optional: true, type: :int32
+
   field :field12831, 3, optional: true, type: :int32
+
   field :field12832, 5, optional: true, type: :int32
+
   field :field12833, 4, repeated: true, type: Benchmarks.GoogleMessage4.Message12817
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message10319 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -157,26 +200,30 @@ defmodule Benchmarks.GoogleMessage4.Message10319 do
           field10346: String.t()
         }
 
-  defstruct [
-    :field10340,
-    :field10341,
-    :field10342,
-    :field10343,
-    :field10344,
-    :field10345,
-    :field10346
-  ]
+  defstruct field10340: nil,
+            field10341: nil,
+            field10342: nil,
+            field10343: nil,
+            field10344: nil,
+            field10345: nil,
+            field10346: nil
 
   field :field10340, 1, optional: true, type: Benchmarks.GoogleMessage4.Enum10325, enum: true
+
   field :field10341, 4, optional: true, type: :int32
+
   field :field10342, 5, optional: true, type: :int32
+
   field :field10343, 3, optional: true, type: :bytes
+
   field :field10344, 2, optional: true, type: :string
+
   field :field10345, 6, optional: true, type: :string
+
   field :field10346, 7, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message6578 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -186,13 +233,15 @@ defmodule Benchmarks.GoogleMessage4.Message6578 do
           field6633: Benchmarks.GoogleMessage4.Enum6588.t()
         }
 
-  defstruct [:field6632, :field6633]
+  defstruct field6632: nil,
+            field6633: nil
 
   field :field6632, 1, optional: true, type: Benchmarks.GoogleMessage4.Enum6579, enum: true
+
   field :field6633, 2, optional: true, type: Benchmarks.GoogleMessage4.Enum6588, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message6126 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -219,50 +268,66 @@ defmodule Benchmarks.GoogleMessage4.Message6126 do
           field6170: integer
         }
 
-  defstruct [
-    :field6152,
-    :field6153,
-    :field6154,
-    :field6155,
-    :field6156,
-    :field6157,
-    :field6158,
-    :field6159,
-    :field6160,
-    :field6161,
-    :field6162,
-    :field6163,
-    :field6164,
-    :field6165,
-    :field6166,
-    :field6167,
-    :field6168,
-    :field6169,
-    :field6170
-  ]
+  defstruct field6152: "",
+            field6153: [],
+            field6154: nil,
+            field6155: nil,
+            field6156: nil,
+            field6157: nil,
+            field6158: nil,
+            field6159: nil,
+            field6160: [],
+            field6161: [],
+            field6162: [],
+            field6163: [],
+            field6164: nil,
+            field6165: [],
+            field6166: nil,
+            field6167: nil,
+            field6168: nil,
+            field6169: [],
+            field6170: nil
 
   field :field6152, 1, required: true, type: :string
+
   field :field6153, 9, repeated: true, type: Benchmarks.GoogleMessage4.Message6127
+
   field :field6154, 14, optional: true, type: :int32
+
   field :field6155, 10, optional: true, type: :bytes
+
   field :field6156, 12, optional: true, type: Benchmarks.GoogleMessage4.Message6024
+
   field :field6157, 4, optional: true, type: :int32
+
   field :field6158, 5, optional: true, type: :string
+
   field :field6159, 6, optional: true, type: :int32
+
   field :field6160, 2, repeated: true, type: :int32
+
   field :field6161, 3, repeated: true, type: :int32
+
   field :field6162, 7, repeated: true, type: Benchmarks.GoogleMessage4.Message6052
+
   field :field6163, 11, repeated: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field6164, 15, optional: true, type: Benchmarks.GoogleMessage4.Enum6065, enum: true
+
   field :field6165, 8, repeated: true, type: Benchmarks.GoogleMessage4.Message6127
+
   field :field6166, 13, optional: true, type: :bool
+
   field :field6167, 16, optional: true, type: :bool
+
   field :field6168, 18, optional: true, type: :bool
+
   field :field6169, 17, repeated: true, type: Benchmarks.GoogleMessage4.Message6054
+
   field :field6170, 19, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message5881 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -276,26 +341,37 @@ defmodule Benchmarks.GoogleMessage4.Message5881 do
           field5902: Benchmarks.GoogleMessage4.Message5880.t() | nil
         }
 
-  defstruct [:field5897, :field5898, :field5899, :field5900, :field5901, :field5902]
+  defstruct field5897: 0.0,
+            field5898: nil,
+            field5899: nil,
+            field5900: nil,
+            field5901: nil,
+            field5902: nil
 
   field :field5897, 1, required: true, type: :double
+
   field :field5898, 5, optional: true, type: :string
+
   field :field5899, 2, optional: true, type: Benchmarks.GoogleMessage4.Message5861
+
   field :field5900, 3, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   field :field5901, 4, optional: true, type: Benchmarks.GoogleMessage4.Message5867
+
   field :field5902, 6, optional: true, type: Benchmarks.GoogleMessage4.Message5880
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message6110 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message6107 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -309,17 +385,27 @@ defmodule Benchmarks.GoogleMessage4.Message6107 do
           field6139: [Benchmarks.GoogleMessage4.Message6108.t()]
         }
 
-  defstruct [:field6134, :field6135, :field6136, :field6137, :field6138, :field6139]
+  defstruct field6134: nil,
+            field6135: nil,
+            field6136: nil,
+            field6137: [],
+            field6138: nil,
+            field6139: []
 
   field :field6134, 1, optional: true, type: Benchmarks.GoogleMessage4.Message4016
+
   field :field6135, 2, optional: true, type: :int32
+
   field :field6136, 3, optional: true, type: :string
+
   field :field6137, 4, repeated: true, type: :int32
+
   field :field6138, 5, optional: true, type: :int32
+
   field :field6139, 6, repeated: true, type: Benchmarks.GoogleMessage4.Message6108
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message6129 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -329,13 +415,15 @@ defmodule Benchmarks.GoogleMessage4.Message6129 do
           field6172: String.t()
         }
 
-  defstruct [:field6171, :field6172]
+  defstruct field6171: 0,
+            field6172: ""
 
   field :field6171, 1, required: true, type: Benchmarks.GoogleMessage4.Enum6130, enum: true
+
   field :field6172, 2, required: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message5908 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -393,112 +481,159 @@ defmodule Benchmarks.GoogleMessage4.Message5908 do
           field6020: Benchmarks.GoogleMessage4.Enum5962.t()
         }
 
-  defstruct [
-    :field5971,
-    :field5972,
-    :field5973,
-    :field5974,
-    :field5975,
-    :field5976,
-    :field5977,
-    :field5978,
-    :field5979,
-    :field5980,
-    :field5981,
-    :field5982,
-    :field5983,
-    :field5984,
-    :field5985,
-    :field5986,
-    :field5987,
-    :field5988,
-    :field5989,
-    :field5990,
-    :field5991,
-    :field5992,
-    :field5993,
-    :field5994,
-    :field5995,
-    :field5996,
-    :field5997,
-    :field5998,
-    :field5999,
-    :field6000,
-    :field6001,
-    :field6002,
-    :field6003,
-    :field6004,
-    :field6005,
-    :field6006,
-    :field6007,
-    :field6008,
-    :field6009,
-    :field6010,
-    :field6011,
-    :field6012,
-    :field6013,
-    :field6014,
-    :field6015,
-    :field6016,
-    :field6017,
-    :field6018,
-    :field6019,
-    :field6020
-  ]
+  defstruct field5971: nil,
+            field5972: nil,
+            field5973: nil,
+            field5974: nil,
+            field5975: nil,
+            field5976: nil,
+            field5977: nil,
+            field5978: nil,
+            field5979: nil,
+            field5980: nil,
+            field5981: nil,
+            field5982: nil,
+            field5983: nil,
+            field5984: nil,
+            field5985: nil,
+            field5986: nil,
+            field5987: nil,
+            field5988: nil,
+            field5989: [],
+            field5990: nil,
+            field5991: nil,
+            field5992: nil,
+            field5993: nil,
+            field5994: nil,
+            field5995: nil,
+            field5996: nil,
+            field5997: nil,
+            field5998: nil,
+            field5999: nil,
+            field6000: nil,
+            field6001: nil,
+            field6002: nil,
+            field6003: [],
+            field6004: nil,
+            field6005: nil,
+            field6006: nil,
+            field6007: nil,
+            field6008: nil,
+            field6009: nil,
+            field6010: nil,
+            field6011: nil,
+            field6012: nil,
+            field6013: nil,
+            field6014: nil,
+            field6015: nil,
+            field6016: nil,
+            field6017: nil,
+            field6018: nil,
+            field6019: nil,
+            field6020: nil
 
   field :field5971, 1, optional: true, type: :string
+
   field :field5972, 2, optional: true, type: :int32
+
   field :field5973, 3, optional: true, type: :int32
+
   field :field5974, 45, optional: true, type: Benchmarks.GoogleMessage4.Enum5909, enum: true
+
   field :field5975, 4, optional: true, type: Benchmarks.GoogleMessage4.Enum5912, enum: true
+
   field :field5976, 50, optional: true, type: :fixed32
+
   field :field5977, 5, optional: true, type: :fixed32
+
   field :field5978, 6, optional: true, type: :fixed32
+
   field :field5979, 7, optional: true, type: :string
+
   field :field5980, 8, optional: true, type: Benchmarks.GoogleMessage4.Enum5915, enum: true
+
   field :field5981, 9, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5982, 10, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5983, 11, optional: true, type: Benchmarks.GoogleMessage4.Enum5920, enum: true
+
   field :field5984, 40, optional: true, type: Benchmarks.GoogleMessage4.Enum5923, enum: true
+
   field :field5985, 41, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5986, 42, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5987, 47, optional: true, type: Benchmarks.GoogleMessage4.Enum5928, enum: true
+
   field :field5988, 48, optional: true, type: :bool
+
   field :field5989, 49, repeated: true, type: :fixed32
+
   field :field5990, 12, optional: true, type: :string
+
   field :field5991, 13, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5992, 14, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5993, 15, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5994, 16, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5995, 32, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5996, 33, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5997, 34, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5998, 35, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5999, 17, optional: true, type: Benchmarks.GoogleMessage4.Enum5931, enum: true
+
   field :field6000, 18, optional: true, type: Benchmarks.GoogleMessage4.Enum5935, enum: true
+
   field :field6001, 36, optional: true, type: Benchmarks.GoogleMessage4.Enum5939, enum: true
+
   field :field6002, 37, optional: true, type: Benchmarks.GoogleMessage4.Enum5939, enum: true
+
   field :field6003, 19, repeated: true, type: :int32
+
   field :field6004, 20, optional: true, type: :uint32
+
   field :field6005, 21, optional: true, type: :uint32
+
   field :field6006, 22, optional: true, type: :uint32
+
   field :field6007, 23, optional: true, type: :uint32
+
   field :field6008, 24, optional: true, type: Benchmarks.GoogleMessage4.Enum5946, enum: true
+
   field :field6009, 25, optional: true, type: Benchmarks.GoogleMessage4.Enum5946, enum: true
+
   field :field6010, 26, optional: true, type: Benchmarks.GoogleMessage4.Enum5946, enum: true
+
   field :field6011, 27, optional: true, type: Benchmarks.GoogleMessage4.Enum5946, enum: true
+
   field :field6012, 28, optional: true, type: :fixed32
+
   field :field6013, 29, optional: true, type: :fixed32
+
   field :field6014, 30, optional: true, type: :fixed32
+
   field :field6015, 31, optional: true, type: :fixed32
+
   field :field6016, 38, optional: true, type: :int32
+
   field :field6017, 39, optional: true, type: :float
+
   field :field6018, 43, optional: true, type: Benchmarks.GoogleMessage4.Enum5957, enum: true
+
   field :field6019, 44, optional: true, type: Benchmarks.GoogleMessage4.Message5907
+
   field :field6020, 46, optional: true, type: Benchmarks.GoogleMessage4.Enum5962, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3850 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -512,26 +647,37 @@ defmodule Benchmarks.GoogleMessage4.Message3850 do
           field3929: boolean
         }
 
-  defstruct [:field3924, :field3925, :field3926, :field3927, :field3928, :field3929]
+  defstruct field3924: nil,
+            field3925: nil,
+            field3926: nil,
+            field3927: nil,
+            field3928: nil,
+            field3929: nil
 
   field :field3924, 2, optional: true, type: Benchmarks.GoogleMessage4.Enum3851, enum: true
+
   field :field3925, 12, optional: true, type: :bool
+
   field :field3926, 4, optional: true, type: :int32
+
   field :field3927, 10, optional: true, type: :bool
+
   field :field3928, 13, optional: true, type: :bool
+
   field :field3929, 14, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7865 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7511 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -546,27 +692,40 @@ defmodule Benchmarks.GoogleMessage4.Message7511 do
           field7529: integer
         }
 
-  defstruct [:field7523, :field7524, :field7525, :field7526, :field7527, :field7528, :field7529]
+  defstruct field7523: nil,
+            field7524: nil,
+            field7525: nil,
+            field7526: nil,
+            field7527: nil,
+            field7528: nil,
+            field7529: nil
 
   field :field7523, 1, optional: true, type: :bool
+
   field :field7524, 2, optional: true, type: Benchmarks.GoogleMessage4.Enum7512, enum: true
+
   field :field7525, 3, optional: true, type: :int32
+
   field :field7526, 4, optional: true, type: :int32
+
   field :field7527, 5, optional: true, type: :bool
+
   field :field7528, 6, optional: true, type: :int32
+
   field :field7529, 7, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message3920 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7928 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -576,13 +735,15 @@ defmodule Benchmarks.GoogleMessage4.Message7928 do
           field7941: integer
         }
 
-  defstruct [:field7940, :field7941]
+  defstruct field7940: nil,
+            field7941: nil
 
   field :field7940, 1, optional: true, type: :string
+
   field :field7941, 2, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7921 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -594,15 +755,21 @@ defmodule Benchmarks.GoogleMessage4.Message7921 do
           field7939: Benchmarks.GoogleMessage4.Enum7922.t()
         }
 
-  defstruct [:field7936, :field7937, :field7938, :field7939]
+  defstruct field7936: nil,
+            field7937: nil,
+            field7938: nil,
+            field7939: nil
 
   field :field7936, 1, optional: true, type: :int32
+
   field :field7937, 2, optional: true, type: :int64
+
   field :field7938, 3, optional: true, type: :float
+
   field :field7939, 4, optional: true, type: Benchmarks.GoogleMessage4.Enum7922, enum: true
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7920 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -612,13 +779,15 @@ defmodule Benchmarks.GoogleMessage4.Message7920 do
           field7935: integer
         }
 
-  defstruct [:field7934, :field7935]
+  defstruct field7934: nil,
+            field7935: nil
 
   field :field7934, 1, optional: true, type: :int64
+
   field :field7935, 2, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message7919 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -629,14 +798,18 @@ defmodule Benchmarks.GoogleMessage4.Message7919 do
           field7933: binary
         }
 
-  defstruct [:field7931, :field7932, :field7933]
+  defstruct field7931: nil,
+            field7932: nil,
+            field7933: nil
 
   field :field7931, 1, optional: true, type: :fixed64
+
   field :field7932, 2, optional: true, type: :int64
+
   field :field7933, 3, optional: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message12817 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -647,14 +820,18 @@ defmodule Benchmarks.GoogleMessage4.Message12817 do
           field12828: integer
         }
 
-  defstruct [:field12826, :field12827, :field12828]
+  defstruct field12826: nil,
+            field12827: nil,
+            field12828: nil
 
   field :field12826, 1, optional: true, type: :int32
+
   field :field12827, 2, optional: true, type: :int32
+
   field :field12828, 3, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message6054 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -664,22 +841,25 @@ defmodule Benchmarks.GoogleMessage4.Message6054 do
           field6090: String.t()
         }
 
-  defstruct [:field6089, :field6090]
+  defstruct field6089: "",
+            field6090: nil
 
   field :field6089, 1, required: true, type: :string
+
   field :field6090, 2, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message6127 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message6052 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -689,13 +869,15 @@ defmodule Benchmarks.GoogleMessage4.Message6052 do
           field6085: binary
         }
 
-  defstruct [:field6084, :field6085]
+  defstruct field6084: "",
+            field6085: ""
 
   field :field6084, 1, required: true, type: :string
+
   field :field6085, 2, required: true, type: :bytes
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message6024 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -706,14 +888,18 @@ defmodule Benchmarks.GoogleMessage4.Message6024 do
           field6050: Benchmarks.GoogleMessage4.UnusedEmptyMessage.t() | nil
         }
 
-  defstruct [:field6048, :field6049, :field6050]
+  defstruct field6048: nil,
+            field6049: nil,
+            field6050: nil
 
   field :field6048, 1, optional: true, type: Benchmarks.GoogleMessage4.Enum6025, enum: true
+
   field :field6049, 2, optional: true, type: :string
+
   field :field6050, 3, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message5861 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -725,15 +911,21 @@ defmodule Benchmarks.GoogleMessage4.Message5861 do
           field5885: String.t()
         }
 
-  defstruct [:field5882, :field5883, :field5884, :field5885]
+  defstruct field5882: 0,
+            field5883: "",
+            field5884: nil,
+            field5885: nil
 
   field :field5882, 1, required: true, type: Benchmarks.GoogleMessage4.Enum5862, enum: true
+
   field :field5883, 2, required: true, type: :string
+
   field :field5884, 3, optional: true, type: :bool
+
   field :field5885, 4, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message5880 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -742,12 +934,12 @@ defmodule Benchmarks.GoogleMessage4.Message5880 do
           field5896: String.t()
         }
 
-  defstruct [:field5896]
+  defstruct field5896: nil
 
   field :field5896, 1, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message5867 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -761,17 +953,27 @@ defmodule Benchmarks.GoogleMessage4.Message5867 do
           field5895: boolean
         }
 
-  defstruct [:field5890, :field5891, :field5892, :field5893, :field5894, :field5895]
+  defstruct field5890: nil,
+            field5891: nil,
+            field5892: nil,
+            field5893: nil,
+            field5894: nil,
+            field5895: nil
 
   field :field5890, 1, optional: true, type: Benchmarks.GoogleMessage4.Enum5868, enum: true
+
   field :field5891, 2, optional: true, type: :string
+
   field :field5892, 3, optional: true, type: Benchmarks.GoogleMessage4.Enum5873, enum: true
+
   field :field5893, 4, optional: true, type: :int32
+
   field :field5894, 5, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
+
   field :field5895, 6, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message4016 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -783,24 +985,31 @@ defmodule Benchmarks.GoogleMessage4.Message4016 do
           field4020: integer
         }
 
-  defstruct [:field4017, :field4018, :field4019, :field4020]
+  defstruct field4017: 0,
+            field4018: 0,
+            field4019: 0,
+            field4020: 0
 
   field :field4017, 1, required: true, type: :int32
+
   field :field4018, 2, required: true, type: :int32
+
   field :field4019, 3, required: true, type: :int32
+
   field :field4020, 4, required: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message6108 do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message5907 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -812,24 +1021,31 @@ defmodule Benchmarks.GoogleMessage4.Message5907 do
           field5970: Benchmarks.GoogleMessage4.Message5903.t() | nil
         }
 
-  defstruct [:field5967, :field5968, :field5969, :field5970]
+  defstruct field5967: nil,
+            field5968: nil,
+            field5969: nil,
+            field5970: nil
 
   field :field5967, 1, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5968, 2, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5969, 3, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   field :field5970, 4, optional: true, type: Benchmarks.GoogleMessage4.Message5903
+
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.UnusedEmptyMessage do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule Benchmarks.GoogleMessage4.Message5903 do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -839,9 +1055,12 @@ defmodule Benchmarks.GoogleMessage4.Message5903 do
           field5966: Benchmarks.GoogleMessage4.Enum5904.t()
         }
 
-  defstruct [:field5965, :field5966]
+  defstruct field5965: 0,
+            field5966: nil
 
   field :field5965, 1, required: true, type: :int32
+
   field :field5966, 2, optional: true, type: Benchmarks.GoogleMessage4.Enum5904, enum: true
+
   def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message4/benchmark_message4_3.pb.ex
+++ b/bench/lib/datasets/google_message4/benchmark_message4_3.pb.ex
@@ -1,12 +1,12 @@
 defmodule Benchmarks.GoogleMessage4.UnusedEnum do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :UNUSED_ENUM_VALUE1 | :UNUSED_ENUM_VALUE2
 
   field :UNUSED_ENUM_VALUE1, 0
   field :UNUSED_ENUM_VALUE2, 1
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum2593 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -31,17 +31,16 @@ defmodule Benchmarks.GoogleMessage4.Enum2593 do
   field :ENUM_VALUE2600, 6
   field :ENUM_VALUE2601, 7
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum2834 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE2835 | :ENUM_VALUE2836 | :ENUM_VALUE2837
 
   field :ENUM_VALUE2835, 0
   field :ENUM_VALUE2836, 1
   field :ENUM_VALUE2837, 2
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum2806 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -80,7 +79,6 @@ defmodule Benchmarks.GoogleMessage4.Enum2806 do
   field :ENUM_VALUE2820, 13
   field :ENUM_VALUE2821, 14
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum2851 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -331,7 +329,6 @@ defmodule Benchmarks.GoogleMessage4.Enum2851 do
   field :ENUM_VALUE2971, 118
   field :ENUM_VALUE2972, 119
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum2602 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -364,7 +361,6 @@ defmodule Benchmarks.GoogleMessage4.Enum2602 do
   field :ENUM_VALUE2613, 10
   field :ENUM_VALUE2614, 11
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum3071 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -429,7 +425,6 @@ defmodule Benchmarks.GoogleMessage4.Enum3071 do
   field :ENUM_VALUE3098, 27
   field :ENUM_VALUE3099, 28
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum3805 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -462,7 +457,6 @@ defmodule Benchmarks.GoogleMessage4.Enum3805 do
   field :ENUM_VALUE3816, 11
   field :ENUM_VALUE3817, 10
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum3783 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -511,7 +505,6 @@ defmodule Benchmarks.GoogleMessage4.Enum3783 do
   field :ENUM_VALUE3802, 21
   field :ENUM_VALUE3803, 50
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum3851 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -556,20 +549,20 @@ defmodule Benchmarks.GoogleMessage4.Enum3851 do
   field :ENUM_VALUE3868, 16
   field :ENUM_VALUE3869, 17
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5862 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5863 | :ENUM_VALUE5864 | :ENUM_VALUE5865
 
   field :ENUM_VALUE5863, 1
   field :ENUM_VALUE5864, 2
   field :ENUM_VALUE5865, 3
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5868 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5869 | :ENUM_VALUE5870 | :ENUM_VALUE5871 | :ENUM_VALUE5872
 
   field :ENUM_VALUE5869, 0
@@ -577,47 +570,47 @@ defmodule Benchmarks.GoogleMessage4.Enum5868 do
   field :ENUM_VALUE5871, 2
   field :ENUM_VALUE5872, 3
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5873 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5874 | :ENUM_VALUE5875 | :ENUM_VALUE5876
 
   field :ENUM_VALUE5874, 0
   field :ENUM_VALUE5875, 1
   field :ENUM_VALUE5876, 2
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5904 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5905 | :ENUM_VALUE5906
 
   field :ENUM_VALUE5905, 0
   field :ENUM_VALUE5906, 1
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5909 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5910 | :ENUM_VALUE5911
 
   field :ENUM_VALUE5910, 0
   field :ENUM_VALUE5911, 1
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5912 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5913 | :ENUM_VALUE5914
 
   field :ENUM_VALUE5913, 0
   field :ENUM_VALUE5914, 1
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5915 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5916 | :ENUM_VALUE5917 | :ENUM_VALUE5918 | :ENUM_VALUE5919
 
   field :ENUM_VALUE5916, 0
@@ -625,19 +618,19 @@ defmodule Benchmarks.GoogleMessage4.Enum5915 do
   field :ENUM_VALUE5918, 2
   field :ENUM_VALUE5919, 3
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5920 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5921 | :ENUM_VALUE5922
 
   field :ENUM_VALUE5921, 0
   field :ENUM_VALUE5922, 1
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5923 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5924 | :ENUM_VALUE5925 | :ENUM_VALUE5926 | :ENUM_VALUE5927
 
   field :ENUM_VALUE5924, 0
@@ -645,36 +638,35 @@ defmodule Benchmarks.GoogleMessage4.Enum5923 do
   field :ENUM_VALUE5926, 2
   field :ENUM_VALUE5927, 3
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5928 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5929 | :ENUM_VALUE5930
 
   field :ENUM_VALUE5929, 0
   field :ENUM_VALUE5930, 1
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5931 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5932 | :ENUM_VALUE5933 | :ENUM_VALUE5934
 
   field :ENUM_VALUE5932, 0
   field :ENUM_VALUE5933, 1
   field :ENUM_VALUE5934, 2
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5935 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5936 | :ENUM_VALUE5937 | :ENUM_VALUE5938
 
   field :ENUM_VALUE5936, 0
   field :ENUM_VALUE5937, 1
   field :ENUM_VALUE5938, 2
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5939 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -695,7 +687,6 @@ defmodule Benchmarks.GoogleMessage4.Enum5939 do
   field :ENUM_VALUE5944, 4
   field :ENUM_VALUE5945, 5
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5946 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -724,10 +715,10 @@ defmodule Benchmarks.GoogleMessage4.Enum5946 do
   field :ENUM_VALUE5955, 8
   field :ENUM_VALUE5956, 9
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5957 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5958 | :ENUM_VALUE5959 | :ENUM_VALUE5960 | :ENUM_VALUE5961
 
   field :ENUM_VALUE5958, 0
@@ -735,16 +726,15 @@ defmodule Benchmarks.GoogleMessage4.Enum5957 do
   field :ENUM_VALUE5960, 2
   field :ENUM_VALUE5961, 3
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum5962 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE5963 | :ENUM_VALUE5964
 
   field :ENUM_VALUE5963, 0
   field :ENUM_VALUE5964, 1
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum6025 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -797,7 +787,6 @@ defmodule Benchmarks.GoogleMessage4.Enum6025 do
   field :ENUM_VALUE6046, 20
   field :ENUM_VALUE6047, 21
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum6111 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -834,7 +823,6 @@ defmodule Benchmarks.GoogleMessage4.Enum6111 do
   field :ENUM_VALUE6124, 13
   field :ENUM_VALUE6125, 14
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum6065 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -873,16 +861,15 @@ defmodule Benchmarks.GoogleMessage4.Enum6065 do
   field :ENUM_VALUE6079, 13
   field :ENUM_VALUE6080, 14
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum6130 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE6131 | :ENUM_VALUE6132
 
   field :ENUM_VALUE6131, 0
   field :ENUM_VALUE6132, 1
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum6579 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -907,7 +894,6 @@ defmodule Benchmarks.GoogleMessage4.Enum6579 do
   field :ENUM_VALUE6586, 25
   field :ENUM_VALUE6587, 30
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum6588 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -984,10 +970,10 @@ defmodule Benchmarks.GoogleMessage4.Enum6588 do
   field :ENUM_VALUE6621, 33
   field :ENUM_VALUE6622, 34
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum7288 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE7289 | :ENUM_VALUE7290 | :ENUM_VALUE7291 | :ENUM_VALUE7292
 
   field :ENUM_VALUE7289, 0
@@ -995,7 +981,6 @@ defmodule Benchmarks.GoogleMessage4.Enum7288 do
   field :ENUM_VALUE7291, 2
   field :ENUM_VALUE7292, 3
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum7512 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -1020,7 +1005,6 @@ defmodule Benchmarks.GoogleMessage4.Enum7512 do
   field :ENUM_VALUE7519, 6
   field :ENUM_VALUE7520, 7
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum7922 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -1039,7 +1023,6 @@ defmodule Benchmarks.GoogleMessage4.Enum7922 do
   field :ENUM_VALUE7926, 4
   field :ENUM_VALUE7927, 5
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum3476 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -1416,7 +1399,6 @@ defmodule Benchmarks.GoogleMessage4.Enum3476 do
   field :ENUM_VALUE3659, 182
   field :ENUM_VALUE3660, 183
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum10325 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -1443,27 +1425,27 @@ defmodule Benchmarks.GoogleMessage4.Enum10325 do
   field :ENUM_VALUE10333, 7
   field :ENUM_VALUE10334, 8
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum10335 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE10336
 
   field :ENUM_VALUE10336, 0
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum10337 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE10338 | :ENUM_VALUE10339
 
   field :ENUM_VALUE10338, 0
   field :ENUM_VALUE10339, 1
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum11901 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE11902 | :ENUM_VALUE11903 | :ENUM_VALUE11904 | :ENUM_VALUE11905
 
   field :ENUM_VALUE11902, 0
@@ -1471,10 +1453,10 @@ defmodule Benchmarks.GoogleMessage4.Enum11901 do
   field :ENUM_VALUE11904, 2
   field :ENUM_VALUE11905, 3
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum12735 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :ENUM_VALUE12736 | :ENUM_VALUE12737 | :ENUM_VALUE12738 | :ENUM_VALUE12739
 
   field :ENUM_VALUE12736, 0
@@ -1482,7 +1464,6 @@ defmodule Benchmarks.GoogleMessage4.Enum12735 do
   field :ENUM_VALUE12738, 2
   field :ENUM_VALUE12739, 3
 end
-
 defmodule Benchmarks.GoogleMessage4.Enum12871 do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2

--- a/lib/elixirpb.pb.ex
+++ b/lib/elixirpb.pb.ex
@@ -12,6 +12,7 @@ defmodule Elixirpb.FileOptions do
 
   def transform_module(), do: nil
 end
+
 defmodule Elixirpb.PbExtension do
   @moduledoc false
   use Protobuf, syntax: :proto2

--- a/lib/elixirpb.pb.ex
+++ b/lib/elixirpb.pb.ex
@@ -6,12 +6,12 @@ defmodule Elixirpb.FileOptions do
           module_prefix: String.t()
         }
 
-  defstruct [:module_prefix]
+  defstruct module_prefix: nil
 
   field :module_prefix, 1, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule Elixirpb.PbExtension do
   @moduledoc false
   use Protobuf, syntax: :proto2

--- a/lib/google/compiler/plugin.pb.ex
+++ b/lib/google/compiler/plugin.pb.ex
@@ -1,6 +1,7 @@
 defmodule Google.Protobuf.Compiler.CodeGeneratorResponse.Feature do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :FEATURE_NONE | :FEATURE_PROTO3_OPTIONAL
 
   field :FEATURE_NONE, 0
@@ -18,12 +19,19 @@ defmodule Google.Protobuf.Compiler.Version do
           suffix: String.t()
         }
 
-  defstruct [:major, :minor, :patch, :suffix]
+  defstruct major: nil,
+            minor: nil,
+            patch: nil,
+            suffix: nil
 
   field :major, 1, optional: true, type: :int32
+
   field :minor, 2, optional: true, type: :int32
+
   field :patch, 3, optional: true, type: :int32
+
   field :suffix, 4, optional: true, type: :string
+
   def transform_module(), do: nil
 end
 
@@ -38,12 +46,19 @@ defmodule Google.Protobuf.Compiler.CodeGeneratorRequest do
           compiler_version: Google.Protobuf.Compiler.Version.t() | nil
         }
 
-  defstruct [:file_to_generate, :parameter, :proto_file, :compiler_version]
+  defstruct file_to_generate: [],
+            parameter: nil,
+            proto_file: [],
+            compiler_version: nil
 
   field :file_to_generate, 1, repeated: true, type: :string
+
   field :parameter, 2, optional: true, type: :string
+
   field :proto_file, 15, repeated: true, type: Google.Protobuf.FileDescriptorProto
+
   field :compiler_version, 3, optional: true, type: Google.Protobuf.Compiler.Version
+
   def transform_module(), do: nil
 end
 
@@ -58,12 +73,19 @@ defmodule Google.Protobuf.Compiler.CodeGeneratorResponse.File do
           generated_code_info: Google.Protobuf.GeneratedCodeInfo.t() | nil
         }
 
-  defstruct [:name, :insertion_point, :content, :generated_code_info]
+  defstruct name: nil,
+            insertion_point: nil,
+            content: nil,
+            generated_code_info: nil
 
   field :name, 1, optional: true, type: :string
+
   field :insertion_point, 2, optional: true, type: :string
+
   field :content, 15, optional: true, type: :string
+
   field :generated_code_info, 16, optional: true, type: Google.Protobuf.GeneratedCodeInfo
+
   def transform_module(), do: nil
 end
 
@@ -77,10 +99,15 @@ defmodule Google.Protobuf.Compiler.CodeGeneratorResponse do
           file: [Google.Protobuf.Compiler.CodeGeneratorResponse.File.t()]
         }
 
-  defstruct [:error, :supported_features, :file]
+  defstruct error: nil,
+            supported_features: nil,
+            file: []
 
   field :error, 1, optional: true, type: :string
+
   field :supported_features, 2, optional: true, type: :uint64
+
   field :file, 15, repeated: true, type: Google.Protobuf.Compiler.CodeGeneratorResponse.File
+
   def transform_module(), do: nil
 end

--- a/lib/google/descriptor.pb.ex
+++ b/lib/google/descriptor.pb.ex
@@ -46,6 +46,7 @@ end
 defmodule Google.Protobuf.FieldDescriptorProto.Label do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :LABEL_OPTIONAL | :LABEL_REQUIRED | :LABEL_REPEATED
 
   field :LABEL_OPTIONAL, 1
@@ -56,6 +57,7 @@ end
 defmodule Google.Protobuf.FileOptions.OptimizeMode do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :SPEED | :CODE_SIZE | :LITE_RUNTIME
 
   field :SPEED, 1
@@ -66,6 +68,7 @@ end
 defmodule Google.Protobuf.FieldOptions.CType do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :STRING | :CORD | :STRING_PIECE
 
   field :STRING, 0
@@ -76,6 +79,7 @@ end
 defmodule Google.Protobuf.FieldOptions.JSType do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :JS_NORMAL | :JS_STRING | :JS_NUMBER
 
   field :JS_NORMAL, 0
@@ -86,6 +90,7 @@ end
 defmodule Google.Protobuf.MethodOptions.IdempotencyLevel do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :IDEMPOTENCY_UNKNOWN | :NO_SIDE_EFFECTS | :IDEMPOTENT
 
   field :IDEMPOTENCY_UNKNOWN, 0
@@ -101,9 +106,10 @@ defmodule Google.Protobuf.FileDescriptorSet do
           file: [Google.Protobuf.FileDescriptorProto.t()]
         }
 
-  defstruct [:file]
+  defstruct file: []
 
   field :file, 1, repeated: true, type: Google.Protobuf.FileDescriptorProto
+
   def transform_module(), do: nil
 end
 
@@ -126,33 +132,43 @@ defmodule Google.Protobuf.FileDescriptorProto do
           syntax: String.t()
         }
 
-  defstruct [
-    :name,
-    :package,
-    :dependency,
-    :public_dependency,
-    :weak_dependency,
-    :message_type,
-    :enum_type,
-    :service,
-    :extension,
-    :options,
-    :source_code_info,
-    :syntax
-  ]
+  defstruct name: nil,
+            package: nil,
+            dependency: [],
+            public_dependency: [],
+            weak_dependency: [],
+            message_type: [],
+            enum_type: [],
+            service: [],
+            extension: [],
+            options: nil,
+            source_code_info: nil,
+            syntax: nil
 
   field :name, 1, optional: true, type: :string
+
   field :package, 2, optional: true, type: :string
+
   field :dependency, 3, repeated: true, type: :string
+
   field :public_dependency, 10, repeated: true, type: :int32
+
   field :weak_dependency, 11, repeated: true, type: :int32
+
   field :message_type, 4, repeated: true, type: Google.Protobuf.DescriptorProto
+
   field :enum_type, 5, repeated: true, type: Google.Protobuf.EnumDescriptorProto
+
   field :service, 6, repeated: true, type: Google.Protobuf.ServiceDescriptorProto
+
   field :extension, 7, repeated: true, type: Google.Protobuf.FieldDescriptorProto
+
   field :options, 8, optional: true, type: Google.Protobuf.FileOptions
+
   field :source_code_info, 9, optional: true, type: Google.Protobuf.SourceCodeInfo
+
   field :syntax, 12, optional: true, type: :string
+
   def transform_module(), do: nil
 end
 
@@ -166,11 +182,16 @@ defmodule Google.Protobuf.DescriptorProto.ExtensionRange do
           options: Google.Protobuf.ExtensionRangeOptions.t() | nil
         }
 
-  defstruct [:start, :end, :options]
+  defstruct start: nil,
+            end: nil,
+            options: nil
 
   field :start, 1, optional: true, type: :int32
+
   field :end, 2, optional: true, type: :int32
+
   field :options, 3, optional: true, type: Google.Protobuf.ExtensionRangeOptions
+
   def transform_module(), do: nil
 end
 
@@ -183,10 +204,13 @@ defmodule Google.Protobuf.DescriptorProto.ReservedRange do
           end: integer
         }
 
-  defstruct [:start, :end]
+  defstruct start: nil,
+            end: nil
 
   field :start, 1, optional: true, type: :int32
+
   field :end, 2, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
 
@@ -207,29 +231,37 @@ defmodule Google.Protobuf.DescriptorProto do
           reserved_name: [String.t()]
         }
 
-  defstruct [
-    :name,
-    :field,
-    :extension,
-    :nested_type,
-    :enum_type,
-    :extension_range,
-    :oneof_decl,
-    :options,
-    :reserved_range,
-    :reserved_name
-  ]
+  defstruct name: nil,
+            field: [],
+            extension: [],
+            nested_type: [],
+            enum_type: [],
+            extension_range: [],
+            oneof_decl: [],
+            options: nil,
+            reserved_range: [],
+            reserved_name: []
 
   field :name, 1, optional: true, type: :string
+
   field :field, 2, repeated: true, type: Google.Protobuf.FieldDescriptorProto
+
   field :extension, 6, repeated: true, type: Google.Protobuf.FieldDescriptorProto
+
   field :nested_type, 3, repeated: true, type: Google.Protobuf.DescriptorProto
+
   field :enum_type, 4, repeated: true, type: Google.Protobuf.EnumDescriptorProto
+
   field :extension_range, 5, repeated: true, type: Google.Protobuf.DescriptorProto.ExtensionRange
+
   field :oneof_decl, 8, repeated: true, type: Google.Protobuf.OneofDescriptorProto
+
   field :options, 7, optional: true, type: Google.Protobuf.MessageOptions
+
   field :reserved_range, 9, repeated: true, type: Google.Protobuf.DescriptorProto.ReservedRange
+
   field :reserved_name, 10, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
 
@@ -242,9 +274,11 @@ defmodule Google.Protobuf.ExtensionRangeOptions do
           __pb_extensions__: map
         }
 
-  defstruct [:uninterpreted_option, :__pb_extensions__]
+  defstruct uninterpreted_option: [],
+            __pb_extensions__: nil
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
+
   def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
@@ -268,31 +302,40 @@ defmodule Google.Protobuf.FieldDescriptorProto do
           proto3_optional: boolean
         }
 
-  defstruct [
-    :name,
-    :number,
-    :label,
-    :type,
-    :type_name,
-    :extendee,
-    :default_value,
-    :oneof_index,
-    :json_name,
-    :options,
-    :proto3_optional
-  ]
+  defstruct name: nil,
+            number: nil,
+            label: nil,
+            type: nil,
+            type_name: nil,
+            extendee: nil,
+            default_value: nil,
+            oneof_index: nil,
+            json_name: nil,
+            options: nil,
+            proto3_optional: nil
 
   field :name, 1, optional: true, type: :string
+
   field :number, 3, optional: true, type: :int32
+
   field :label, 4, optional: true, type: Google.Protobuf.FieldDescriptorProto.Label, enum: true
+
   field :type, 5, optional: true, type: Google.Protobuf.FieldDescriptorProto.Type, enum: true
+
   field :type_name, 6, optional: true, type: :string
+
   field :extendee, 2, optional: true, type: :string
+
   field :default_value, 7, optional: true, type: :string
+
   field :oneof_index, 9, optional: true, type: :int32
+
   field :json_name, 10, optional: true, type: :string
+
   field :options, 8, optional: true, type: Google.Protobuf.FieldOptions
+
   field :proto3_optional, 17, optional: true, type: :bool
+
   def transform_module(), do: nil
 end
 
@@ -305,10 +348,13 @@ defmodule Google.Protobuf.OneofDescriptorProto do
           options: Google.Protobuf.OneofOptions.t() | nil
         }
 
-  defstruct [:name, :options]
+  defstruct name: nil,
+            options: nil
 
   field :name, 1, optional: true, type: :string
+
   field :options, 2, optional: true, type: Google.Protobuf.OneofOptions
+
   def transform_module(), do: nil
 end
 
@@ -321,10 +367,13 @@ defmodule Google.Protobuf.EnumDescriptorProto.EnumReservedRange do
           end: integer
         }
 
-  defstruct [:start, :end]
+  defstruct start: nil,
+            end: nil
 
   field :start, 1, optional: true, type: :int32
+
   field :end, 2, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
 
@@ -340,10 +389,16 @@ defmodule Google.Protobuf.EnumDescriptorProto do
           reserved_name: [String.t()]
         }
 
-  defstruct [:name, :value, :options, :reserved_range, :reserved_name]
+  defstruct name: nil,
+            value: [],
+            options: nil,
+            reserved_range: [],
+            reserved_name: []
 
   field :name, 1, optional: true, type: :string
+
   field :value, 2, repeated: true, type: Google.Protobuf.EnumValueDescriptorProto
+
   field :options, 3, optional: true, type: Google.Protobuf.EnumOptions
 
   field :reserved_range, 4,
@@ -351,6 +406,7 @@ defmodule Google.Protobuf.EnumDescriptorProto do
     type: Google.Protobuf.EnumDescriptorProto.EnumReservedRange
 
   field :reserved_name, 5, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
 
@@ -364,11 +420,16 @@ defmodule Google.Protobuf.EnumValueDescriptorProto do
           options: Google.Protobuf.EnumValueOptions.t() | nil
         }
 
-  defstruct [:name, :number, :options]
+  defstruct name: nil,
+            number: nil,
+            options: nil
 
   field :name, 1, optional: true, type: :string
+
   field :number, 2, optional: true, type: :int32
+
   field :options, 3, optional: true, type: Google.Protobuf.EnumValueOptions
+
   def transform_module(), do: nil
 end
 
@@ -382,11 +443,16 @@ defmodule Google.Protobuf.ServiceDescriptorProto do
           options: Google.Protobuf.ServiceOptions.t() | nil
         }
 
-  defstruct [:name, :method, :options]
+  defstruct name: nil,
+            method: [],
+            options: nil
 
   field :name, 1, optional: true, type: :string
+
   field :method, 2, repeated: true, type: Google.Protobuf.MethodDescriptorProto
+
   field :options, 3, optional: true, type: Google.Protobuf.ServiceOptions
+
   def transform_module(), do: nil
 end
 
@@ -403,14 +469,25 @@ defmodule Google.Protobuf.MethodDescriptorProto do
           server_streaming: boolean
         }
 
-  defstruct [:name, :input_type, :output_type, :options, :client_streaming, :server_streaming]
+  defstruct name: nil,
+            input_type: nil,
+            output_type: nil,
+            options: nil,
+            client_streaming: nil,
+            server_streaming: nil
 
   field :name, 1, optional: true, type: :string
+
   field :input_type, 2, optional: true, type: :string
+
   field :output_type, 3, optional: true, type: :string
+
   field :options, 4, optional: true, type: Google.Protobuf.MethodOptions
+
   field :client_streaming, 5, optional: true, type: :bool, default: false
+
   field :server_streaming, 6, optional: true, type: :bool, default: false
+
   def transform_module(), do: nil
 end
 
@@ -443,35 +520,37 @@ defmodule Google.Protobuf.FileOptions do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :java_package,
-    :java_outer_classname,
-    :java_multiple_files,
-    :java_generate_equals_and_hash,
-    :java_string_check_utf8,
-    :optimize_for,
-    :go_package,
-    :cc_generic_services,
-    :java_generic_services,
-    :py_generic_services,
-    :php_generic_services,
-    :deprecated,
-    :cc_enable_arenas,
-    :objc_class_prefix,
-    :csharp_namespace,
-    :swift_prefix,
-    :php_class_prefix,
-    :php_namespace,
-    :php_metadata_namespace,
-    :ruby_package,
-    :uninterpreted_option,
-    :__pb_extensions__
-  ]
+  defstruct java_package: nil,
+            java_outer_classname: nil,
+            java_multiple_files: nil,
+            java_generate_equals_and_hash: nil,
+            java_string_check_utf8: nil,
+            optimize_for: nil,
+            go_package: nil,
+            cc_generic_services: nil,
+            java_generic_services: nil,
+            py_generic_services: nil,
+            php_generic_services: nil,
+            deprecated: nil,
+            cc_enable_arenas: nil,
+            objc_class_prefix: nil,
+            csharp_namespace: nil,
+            swift_prefix: nil,
+            php_class_prefix: nil,
+            php_namespace: nil,
+            php_metadata_namespace: nil,
+            ruby_package: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: nil
 
   field :java_package, 1, optional: true, type: :string
+
   field :java_outer_classname, 8, optional: true, type: :string
+
   field :java_multiple_files, 10, optional: true, type: :bool, default: false
+
   field :java_generate_equals_and_hash, 20, optional: true, type: :bool, deprecated: true
+
   field :java_string_check_utf8, 27, optional: true, type: :bool, default: false
 
   field :optimize_for, 9,
@@ -481,20 +560,35 @@ defmodule Google.Protobuf.FileOptions do
     enum: true
 
   field :go_package, 11, optional: true, type: :string
+
   field :cc_generic_services, 16, optional: true, type: :bool, default: false
+
   field :java_generic_services, 17, optional: true, type: :bool, default: false
+
   field :py_generic_services, 18, optional: true, type: :bool, default: false
+
   field :php_generic_services, 42, optional: true, type: :bool, default: false
+
   field :deprecated, 23, optional: true, type: :bool, default: false
+
   field :cc_enable_arenas, 31, optional: true, type: :bool, default: true
+
   field :objc_class_prefix, 36, optional: true, type: :string
+
   field :csharp_namespace, 37, optional: true, type: :string
+
   field :swift_prefix, 39, optional: true, type: :string
+
   field :php_class_prefix, 40, optional: true, type: :string
+
   field :php_namespace, 41, optional: true, type: :string
+
   field :php_metadata_namespace, 44, optional: true, type: :string
+
   field :ruby_package, 45, optional: true, type: :string
+
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
+
   def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
@@ -513,20 +607,23 @@ defmodule Google.Protobuf.MessageOptions do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :message_set_wire_format,
-    :no_standard_descriptor_accessor,
-    :deprecated,
-    :map_entry,
-    :uninterpreted_option,
-    :__pb_extensions__
-  ]
+  defstruct message_set_wire_format: nil,
+            no_standard_descriptor_accessor: nil,
+            deprecated: nil,
+            map_entry: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: nil
 
   field :message_set_wire_format, 1, optional: true, type: :bool, default: false
+
   field :no_standard_descriptor_accessor, 2, optional: true, type: :bool, default: false
+
   field :deprecated, 3, optional: true, type: :bool, default: false
+
   field :map_entry, 7, optional: true, type: :bool
+
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
+
   def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
@@ -547,16 +644,14 @@ defmodule Google.Protobuf.FieldOptions do
           __pb_extensions__: map
         }
 
-  defstruct [
-    :ctype,
-    :packed,
-    :jstype,
-    :lazy,
-    :deprecated,
-    :weak,
-    :uninterpreted_option,
-    :__pb_extensions__
-  ]
+  defstruct ctype: nil,
+            packed: nil,
+            jstype: nil,
+            lazy: nil,
+            deprecated: nil,
+            weak: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: nil
 
   field :ctype, 1,
     optional: true,
@@ -573,9 +668,13 @@ defmodule Google.Protobuf.FieldOptions do
     enum: true
 
   field :lazy, 5, optional: true, type: :bool, default: false
+
   field :deprecated, 3, optional: true, type: :bool, default: false
+
   field :weak, 10, optional: true, type: :bool, default: false
+
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
+
   def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
@@ -590,9 +689,11 @@ defmodule Google.Protobuf.OneofOptions do
           __pb_extensions__: map
         }
 
-  defstruct [:uninterpreted_option, :__pb_extensions__]
+  defstruct uninterpreted_option: [],
+            __pb_extensions__: nil
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
+
   def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
@@ -609,11 +710,17 @@ defmodule Google.Protobuf.EnumOptions do
           __pb_extensions__: map
         }
 
-  defstruct [:allow_alias, :deprecated, :uninterpreted_option, :__pb_extensions__]
+  defstruct allow_alias: nil,
+            deprecated: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: nil
 
   field :allow_alias, 2, optional: true, type: :bool
+
   field :deprecated, 3, optional: true, type: :bool, default: false
+
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
+
   def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
@@ -629,10 +736,14 @@ defmodule Google.Protobuf.EnumValueOptions do
           __pb_extensions__: map
         }
 
-  defstruct [:deprecated, :uninterpreted_option, :__pb_extensions__]
+  defstruct deprecated: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: nil
 
   field :deprecated, 1, optional: true, type: :bool, default: false
+
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
+
   def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
@@ -648,10 +759,14 @@ defmodule Google.Protobuf.ServiceOptions do
           __pb_extensions__: map
         }
 
-  defstruct [:deprecated, :uninterpreted_option, :__pb_extensions__]
+  defstruct deprecated: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: nil
 
   field :deprecated, 33, optional: true, type: :bool, default: false
+
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
+
   def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
@@ -668,7 +783,10 @@ defmodule Google.Protobuf.MethodOptions do
           __pb_extensions__: map
         }
 
-  defstruct [:deprecated, :idempotency_level, :uninterpreted_option, :__pb_extensions__]
+  defstruct deprecated: nil,
+            idempotency_level: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: nil
 
   field :deprecated, 33, optional: true, type: :bool, default: false
 
@@ -679,6 +797,7 @@ defmodule Google.Protobuf.MethodOptions do
     enum: true
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
+
   def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
@@ -693,10 +812,13 @@ defmodule Google.Protobuf.UninterpretedOption.NamePart do
           is_extension: boolean
         }
 
-  defstruct [:name_part, :is_extension]
+  defstruct name_part: "",
+            is_extension: false
 
   field :name_part, 1, required: true, type: :string
+
   field :is_extension, 2, required: true, type: :bool
+
   def transform_module(), do: nil
 end
 
@@ -714,23 +836,28 @@ defmodule Google.Protobuf.UninterpretedOption do
           aggregate_value: String.t()
         }
 
-  defstruct [
-    :name,
-    :identifier_value,
-    :positive_int_value,
-    :negative_int_value,
-    :double_value,
-    :string_value,
-    :aggregate_value
-  ]
+  defstruct name: [],
+            identifier_value: nil,
+            positive_int_value: nil,
+            negative_int_value: nil,
+            double_value: nil,
+            string_value: nil,
+            aggregate_value: nil
 
   field :name, 2, repeated: true, type: Google.Protobuf.UninterpretedOption.NamePart
+
   field :identifier_value, 3, optional: true, type: :string
+
   field :positive_int_value, 4, optional: true, type: :uint64
+
   field :negative_int_value, 5, optional: true, type: :int64
+
   field :double_value, 6, optional: true, type: :double
+
   field :string_value, 7, optional: true, type: :bytes
+
   field :aggregate_value, 8, optional: true, type: :string
+
   def transform_module(), do: nil
 end
 
@@ -746,13 +873,22 @@ defmodule Google.Protobuf.SourceCodeInfo.Location do
           leading_detached_comments: [String.t()]
         }
 
-  defstruct [:path, :span, :leading_comments, :trailing_comments, :leading_detached_comments]
+  defstruct path: [],
+            span: [],
+            leading_comments: nil,
+            trailing_comments: nil,
+            leading_detached_comments: []
 
   field :path, 1, repeated: true, type: :int32, packed: true
+
   field :span, 2, repeated: true, type: :int32, packed: true
+
   field :leading_comments, 3, optional: true, type: :string
+
   field :trailing_comments, 4, optional: true, type: :string
+
   field :leading_detached_comments, 6, repeated: true, type: :string
+
   def transform_module(), do: nil
 end
 
@@ -764,9 +900,10 @@ defmodule Google.Protobuf.SourceCodeInfo do
           location: [Google.Protobuf.SourceCodeInfo.Location.t()]
         }
 
-  defstruct [:location]
+  defstruct location: []
 
   field :location, 1, repeated: true, type: Google.Protobuf.SourceCodeInfo.Location
+
   def transform_module(), do: nil
 end
 
@@ -781,12 +918,19 @@ defmodule Google.Protobuf.GeneratedCodeInfo.Annotation do
           end: integer
         }
 
-  defstruct [:path, :source_file, :begin, :end]
+  defstruct path: [],
+            source_file: nil,
+            begin: nil,
+            end: nil
 
   field :path, 1, repeated: true, type: :int32, packed: true
+
   field :source_file, 2, optional: true, type: :string
+
   field :begin, 3, optional: true, type: :int32
+
   field :end, 4, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
 
@@ -798,8 +942,9 @@ defmodule Google.Protobuf.GeneratedCodeInfo do
           annotation: [Google.Protobuf.GeneratedCodeInfo.Annotation.t()]
         }
 
-  defstruct [:annotation]
+  defstruct annotation: []
 
   field :annotation, 1, repeated: true, type: Google.Protobuf.GeneratedCodeInfo.Annotation
+
   def transform_module(), do: nil
 end

--- a/lib/protobuf/builder.ex
+++ b/lib/protobuf/builder.ex
@@ -35,6 +35,8 @@ defmodule Protobuf.Builder do
   def type_default(:double), do: 0.0
   def type_default(:bytes), do: <<>>
   def type_default(:string), do: ""
+  def type_default(:message), do: nil
+  def type_default(:group), do: nil
   def type_default(_), do: nil
 
   defp new_maybe_strict(mod, attrs, strict?) do

--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -121,7 +121,7 @@ defmodule Protobuf.Protoc.Generator.Message do
   end
 
   defp struct_default_value(%{type_enum: type}, _syntax) do
-    case type |> TypeUtil.from_enum() do
+    case TypeUtil.from_enum(type) do
       :enum -> {:enum, 0}
       other -> other
     end

--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -47,7 +47,7 @@ defmodule Protobuf.Protoc.Generator.Message do
          message_template(
            module: msg_name,
            use_options: msg_opts_str(ctx, desc.options),
-           struct_fields: struct_fields_with_defaults(ctx, desc, extensions),
+           struct_fields: struct_fields_with_defaults(ctx, desc, fields, extensions),
            struct_field_typespecs: struct_field_typespecs(fields, desc.oneof_decl, extensions),
            oneofs: desc.oneof_decl,
            fields: gen_fields(ctx.syntax, fields),
@@ -90,22 +90,43 @@ defmodule Protobuf.Protoc.Generator.Message do
     if String.length(str) > 0, do: ", " <> str, else: ""
   end
 
-  defp struct_fields_with_defaults(ctx, %Google.Protobuf.DescriptorProto{} = desc, extensions) do
-    oneof_fields = Enum.map(desc.oneof_decl, &{&1.name, nil})
+  defp struct_fields_with_defaults(ctx, desc, fields, extensions) do
+    oneof_fields = Enum.map(desc.oneof_decl, &{&1.name, _default = "nil"})
 
     fields =
-      for f <- desc.field,
-          !f.oneof_index,
-          do: {f.name, struct_default_value(f, ctx.syntax)}
+      for field <- fields,
+          is_nil(field.oneof),
+          do: {field.name, struct_default_value(field, ctx.syntax)}
 
     extensions_fields =
-      if Enum.empty?(extensions), do: [], else: [{:__pb_extensions__, _default = nil}]
+      if Enum.empty?(extensions), do: [], else: [{:__pb_extensions__, _default = "nil"}]
 
     oneof_fields ++ fields ++ extensions_fields
   end
 
-  defp struct_default_value(_, _) do
-    nil
+  defp struct_default_value(%{label: "optional"}, syntax) when syntax != :proto3 do
+    "nil"
+  end
+
+  defp struct_default_value(%{map: map}, _syntax) when not is_nil(map) do
+    "%{}"
+  end
+
+  defp struct_default_value(%{label: "repeated"}, _syntax) do
+    "[]"
+  end
+
+  defp struct_default_value(%{opts: %{default: default}}, _syntax) when is_binary(default) do
+    default
+  end
+
+  defp struct_default_value(%{type_enum: type}, _syntax) do
+    case type |> TypeUtil.from_enum() do
+      :enum -> {:enum, 0}
+      other -> other
+    end
+    |> Protobuf.Builder.type_default()
+    |> inspect()
   end
 
   defp struct_field_typespecs(fields, oneofs, extensions) do

--- a/mix.exs
+++ b/mix.exs
@@ -84,20 +84,23 @@ defmodule Protobuf.Mixfile do
         "escript.build",
         "cmd protoc -I src -I test/protobuf/protoc/proto --elixir_out=test/protobuf/protoc/proto_gen --plugin=./protoc-gen-elixir test/protobuf/protoc/proto/extension.proto",
         "cmd protoc -I src -I test/protobuf/protoc/proto --elixir_out=test/protobuf/protoc/proto_gen --elixir_opt=package_prefix=my --plugin=./protoc-gen-elixir test/protobuf/protoc/proto/test.proto",
-        "cmd protoc -I src --elixir_out=lib --plugin=./protoc-gen-elixir elixirpb.proto"
+        "cmd protoc -I src --elixir_out=lib --plugin=./protoc-gen-elixir elixirpb.proto",
+        "format"
       ],
       # $PROTO_LIB should be your local path to https://github.com/google/protobuf/tree/master/src/google/protobuf
       gen_google_protos: [
         "escript.build",
         require_env_variable("PROTO_LIB"),
         "cmd protoc -I $PROTO_LIB --elixir_out=lib/google --plugin=./protoc-gen-elixir descriptor.proto",
-        "cmd protoc -I $PROTO_LIB --elixir_out=lib/google --plugin=./protoc-gen-elixir compiler/plugin.proto"
+        "cmd protoc -I $PROTO_LIB --elixir_out=lib/google --plugin=./protoc-gen-elixir compiler/plugin.proto",
+        "format"
       ],
       # $PROTO_BENCH should be your local path to https://github.com/google/protobuf/tree/master/benchmarks
       gen_bench_protos: [
         "escript.build",
         require_env_variable("PROTO_BENCH"),
-        "cmd protoc -I $PROTO_BENCH --elixir_out=bench/lib --plugin=./protoc-gen-elixir #{Enum.join(benchmark_proto_files(), " ")}"
+        "cmd protoc -I $PROTO_BENCH --elixir_out=bench/lib --plugin=./protoc-gen-elixir #{Enum.join(benchmark_proto_files(), " ")}",
+        "format"
       ]
     ]
   end

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -10,7 +10,7 @@ defmodule <%= @module %> do
 
   defstruct [
     <%= for {name, default_value} <- @struct_fields do %>
-    <%= name %>: <%= inspect(default_value) %>,
+    <%= name %>: <%= default_value %>,
     <% end %>
   ]
 

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -8,7 +8,11 @@ defmodule <%= @module %> do
     <% end %>
   }
 
-  defstruct [<%= @struct_fields %>]
+  defstruct [
+    <%= for {name, default_value} <- @struct_fields do %>
+    <%= name %>: <%= inspect(default_value) %>,
+    <% end %>
+  ]
 
   <%= if @descriptor_fun_body do %>
   def descriptor do

--- a/test/protobuf/protoc/generator/message_test.exs
+++ b/test/protobuf/protoc/generator/message_test.exs
@@ -79,7 +79,12 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       )
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
-    assert msg =~ "defstruct [:a, :b]\n"
+
+    assert msg =~ """
+             defstruct a: nil,
+                       b: nil
+           """
+
     assert msg =~ "a: integer"
     assert msg =~ "b: String.t()"
     assert msg =~ "field :a, 1, optional: true, type: :int32\n"
@@ -118,7 +123,13 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       )
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
-    assert msg =~ "defstruct [:a, :b, :c]\n"
+
+    assert msg =~ """
+             defstruct a: nil,
+                       b: nil,
+                       c: nil
+           """
+
     assert msg =~ "a: integer"
     assert msg =~ "b: String.t()"
     assert msg =~ "field :a, 1, type: :int32\n"
@@ -473,7 +484,13 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
            """
 
     refute msg =~ "a: integer,\n"
-    assert msg =~ "defstruct [:first, :second, :other]\n"
+
+    assert msg =~ """
+             defstruct first: nil,
+                       second: nil,
+                       other: nil
+           """
+
     assert msg =~ "oneof :first, 0\n"
     assert msg =~ "oneof :second, 1\n"
     assert msg =~ "field :a, 1, optional: true, type: :int32, oneof: 0\n"
@@ -509,7 +526,12 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
         )
 
       {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
-      assert msg =~ "defstruct [:simple, :the_field_name]\n"
+
+      assert msg =~ """
+               defstruct simple: nil,
+                         the_field_name: nil
+             """
+
       assert msg =~ "field :simple, 1, type: :int32\n"
       assert msg =~ "field :the_field_name, 2, type: :string, json_name: \"theFieldName\"\n"
     end
@@ -532,7 +554,8 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
         )
 
       {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
-      assert msg =~ "defstruct [:the_field_name]\n"
+
+      assert msg =~ "defstruct the_field_name: nil"
       assert msg =~ "field :the_field_name, 1, required: true, type: :string\n"
     end
   end

--- a/test/protobuf/protoc/proto_gen/extension.pb.ex
+++ b/test/protobuf/protoc/proto_gen/extension.pb.ex
@@ -6,8 +6,9 @@ defmodule Protobuf.Protoc.ExtTest.Foo do
           a: String.t()
         }
 
-  defstruct [:a]
+  defstruct a: nil
 
   field :a, 1, optional: true, type: :string
+
   def transform_module(), do: nil
 end

--- a/test/protobuf/protoc/proto_gen/test.pb.ex
+++ b/test/protobuf/protoc/proto_gen/test.pb.ex
@@ -1,41 +1,41 @@
 defmodule My.Test.HatType do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :FEDORA | :FEZ
 
   field :FEDORA, 1
   field :FEZ, 2
 end
-
 defmodule My.Test.Days do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :MONDAY | :TUESDAY | :LUNDI
 
   field :MONDAY, 1
   field :TUESDAY, 2
   field :LUNDI, 1
 end
-
 defmodule My.Test.Request.Color do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :RED | :GREEN | :BLUE
 
   field :RED, 0
   field :GREEN, 1
   field :BLUE, 2
 end
-
 defmodule My.Test.Reply.Entry.Game do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
+
   @type t :: integer | :FOOTBALL | :TENNIS
 
   field :FOOTBALL, 1
   field :TENNIS, 2
 end
-
 defmodule My.Test.Request.SomeGroup do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -44,12 +44,12 @@ defmodule My.Test.Request.SomeGroup do
           group_field: integer
         }
 
-  defstruct [:group_field]
+  defstruct group_field: nil
 
   field :group_field, 9, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule My.Test.Request.NameMappingEntry do
   @moduledoc false
   use Protobuf, map: true, syntax: :proto2
@@ -59,13 +59,15 @@ defmodule My.Test.Request.NameMappingEntry do
           value: String.t()
         }
 
-  defstruct [:key, :value]
+  defstruct key: nil,
+            value: nil
 
   field :key, 1, optional: true, type: :int32
+
   field :value, 2, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule My.Test.Request.MsgMappingEntry do
   @moduledoc false
   use Protobuf, map: true, syntax: :proto2
@@ -75,13 +77,15 @@ defmodule My.Test.Request.MsgMappingEntry do
           value: My.Test.Reply.t() | nil
         }
 
-  defstruct [:key, :value]
+  defstruct key: nil,
+            value: nil
 
   field :key, 1, optional: true, type: :sint64
+
   field :value, 2, optional: true, type: My.Test.Reply
+
   def transform_module(), do: nil
 end
-
 defmodule My.Test.Request do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -98,30 +102,36 @@ defmodule My.Test.Request do
           get_key: String.t()
         }
 
-  defstruct [
-    :key,
-    :hue,
-    :hat,
-    :deadline,
-    :somegroup,
-    :name_mapping,
-    :msg_mapping,
-    :reset,
-    :get_key
-  ]
+  defstruct key: [],
+            hue: nil,
+            hat: nil,
+            deadline: nil,
+            somegroup: nil,
+            name_mapping: %{},
+            msg_mapping: %{},
+            reset: nil,
+            get_key: nil
 
   field :key, 1, repeated: true, type: :int64
+
   field :hue, 3, optional: true, type: My.Test.Request.Color, enum: true
+
   field :hat, 4, optional: true, type: My.Test.HatType, default: :FEDORA, enum: true
+
   field :deadline, 7, optional: true, type: :float, default: "inf"
+
   field :somegroup, 8, optional: true, type: :group
+
   field :name_mapping, 14, repeated: true, type: My.Test.Request.NameMappingEntry, map: true
+
   field :msg_mapping, 15, repeated: true, type: My.Test.Request.MsgMappingEntry, map: true
+
   field :reset, 12, optional: true, type: :int32
+
   field :get_key, 16, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule My.Test.Reply.Entry do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -132,14 +142,18 @@ defmodule My.Test.Reply.Entry do
           _my_field_name_2: integer
         }
 
-  defstruct [:key_that_needs_1234camel_CasIng, :value, :_my_field_name_2]
+  defstruct key_that_needs_1234camel_CasIng: 0,
+            value: nil,
+            _my_field_name_2: nil
 
   field :key_that_needs_1234camel_CasIng, 1, required: true, type: :int64
+
   field :value, 2, optional: true, type: :int64, default: 7
+
   field :_my_field_name_2, 3, optional: true, type: :int64
+
   def transform_module(), do: nil
 end
-
 defmodule My.Test.Reply do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -150,15 +164,18 @@ defmodule My.Test.Reply do
           __pb_extensions__: map
         }
 
-  defstruct [:found, :compact_keys, :__pb_extensions__]
+  defstruct found: [],
+            compact_keys: [],
+            __pb_extensions__: nil
 
   field :found, 1, repeated: true, type: My.Test.Reply.Entry
+
   field :compact_keys, 2, repeated: true, type: :int32, packed: true
+
   def transform_module(), do: nil
 
   extensions [{100, 536_870_912}]
 end
-
 defmodule My.Test.OtherBase do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -168,23 +185,25 @@ defmodule My.Test.OtherBase do
           __pb_extensions__: map
         }
 
-  defstruct [:name, :__pb_extensions__]
+  defstruct name: nil,
+            __pb_extensions__: nil
 
   field :name, 1, optional: true, type: :string
+
   def transform_module(), do: nil
 
   extensions [{100, 536_870_912}]
 end
-
 defmodule My.Test.ReplyExtensions do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule My.Test.OtherReplyExtensions do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -193,23 +212,26 @@ defmodule My.Test.OtherReplyExtensions do
           key: integer
         }
 
-  defstruct [:key]
+  defstruct key: nil
 
   field :key, 1, optional: true, type: :int32
+
   def transform_module(), do: nil
 end
-
 defmodule My.Test.OldReply do
   @moduledoc false
   use Protobuf, syntax: :proto2
-  @type t :: %__MODULE__{__pb_extensions__: map}
-  defstruct [:__pb_extensions__]
+
+  @type t :: %__MODULE__{
+          __pb_extensions__: map
+        }
+
+  defstruct __pb_extensions__: nil
 
   def transform_module(), do: nil
 
   extensions [{100, 2_147_483_647}]
 end
-
 defmodule My.Test.Communique.SomeGroup do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -218,21 +240,22 @@ defmodule My.Test.Communique.SomeGroup do
           member: String.t()
         }
 
-  defstruct [:member]
+  defstruct member: nil
 
   field :member, 15, optional: true, type: :string
+
   def transform_module(), do: nil
 end
-
 defmodule My.Test.Communique.Delta do
   @moduledoc false
   use Protobuf, syntax: :proto2
+
   @type t :: %__MODULE__{}
+
   defstruct []
 
   def transform_module(), do: nil
 end
-
 defmodule My.Test.Communique do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -252,24 +275,35 @@ defmodule My.Test.Communique do
           make_me_cry: boolean
         }
 
-  defstruct [:union, :make_me_cry]
+  defstruct union: nil,
+            make_me_cry: nil
 
   oneof :union, 0
 
   field :make_me_cry, 1, optional: true, type: :bool
+
   field :number, 5, optional: true, type: :int32, oneof: 0
+
   field :name, 6, optional: true, type: :string, oneof: 0
+
   field :data, 7, optional: true, type: :bytes, oneof: 0
+
   field :temp_c, 8, optional: true, type: :double, oneof: 0
+
   field :height, 9, optional: true, type: :float, oneof: 0
+
   field :today, 10, optional: true, type: My.Test.Days, enum: true, oneof: 0
+
   field :maybe, 11, optional: true, type: :bool, oneof: 0
+
   field :delta, 12, optional: true, type: :sint32, oneof: 0
+
   field :msg, 13, optional: true, type: My.Test.Reply, oneof: 0
+
   field :somegroup, 14, optional: true, type: :group, oneof: 0
+
   def transform_module(), do: nil
 end
-
 defmodule My.Test.Options do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -278,18 +312,20 @@ defmodule My.Test.Options do
           opt1: String.t()
         }
 
-  defstruct [:opt1]
+  defstruct opt1: nil
 
   field :opt1, 1, optional: true, type: :string, deprecated: true
+
   def transform_module(), do: nil
 end
-
 defmodule My.Test.PbExtension do
   @moduledoc false
   use Protobuf, syntax: :proto2
 
   extend My.Test.Reply, :tag, 103, optional: true, type: :string
+
   extend My.Test.Reply, :donut, 106, optional: true, type: My.Test.OtherReplyExtensions
+
   extend My.Test.Reply, :"ReplyExtensions.time", 101, optional: true, type: :double
 
   extend My.Test.Reply, :"ReplyExtensions.carrot", 105,

--- a/test/protobuf/protoc/proto_gen/test.pb.ex
+++ b/test/protobuf/protoc/proto_gen/test.pb.ex
@@ -7,6 +7,7 @@ defmodule My.Test.HatType do
   field :FEDORA, 1
   field :FEZ, 2
 end
+
 defmodule My.Test.Days do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -17,6 +18,7 @@ defmodule My.Test.Days do
   field :TUESDAY, 2
   field :LUNDI, 1
 end
+
 defmodule My.Test.Request.Color do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -27,6 +29,7 @@ defmodule My.Test.Request.Color do
   field :GREEN, 1
   field :BLUE, 2
 end
+
 defmodule My.Test.Reply.Entry.Game do
   @moduledoc false
   use Protobuf, enum: true, syntax: :proto2
@@ -36,6 +39,7 @@ defmodule My.Test.Reply.Entry.Game do
   field :FOOTBALL, 1
   field :TENNIS, 2
 end
+
 defmodule My.Test.Request.SomeGroup do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -50,6 +54,7 @@ defmodule My.Test.Request.SomeGroup do
 
   def transform_module(), do: nil
 end
+
 defmodule My.Test.Request.NameMappingEntry do
   @moduledoc false
   use Protobuf, map: true, syntax: :proto2
@@ -68,6 +73,7 @@ defmodule My.Test.Request.NameMappingEntry do
 
   def transform_module(), do: nil
 end
+
 defmodule My.Test.Request.MsgMappingEntry do
   @moduledoc false
   use Protobuf, map: true, syntax: :proto2
@@ -86,6 +92,7 @@ defmodule My.Test.Request.MsgMappingEntry do
 
   def transform_module(), do: nil
 end
+
 defmodule My.Test.Request do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -132,6 +139,7 @@ defmodule My.Test.Request do
 
   def transform_module(), do: nil
 end
+
 defmodule My.Test.Reply.Entry do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -154,6 +162,7 @@ defmodule My.Test.Reply.Entry do
 
   def transform_module(), do: nil
 end
+
 defmodule My.Test.Reply do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -176,6 +185,7 @@ defmodule My.Test.Reply do
 
   extensions [{100, 536_870_912}]
 end
+
 defmodule My.Test.OtherBase do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -194,6 +204,7 @@ defmodule My.Test.OtherBase do
 
   extensions [{100, 536_870_912}]
 end
+
 defmodule My.Test.ReplyExtensions do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -204,6 +215,7 @@ defmodule My.Test.ReplyExtensions do
 
   def transform_module(), do: nil
 end
+
 defmodule My.Test.OtherReplyExtensions do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -218,6 +230,7 @@ defmodule My.Test.OtherReplyExtensions do
 
   def transform_module(), do: nil
 end
+
 defmodule My.Test.OldReply do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -232,6 +245,7 @@ defmodule My.Test.OldReply do
 
   extensions [{100, 2_147_483_647}]
 end
+
 defmodule My.Test.Communique.SomeGroup do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -246,6 +260,7 @@ defmodule My.Test.Communique.SomeGroup do
 
   def transform_module(), do: nil
 end
+
 defmodule My.Test.Communique.Delta do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -256,6 +271,7 @@ defmodule My.Test.Communique.Delta do
 
   def transform_module(), do: nil
 end
+
 defmodule My.Test.Communique do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -304,6 +320,7 @@ defmodule My.Test.Communique do
 
   def transform_module(), do: nil
 end
+
 defmodule My.Test.Options do
   @moduledoc false
   use Protobuf, syntax: :proto2
@@ -318,6 +335,7 @@ defmodule My.Test.Options do
 
   def transform_module(), do: nil
 end
+
 defmodule My.Test.PbExtension do
   @moduledoc false
   use Protobuf, syntax: :proto2


### PR DESCRIPTION
Closing https://github.com/elixir-protobuf/protobuf/pull/184 again in favor of this, which I think has a stronger overall approach. This is only step number 1 and not everything is working, but as far as I can tell, nothing is _broken_. We might generate `nil` in some places where we could be more precise, but I don't think we're generating anything wrong in any place.