### PR TITLE
Do not generate overridable transformer_module/0

### DIFF
--- a/bench/lib/benchmarks.pb.ex
+++ b/bench/lib/benchmarks.pb.ex
@@ -17,6 +17,4 @@ defmodule Benchmarks.BenchmarkDataset do
   field :message_name, 2, type: :string, json_name: "messageName"
 
   field :payload, 3, repeated: true, type: :bytes
-
-  def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message1/proto2/benchmark_message1_proto2.pb.ex
+++ b/bench/lib/datasets/google_message1/proto2/benchmark_message1_proto2.pb.ex
@@ -169,8 +169,6 @@ defmodule Benchmarks.Proto2.GoogleMessage1 do
   field :field129, 129, optional: true, type: :string, default: "xxxxxxxxxxxxxxxxxxxxx"
 
   field :field131, 131, optional: true, type: :int32, default: 0
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.Proto2.GoogleMessage1SubMessage do
   @moduledoc false
@@ -259,6 +257,4 @@ defmodule Benchmarks.Proto2.GoogleMessage1SubMessage do
   field :field207, 207, optional: true, type: :uint64
 
   field :field300, 300, optional: true, type: :uint64
-
-  def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message1/proto3/benchmark_message1_proto3.pb.ex
+++ b/bench/lib/datasets/google_message1/proto3/benchmark_message1_proto3.pb.ex
@@ -169,8 +169,6 @@ defmodule Benchmarks.Proto3.GoogleMessage1 do
   field :field129, 129, type: :string
 
   field :field131, 131, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.Proto3.GoogleMessage1SubMessage do
   @moduledoc false
@@ -259,6 +257,4 @@ defmodule Benchmarks.Proto3.GoogleMessage1SubMessage do
   field :field207, 207, type: :uint64
 
   field :field300, 300, type: :uint64
-
-  def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message2/benchmark_message2.pb.ex
+++ b/bench/lib/datasets/google_message2/benchmark_message2.pb.ex
@@ -69,8 +69,6 @@ defmodule Benchmarks.Proto2.GoogleMessage2.Group1 do
   field :field24, 24, optional: true, type: :string
 
   field :field31, 31, optional: true, type: Benchmarks.Proto2.GoogleMessage2GroupedMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.Proto2.GoogleMessage2 do
   @moduledoc false
@@ -199,8 +197,6 @@ defmodule Benchmarks.Proto2.GoogleMessage2 do
   field :field205, 205, optional: true, type: :bool, default: false
 
   field :field206, 206, optional: true, type: :bool, default: false
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.Proto2.GoogleMessage2GroupedMessage do
   @moduledoc false
@@ -253,6 +249,4 @@ defmodule Benchmarks.Proto2.GoogleMessage2GroupedMessage do
   field :field10, 10, optional: true, type: :float
 
   field :field11, 11, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message3/benchmark_message3.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3.pb.ex
@@ -65,8 +65,6 @@ defmodule Benchmarks.GoogleMessage3.GoogleMessage3 do
   field :field37532, 15, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
   field :field37533, 16, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message1327 do
   @moduledoc false
@@ -91,8 +89,6 @@ defmodule Benchmarks.GoogleMessage3.Message1327 do
   field :field1371, 5, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
   field :field1372, 6, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message3672.Message3673 do
   @moduledoc false
@@ -109,8 +105,6 @@ defmodule Benchmarks.GoogleMessage3.Message3672.Message3673 do
   field :field3738, 4, required: true, type: Benchmarks.GoogleMessage3.Enum3476, enum: true
 
   field :field3739, 5, required: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message3672.Message3674 do
   @moduledoc false
@@ -127,8 +121,6 @@ defmodule Benchmarks.GoogleMessage3.Message3672.Message3674 do
   field :field3740, 7, required: true, type: Benchmarks.GoogleMessage3.Enum3476, enum: true
 
   field :field3741, 8, required: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message3672 do
   @moduledoc false
@@ -177,8 +169,6 @@ defmodule Benchmarks.GoogleMessage3.Message3672 do
   field :field3735, 21, optional: true, type: :int32
 
   field :field3736, 50, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message3804 do
   @moduledoc false
@@ -215,8 +205,6 @@ defmodule Benchmarks.GoogleMessage3.Message3804 do
   field :field3823, 7, optional: true, type: :int64
 
   field :field3824, 8, optional: true, type: Benchmarks.GoogleMessage3.Enum3783, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6849 do
   @moduledoc false
@@ -229,8 +217,6 @@ defmodule Benchmarks.GoogleMessage3.Message6849 do
   defstruct field6910: []
 
   field :field6910, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message6850
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6866 do
   @moduledoc false
@@ -243,8 +229,6 @@ defmodule Benchmarks.GoogleMessage3.Message6866 do
   defstruct field6973: []
 
   field :field6973, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message6863
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6870 do
   @moduledoc false
@@ -257,8 +241,6 @@ defmodule Benchmarks.GoogleMessage3.Message6870 do
   defstruct field6991: []
 
   field :field6991, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message6871
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7651 do
   @moduledoc false
@@ -447,8 +429,6 @@ defmodule Benchmarks.GoogleMessage3.Message7651 do
   field :field7728, 44, optional: true, type: :string
 
   field :field7729, 45, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7864 do
   @moduledoc false
@@ -481,8 +461,6 @@ defmodule Benchmarks.GoogleMessage3.Message7864 do
   field :field7870, 7, repeated: true, type: Benchmarks.GoogleMessage3.Message7865
 
   field :field7871, 8, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7929 do
   @moduledoc false
@@ -571,8 +549,6 @@ defmodule Benchmarks.GoogleMessage3.Message7929 do
   field :field7960, 11, repeated: true, type: :bytes
 
   field :field7961, 16, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8508 do
   @moduledoc false
@@ -649,8 +625,6 @@ defmodule Benchmarks.GoogleMessage3.Message8508 do
   field :field8532, 10, optional: true, type: :bool
 
   field :field8533, 12, optional: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message9122 do
   @moduledoc false
@@ -667,8 +641,6 @@ defmodule Benchmarks.GoogleMessage3.Message9122 do
   field :field9132, 1, optional: true, type: :float
 
   field :field9133, 2, optional: true, type: :float
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10177 do
   @moduledoc false
@@ -681,8 +653,6 @@ defmodule Benchmarks.GoogleMessage3.Message10177 do
   defstruct field10270: []
 
   field :field10270, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message10155
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10278 do
   @moduledoc false
@@ -703,8 +673,6 @@ defmodule Benchmarks.GoogleMessage3.Message10278 do
   field :field10287, 2, repeated: true, type: :int32, packed: true
 
   field :field10288, 3, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10323 do
   @moduledoc false
@@ -717,8 +685,6 @@ defmodule Benchmarks.GoogleMessage3.Message10323 do
   defstruct field10360: []
 
   field :field10360, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message10320
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10324 do
   @moduledoc false
@@ -735,8 +701,6 @@ defmodule Benchmarks.GoogleMessage3.Message10324 do
   field :field10362, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message10322
 
   field :field10363, 2, optional: true, type: Benchmarks.GoogleMessage3.Message10321
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message11990 do
   @moduledoc false
@@ -749,8 +713,6 @@ defmodule Benchmarks.GoogleMessage3.Message11990 do
   defstruct field12030: []
 
   field :field12030, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message11988
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message12691 do
   @moduledoc false
@@ -771,8 +733,6 @@ defmodule Benchmarks.GoogleMessage3.Message12691 do
   field :field12714, 2, optional: true, type: :int32
 
   field :field12715, 3, optional: true, type: Benchmarks.GoogleMessage3.Message12668
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message12870 do
   @moduledoc false
@@ -861,8 +821,6 @@ defmodule Benchmarks.GoogleMessage3.Message12870 do
   field :field12897, 17, optional: true, type: Benchmarks.GoogleMessage3.Enum12871, enum: true
 
   field :field12898, 19, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13154 do
   @moduledoc false
@@ -879,8 +837,6 @@ defmodule Benchmarks.GoogleMessage3.Message13154 do
   field :field13164, 1, required: true, type: :float
 
   field :field13165, 2, required: true, type: :float
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16507 do
   @moduledoc false
@@ -1020,8 +976,6 @@ defmodule Benchmarks.GoogleMessage3.Message16507 do
 
   field :field16541, 41, repeated: true, type: :string
 
-  def transform_module(), do: nil
-
   extensions [{21, 22}]
 end
 defmodule Benchmarks.GoogleMessage3.Message16564 do
@@ -1035,8 +989,6 @@ defmodule Benchmarks.GoogleMessage3.Message16564 do
   defstruct field16568: []
 
   field :field16568, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message16552
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16661 do
   @moduledoc false
@@ -1053,8 +1005,6 @@ defmodule Benchmarks.GoogleMessage3.Message16661 do
   field :field16671, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message16660
 
   field :field16672, 2, repeated: true, type: :uint64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16746 do
   @moduledoc false
@@ -1079,8 +1029,6 @@ defmodule Benchmarks.GoogleMessage3.Message16746 do
   field :field16808, 3, optional: true, type: :bool
 
   field :field16809, 4, repeated: true, type: Benchmarks.GoogleMessage3.Message16725
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message17786.Message17787 do
   @moduledoc false
@@ -1193,8 +1141,6 @@ defmodule Benchmarks.GoogleMessage3.Message17786.Message17787 do
   field :field18201, 17, optional: true, type: :string
 
   field :field18202, 99, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message17786 do
   @moduledoc false
@@ -1211,8 +1157,6 @@ defmodule Benchmarks.GoogleMessage3.Message17786 do
   field :message17787, 1, repeated: true, type: :group
 
   field :field18175, 20, repeated: true, type: Benchmarks.GoogleMessage3.Message17782
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message22857 do
   @moduledoc false
@@ -1225,8 +1169,6 @@ defmodule Benchmarks.GoogleMessage3.Message22857 do
   defstruct field22874: []
 
   field :field22874, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message22853
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24404.Message24405 do
   @moduledoc false
@@ -1359,8 +1301,6 @@ defmodule Benchmarks.GoogleMessage3.Message24404.Message24405 do
   field :field24715, 99, optional: true, type: :bool
 
   field :field24716, 32, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24404 do
   @moduledoc false
@@ -1377,8 +1317,6 @@ defmodule Benchmarks.GoogleMessage3.Message24404 do
   field :message24405, 1, repeated: true, type: :group
 
   field :field24684, 30, optional: true, type: Benchmarks.GoogleMessage3.Message24403
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message27300 do
   @moduledoc false
@@ -1395,8 +1333,6 @@ defmodule Benchmarks.GoogleMessage3.Message27300 do
   field :field27302, 1, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
   field :field27303, 2, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message27453 do
   @moduledoc false
@@ -1497,8 +1433,6 @@ defmodule Benchmarks.GoogleMessage3.Message27453 do
   field :field27480, 21, optional: true, type: :string
 
   field :field27481, 10, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.PbExtension do
   @moduledoc false

--- a/bench/lib/datasets/google_message3/benchmark_message3_1.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_1.pb.ex
@@ -9,8 +9,6 @@ defmodule Benchmarks.GoogleMessage3.Message34390 do
   defstruct field34452: []
 
   field :field34452, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message34387
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message34624 do
   @moduledoc false
@@ -27,8 +25,6 @@ defmodule Benchmarks.GoogleMessage3.Message34624 do
   field :field34683, 1, optional: true, type: Benchmarks.GoogleMessage3.Message34621
 
   field :field34684, 2, optional: true, type: Benchmarks.GoogleMessage3.Message34621
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message34791.Message34792 do
   @moduledoc false
@@ -45,8 +41,6 @@ defmodule Benchmarks.GoogleMessage3.Message34791.Message34792 do
   field :field34808, 3, required: true, type: :string
 
   field :field34809, 4, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message34791 do
   @moduledoc false
@@ -111,8 +105,6 @@ defmodule Benchmarks.GoogleMessage3.Message34791 do
   field :field34805, 15, optional: true, type: :int64
 
   field :field34806, 17, repeated: true, type: :fixed64, packed: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message35483 do
   @moduledoc false
@@ -145,8 +137,6 @@ defmodule Benchmarks.GoogleMessage3.Message35483 do
   field :field35503, 5, repeated: true, type: Benchmarks.GoogleMessage3.Message35476
 
   field :field35504, 6, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message35807 do
   @moduledoc false
@@ -187,8 +177,6 @@ defmodule Benchmarks.GoogleMessage3.Message35807 do
   field :field35816, 7, optional: true, type: :int32
 
   field :field35817, 8, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message37487 do
   @moduledoc false
@@ -205,8 +193,6 @@ defmodule Benchmarks.GoogleMessage3.Message37487 do
   field :field37501, 2, optional: true, type: :bytes
 
   field :field37502, 3, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13062 do
   @moduledoc false
@@ -235,8 +221,6 @@ defmodule Benchmarks.GoogleMessage3.Message13062 do
   field :field13078, 4, optional: true, type: :string
 
   field :field13079, 5, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message952 do
   @moduledoc false
@@ -249,8 +233,6 @@ defmodule Benchmarks.GoogleMessage3.Message952 do
   defstruct field963: []
 
   field :field963, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message949
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36877 do
   @moduledoc false
@@ -279,8 +261,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36877 do
   field :field37047, 115, optional: true, type: :int32
 
   field :field37048, 157, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36878 do
   @moduledoc false
@@ -289,8 +269,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36878 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36879 do
   @moduledoc false
@@ -307,8 +285,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36879 do
   field :field37050, 56, required: true, type: :string
 
   field :field37051, 69, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36880 do
   @moduledoc false
@@ -317,8 +293,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36880 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36881 do
   @moduledoc false
@@ -327,8 +301,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36881 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36882 do
   @moduledoc false
@@ -337,8 +309,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36882 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36883 do
   @moduledoc false
@@ -347,8 +317,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36883 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36884 do
   @moduledoc false
@@ -357,8 +325,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36884 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36885 do
   @moduledoc false
@@ -367,8 +333,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36885 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36886 do
   @moduledoc false
@@ -377,8 +341,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36886 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36887 do
   @moduledoc false
@@ -387,8 +349,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36887 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36888 do
   @moduledoc false
@@ -421,8 +381,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36888 do
   field :field37093, 109, optional: true, type: :uint64
 
   field :field37094, 122, optional: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36889 do
   @moduledoc false
@@ -531,8 +489,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36889 do
   field :field37118, 160, optional: true, type: :int32
 
   field :field37119, 161, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36910 do
   @moduledoc false
@@ -541,8 +497,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36910 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36911 do
   @moduledoc false
@@ -567,8 +521,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36911 do
   field :field37123, 144, optional: true, type: Benchmarks.GoogleMessage3.Message35540
 
   field :field37124, 150, optional: true, type: Benchmarks.GoogleMessage3.Message35542
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876.Message36912 do
   @moduledoc false
@@ -585,8 +537,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876.Message36912 do
   field :field37125, 153, optional: true, type: Benchmarks.GoogleMessage3.Message3901
 
   field :field37126, 162, optional: true, type: Benchmarks.GoogleMessage3.Message3901
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36876 do
   @moduledoc false
@@ -847,8 +797,6 @@ defmodule Benchmarks.GoogleMessage3.Message36876 do
   field :message36912, 152, optional: true, type: :group
 
   field :field37042, 155, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message1328 do
   @moduledoc false
@@ -857,8 +805,6 @@ defmodule Benchmarks.GoogleMessage3.Message1328 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6850 do
   @moduledoc false
@@ -867,8 +813,6 @@ defmodule Benchmarks.GoogleMessage3.Message6850 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6863 do
   @moduledoc false
@@ -1009,8 +953,6 @@ defmodule Benchmarks.GoogleMessage3.Message6863 do
   field :field6962, 33, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
   field :field6963, 34, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6871 do
   @moduledoc false
@@ -1019,8 +961,6 @@ defmodule Benchmarks.GoogleMessage3.Message6871 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7547 do
   @moduledoc false
@@ -1037,8 +977,6 @@ defmodule Benchmarks.GoogleMessage3.Message7547 do
   field :field7549, 1, required: true, type: :bytes
 
   field :field7550, 2, required: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7648 do
   @moduledoc false
@@ -1095,8 +1033,6 @@ defmodule Benchmarks.GoogleMessage3.Message7648 do
   field :field7679, 11, optional: true, type: :bool
 
   field :field7680, 12, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7865 do
   @moduledoc false
@@ -1105,8 +1041,6 @@ defmodule Benchmarks.GoogleMessage3.Message7865 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7928 do
   @moduledoc false
@@ -1123,8 +1057,6 @@ defmodule Benchmarks.GoogleMessage3.Message7928 do
   field :field7940, 1, optional: true, type: :string
 
   field :field7941, 2, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7919 do
   @moduledoc false
@@ -1145,8 +1077,6 @@ defmodule Benchmarks.GoogleMessage3.Message7919 do
   field :field7932, 2, optional: true, type: :int64
 
   field :field7933, 3, optional: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7920 do
   @moduledoc false
@@ -1163,8 +1093,6 @@ defmodule Benchmarks.GoogleMessage3.Message7920 do
   field :field7934, 1, optional: true, type: :int64
 
   field :field7935, 2, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7921 do
   @moduledoc false
@@ -1189,8 +1117,6 @@ defmodule Benchmarks.GoogleMessage3.Message7921 do
   field :field7938, 3, optional: true, type: :float
 
   field :field7939, 4, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8511 do
   @moduledoc false
@@ -1219,8 +1145,6 @@ defmodule Benchmarks.GoogleMessage3.Message8511 do
   field :field8542, 4, optional: true, type: :int64
 
   field :field8543, 5, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8512 do
   @moduledoc false
@@ -1253,8 +1177,6 @@ defmodule Benchmarks.GoogleMessage3.Message8512 do
   field :field8548, 5, optional: true, type: :int64
 
   field :field8549, 6, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8513 do
   @moduledoc false
@@ -1279,8 +1201,6 @@ defmodule Benchmarks.GoogleMessage3.Message8513 do
   field :field8552, 3, optional: true, type: :bool
 
   field :field8553, 4, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8514 do
   @moduledoc false
@@ -1309,8 +1229,6 @@ defmodule Benchmarks.GoogleMessage3.Message8514 do
   field :field8557, 4, repeated: true, type: Benchmarks.GoogleMessage3.Message8130
 
   field :field8558, 5, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8515 do
   @moduledoc false
@@ -1331,8 +1249,6 @@ defmodule Benchmarks.GoogleMessage3.Message8515 do
   field :field8560, 2, optional: true, type: Benchmarks.GoogleMessage3.Message8478
 
   field :field8561, 3, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10320 do
   @moduledoc false
@@ -1369,8 +1285,6 @@ defmodule Benchmarks.GoogleMessage3.Message10320 do
   field :field10352, 6, optional: true, type: :int32
 
   field :field10353, 7, optional: true, type: Benchmarks.GoogleMessage3.Enum10337, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10321 do
   @moduledoc false
@@ -1391,8 +1305,6 @@ defmodule Benchmarks.GoogleMessage3.Message10321 do
   field :field10355, 2, optional: true, type: :int32
 
   field :field10356, 3, optional: true, type: :uint64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10322 do
   @moduledoc false
@@ -1413,8 +1325,6 @@ defmodule Benchmarks.GoogleMessage3.Message10322 do
   field :field10358, 2, optional: true, type: :bool
 
   field :field10359, 3, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message11988 do
   @moduledoc false
@@ -1439,8 +1349,6 @@ defmodule Benchmarks.GoogleMessage3.Message11988 do
   field :field12023, 3, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
   field :field12024, 4, optional: true, type: Benchmarks.GoogleMessage3.Message10155
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message12668 do
   @moduledoc false
@@ -1465,8 +1373,6 @@ defmodule Benchmarks.GoogleMessage3.Message12668 do
   field :field12679, 3, optional: true, type: :int32
 
   field :field12680, 4, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message12825 do
   @moduledoc false
@@ -1503,8 +1409,6 @@ defmodule Benchmarks.GoogleMessage3.Message12825 do
   field :field12867, 6, repeated: true, type: Benchmarks.GoogleMessage3.Message12821
 
   field :field12868, 7, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16478 do
   @moduledoc false
@@ -1525,8 +1429,6 @@ defmodule Benchmarks.GoogleMessage3.Message16478 do
   field :field16482, 3, optional: true, type: :bool
 
   field :field16483, 2, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16552 do
   @moduledoc false
@@ -1547,8 +1449,6 @@ defmodule Benchmarks.GoogleMessage3.Message16552 do
   field :field16566, 2, optional: true, type: :int32
 
   field :field16567, 3, optional: true, type: Benchmarks.GoogleMessage3.Enum16553, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16660 do
   @moduledoc false
@@ -1569,8 +1469,6 @@ defmodule Benchmarks.GoogleMessage3.Message16660 do
   field :field16669, 2, optional: true, type: :string
 
   field :field16670, 3, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16727 do
   @moduledoc false
@@ -1678,8 +1576,6 @@ defmodule Benchmarks.GoogleMessage3.Message16727 do
 
   field :field16805, 25, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
-  def transform_module(), do: nil
-
   extensions [{1000, 536_870_912}]
 end
 defmodule Benchmarks.GoogleMessage3.Message16725 do
@@ -1697,8 +1593,6 @@ defmodule Benchmarks.GoogleMessage3.Message16725 do
   field :field16774, 1, optional: true, type: Benchmarks.GoogleMessage3.Enum16728, enum: true
 
   field :field16775, 2, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message17726 do
   @moduledoc false
@@ -1795,8 +1689,6 @@ defmodule Benchmarks.GoogleMessage3.Message17726 do
   field :field17821, 21, repeated: true, type: Benchmarks.GoogleMessage3.Message17728
 
   field :field17822, 30, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message17782 do
   @moduledoc false
@@ -1813,8 +1705,6 @@ defmodule Benchmarks.GoogleMessage3.Message17782 do
   field :field18153, 1, optional: true, type: :string
 
   field :field18154, 2, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message17783.Message17784 do
   @moduledoc false
@@ -1847,8 +1737,6 @@ defmodule Benchmarks.GoogleMessage3.Message17783.Message17784 do
   field :field18166, 17, optional: true, type: :string
 
   field :field18167, 18, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message17783.Message17785 do
   @moduledoc false
@@ -1881,8 +1769,6 @@ defmodule Benchmarks.GoogleMessage3.Message17783.Message17785 do
   field :field18172, 14, optional: true, type: :string
 
   field :field18173, 15, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message17783 do
   @moduledoc false
@@ -1915,8 +1801,6 @@ defmodule Benchmarks.GoogleMessage3.Message17783 do
   field :message17785, 9, repeated: true, type: :group
 
   field :field18160, 16, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16945 do
   @moduledoc false
@@ -2243,8 +2127,6 @@ defmodule Benchmarks.GoogleMessage3.Message16945 do
   field :field17023, 102, repeated: true, type: Benchmarks.GoogleMessage3.Message0
 
   field :field17024, 274, repeated: true, type: :string
-
-  def transform_module(), do: nil
 
   extensions [
     {17, 18},

--- a/bench/lib/datasets/google_message3/benchmark_message3_2.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_2.pb.ex
@@ -25,8 +25,6 @@ defmodule Benchmarks.GoogleMessage3.Message22853 do
   field :field22872, 5, repeated: true, type: :float, packed: true
 
   field :field22873, 4, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24345 do
   @moduledoc false
@@ -135,8 +133,6 @@ defmodule Benchmarks.GoogleMessage3.Message24345 do
   field :field24556, 24, repeated: true, type: Benchmarks.GoogleMessage3.Message24356
 
   field :field24557, 25, repeated: true, type: Benchmarks.GoogleMessage3.Message24366
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24403 do
   @moduledoc false
@@ -153,8 +149,6 @@ defmodule Benchmarks.GoogleMessage3.Message24403 do
   field :field24681, 1, optional: true, type: Benchmarks.GoogleMessage3.Message24401
 
   field :field24682, 2, optional: true, type: Benchmarks.GoogleMessage3.Message24402
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24391 do
   @moduledoc false
@@ -263,8 +257,6 @@ defmodule Benchmarks.GoogleMessage3.Message24391 do
   field :field24654, 15, repeated: true, type: :string
 
   field :field24655, 6, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message27454 do
   @moduledoc false
@@ -273,8 +265,6 @@ defmodule Benchmarks.GoogleMessage3.Message27454 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message27357 do
   @moduledoc false
@@ -303,8 +293,6 @@ defmodule Benchmarks.GoogleMessage3.Message27357 do
   field :field27413, 4, optional: true, type: :bool
 
   field :field27414, 5, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message27360 do
   @moduledoc false
@@ -329,8 +317,6 @@ defmodule Benchmarks.GoogleMessage3.Message27360 do
   field :field27428, 3, optional: true, type: Benchmarks.GoogleMessage3.Message27358
 
   field :field27429, 4, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message34387 do
   @moduledoc false
@@ -359,8 +345,6 @@ defmodule Benchmarks.GoogleMessage3.Message34387 do
   field :field34449, 4, optional: true, type: Benchmarks.GoogleMessage3.Enum34388, enum: true
 
   field :field34450, 5, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message34621 do
   @moduledoc false
@@ -441,8 +425,6 @@ defmodule Benchmarks.GoogleMessage3.Message34621 do
   field :field34667, 100, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
   field :field34668, 101, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message35476 do
   @moduledoc false
@@ -507,8 +489,6 @@ defmodule Benchmarks.GoogleMessage3.Message35476 do
   field :field35496, 13, optional: true, type: :string
 
   field :field35497, 14, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message949 do
   @moduledoc false
@@ -545,8 +525,6 @@ defmodule Benchmarks.GoogleMessage3.Message949 do
   field :field960, 6, optional: true, type: :string
 
   field :field961, 7, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36869 do
   @moduledoc false
@@ -563,8 +541,6 @@ defmodule Benchmarks.GoogleMessage3.Message36869 do
   field :field36970, 1, optional: true, type: :int32
 
   field :field36971, 2, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message33968.Message33969 do
   @moduledoc false
@@ -573,8 +549,6 @@ defmodule Benchmarks.GoogleMessage3.Message33968.Message33969 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message33968 do
   @moduledoc false
@@ -603,8 +577,6 @@ defmodule Benchmarks.GoogleMessage3.Message33968 do
   field :field33991, 108, optional: true, type: :bool
 
   field :field33992, 107, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6644 do
   @moduledoc false
@@ -677,8 +649,6 @@ defmodule Benchmarks.GoogleMessage3.Message6644 do
   field :field6715, 17, optional: true, type: :int32
 
   field :field6716, 20, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message18831.Message18832.Message18833 do
   @moduledoc false
@@ -707,8 +677,6 @@ defmodule Benchmarks.GoogleMessage3.Message18831.Message18832.Message18833 do
   field :field18846, 12, optional: true, type: :int32
 
   field :field18847, 13, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message18831.Message18832 do
   @moduledoc false
@@ -745,8 +713,6 @@ defmodule Benchmarks.GoogleMessage3.Message18831.Message18832 do
   field :field18841, 4, repeated: true, type: :uint64
 
   field :message18833, 6, repeated: true, type: :group
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message18831 do
   @moduledoc false
@@ -759,8 +725,6 @@ defmodule Benchmarks.GoogleMessage3.Message18831 do
   defstruct message18832: []
 
   field :message18832, 1, repeated: true, type: :group
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13090 do
   @moduledoc false
@@ -777,8 +741,6 @@ defmodule Benchmarks.GoogleMessage3.Message13090 do
   field :field13141, 1, optional: true, type: Benchmarks.GoogleMessage3.Message13083
 
   field :field13142, 2, optional: true, type: Benchmarks.GoogleMessage3.Message13088
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message11874 do
   @moduledoc false
@@ -805,8 +767,6 @@ defmodule Benchmarks.GoogleMessage3.Message11874 do
   field :field11890, 6, optional: true, type: Benchmarks.GoogleMessage3.Message11873
 
   field :field11891, 7, optional: true, type: :bool
-
-  def transform_module(), do: nil
 
   extensions [{1, 2}, {2, 3}, {5, 6}]
 end
@@ -841,8 +801,6 @@ defmodule Benchmarks.GoogleMessage3.Message4144.Message4145 do
   field :field4169, 5, optional: true, type: Benchmarks.GoogleMessage3.Enum4152, enum: true
 
   field :field4170, 6, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message4144 do
   @moduledoc false
@@ -855,8 +813,6 @@ defmodule Benchmarks.GoogleMessage3.Message4144 do
   defstruct message4145: []
 
   field :message4145, 1, repeated: true, type: :group
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message35573.Message35574 do
   @moduledoc false
@@ -865,8 +821,6 @@ defmodule Benchmarks.GoogleMessage3.Message35573.Message35574 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message35573.Message35575.Message35576 do
   @moduledoc false
@@ -975,8 +929,6 @@ defmodule Benchmarks.GoogleMessage3.Message35573.Message35575.Message35576 do
   field :field35770, 54, optional: true, type: :int64
 
   field :field35771, 55, optional: true, type: Benchmarks.GoogleMessage3.Message0
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message35573.Message35575 do
   @moduledoc false
@@ -1137,8 +1089,6 @@ defmodule Benchmarks.GoogleMessage3.Message35573.Message35575 do
   field :field35745, 57, optional: true, type: Benchmarks.GoogleMessage3.Message0
 
   field :message35576, 4, required: true, type: :group
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message35573 do
   @moduledoc false
@@ -1191,8 +1141,6 @@ defmodule Benchmarks.GoogleMessage3.Message35573 do
   field :field35704, 1008, optional: true, type: :int64
 
   field :message35575, 1, repeated: true, type: :group
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36858.Message36859 do
   @moduledoc false
@@ -1209,8 +1157,6 @@ defmodule Benchmarks.GoogleMessage3.Message36858.Message36859 do
   field :field36968, 9, required: true, type: Benchmarks.GoogleMessage3.Enum36860, enum: true
 
   field :field36969, 10, optional: true, type: :float
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message36858 do
   @moduledoc false
@@ -1267,8 +1213,6 @@ defmodule Benchmarks.GoogleMessage3.Message36858 do
   field :field36966, 7, optional: true, type: Benchmarks.GoogleMessage3.Message35506
 
   field :message36859, 8, repeated: true, type: :group
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13174 do
   @moduledoc false
@@ -1361,8 +1305,6 @@ defmodule Benchmarks.GoogleMessage3.Message13174 do
   field :field13256, 14, optional: true, type: :double
 
   field :field13257, 18, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message18283 do
   @moduledoc false
@@ -1790,8 +1732,6 @@ defmodule Benchmarks.GoogleMessage3.Message18283 do
 
   field :field18581, 193, optional: true, type: :bool
 
-  def transform_module(), do: nil
-
   extensions [{116, 117}, {118, 119}, {130, 131}, {165, 166}]
 end
 defmodule Benchmarks.GoogleMessage3.Message13169 do
@@ -1813,8 +1753,6 @@ defmodule Benchmarks.GoogleMessage3.Message13169 do
   field :field13224, 2, required: true, type: Benchmarks.GoogleMessage3.Message13167
 
   field :field13225, 3, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message19255 do
   @moduledoc false
@@ -1827,8 +1765,6 @@ defmodule Benchmarks.GoogleMessage3.Message19255 do
   defstruct field19257: nil
 
   field :field19257, 1, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message35542 do
   @moduledoc false
@@ -1849,8 +1785,6 @@ defmodule Benchmarks.GoogleMessage3.Message35542 do
   field :field35544, 2, optional: true, type: :bool
 
   field :field35545, 3, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message3901 do
   @moduledoc false
@@ -1907,8 +1841,6 @@ defmodule Benchmarks.GoogleMessage3.Message3901 do
   field :field4000, 6, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
 
   field :field4001, 5, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.PbExtension do
   @moduledoc false

--- a/bench/lib/datasets/google_message3/benchmark_message3_3.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_3.pb.ex
@@ -13,8 +13,6 @@ defmodule Benchmarks.GoogleMessage3.Message35546.Message35547 do
   field :field35569, 5, required: true, type: :int32
 
   field :field35570, 6, required: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message35546.Message35548 do
   @moduledoc false
@@ -31,8 +29,6 @@ defmodule Benchmarks.GoogleMessage3.Message35546.Message35548 do
   field :field35571, 11, required: true, type: :int64
 
   field :field35572, 12, required: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message35546 do
   @moduledoc false
@@ -89,8 +85,6 @@ defmodule Benchmarks.GoogleMessage3.Message35546 do
   field :field35566, 18, optional: true, type: :bool
 
   field :field35567, 100, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message2356.Message2357 do
   @moduledoc false
@@ -147,8 +141,6 @@ defmodule Benchmarks.GoogleMessage3.Message2356.Message2357 do
   field :field2409, 122, optional: true, type: :bool
 
   field :field2410, 124, optional: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message2356.Message2358 do
   @moduledoc false
@@ -157,8 +149,6 @@ defmodule Benchmarks.GoogleMessage3.Message2356.Message2358 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message2356.Message2359 do
   @moduledoc false
@@ -199,8 +189,6 @@ defmodule Benchmarks.GoogleMessage3.Message2356.Message2359 do
   field :field2419, 110, optional: true, type: :float
 
   field :field2420, 111, optional: true, type: :float
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message2356 do
   @moduledoc false
@@ -333,8 +321,6 @@ defmodule Benchmarks.GoogleMessage3.Message2356 do
   field :field2397, 100, optional: true, type: :string
 
   field :field2398, 123, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7029.Message7030 do
   @moduledoc false
@@ -355,8 +341,6 @@ defmodule Benchmarks.GoogleMessage3.Message7029.Message7030 do
   field :field7227, 15, optional: true, type: :string
 
   field :field7228, 16, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7029.Message7031 do
   @moduledoc false
@@ -389,8 +373,6 @@ defmodule Benchmarks.GoogleMessage3.Message7029.Message7031 do
   field :field7233, 31, optional: true, type: :int32
 
   field :field7234, 35, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7029 do
   @moduledoc false
@@ -567,8 +549,6 @@ defmodule Benchmarks.GoogleMessage3.Message7029 do
   field :field7223, 50, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
   field :field7224, 51, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message35538 do
   @moduledoc false
@@ -581,8 +561,6 @@ defmodule Benchmarks.GoogleMessage3.Message35538 do
   defstruct field35539: 0
 
   field :field35539, 1, required: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message18921.Message18922 do
   @moduledoc false
@@ -683,8 +661,6 @@ defmodule Benchmarks.GoogleMessage3.Message18921.Message18922 do
   field :field18980, 27, repeated: true, type: :string
 
   field :field18981, 28, optional: true, type: :float
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message18921 do
   @moduledoc false
@@ -741,8 +717,6 @@ defmodule Benchmarks.GoogleMessage3.Message18921 do
   field :field18956, 31, repeated: true, type: Benchmarks.GoogleMessage3.Message18944
 
   field :field18957, 32, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message35540 do
   @moduledoc false
@@ -755,8 +729,6 @@ defmodule Benchmarks.GoogleMessage3.Message35540 do
   defstruct field35541: nil
 
   field :field35541, 1, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message3886.Message3887 do
   @moduledoc false
@@ -781,8 +753,6 @@ defmodule Benchmarks.GoogleMessage3.Message3886.Message3887 do
   field :field3934, 3, optional: true, type: Benchmarks.GoogleMessage3.Message3850
 
   field :field3935, 8, optional: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message3886 do
   @moduledoc false
@@ -795,8 +765,6 @@ defmodule Benchmarks.GoogleMessage3.Message3886 do
   defstruct message3887: []
 
   field :message3887, 1, repeated: true, type: :group
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6743 do
   @moduledoc false
@@ -837,8 +805,6 @@ defmodule Benchmarks.GoogleMessage3.Message6743 do
   field :field6765, 6, optional: true, type: Benchmarks.GoogleMessage3.Message6734
 
   field :field6766, 7, optional: true, type: Benchmarks.GoogleMessage3.Message6742
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6773 do
   @moduledoc false
@@ -887,8 +853,6 @@ defmodule Benchmarks.GoogleMessage3.Message6773 do
   field :field6802, 8, optional: true, type: :double
 
   field :field6803, 6, optional: true, type: Benchmarks.GoogleMessage3.Enum6782, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8224 do
   @moduledoc false
@@ -1005,8 +969,6 @@ defmodule Benchmarks.GoogleMessage3.Message8224 do
   field :field8280, 26, optional: true, type: :bool
 
   field :field8281, 27, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8392 do
   @moduledoc false
@@ -1051,8 +1013,6 @@ defmodule Benchmarks.GoogleMessage3.Message8392 do
   field :field8402, 8, optional: true, type: :string
 
   field :field8403, 9, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8130 do
   @moduledoc false
@@ -1157,8 +1117,6 @@ defmodule Benchmarks.GoogleMessage3.Message8130 do
   field :field8178, 25, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
   field :field8179, 26, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8478 do
   @moduledoc false
@@ -1199,8 +1157,6 @@ defmodule Benchmarks.GoogleMessage3.Message8478 do
   field :field8495, 6, optional: true, type: Benchmarks.GoogleMessage3.Message8454
 
   field :field8496, 8, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8479 do
   @moduledoc false
@@ -1245,8 +1201,6 @@ defmodule Benchmarks.GoogleMessage3.Message8479 do
   field :field8504, 5, optional: true, type: Benchmarks.GoogleMessage3.Message8455
 
   field :field8505, 9, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10319 do
   @moduledoc false
@@ -1283,8 +1237,6 @@ defmodule Benchmarks.GoogleMessage3.Message10319 do
   field :field10345, 6, optional: true, type: :string
 
   field :field10346, 7, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message4016 do
   @moduledoc false
@@ -1309,8 +1261,6 @@ defmodule Benchmarks.GoogleMessage3.Message4016 do
   field :field4019, 3, required: true, type: :int32
 
   field :field4020, 4, required: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message12669 do
   @moduledoc false
@@ -1335,8 +1285,6 @@ defmodule Benchmarks.GoogleMessage3.Message12669 do
   field :field12683, 3, optional: true, type: :bool
 
   field :field12684, 4, optional: true, type: Benchmarks.GoogleMessage3.Enum12670, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message12819 do
   @moduledoc false
@@ -1369,8 +1317,6 @@ defmodule Benchmarks.GoogleMessage3.Message12819 do
   field :field12838, 5, optional: true, type: :double
 
   field :field12839, 6, optional: true, type: :double
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message12820 do
   @moduledoc false
@@ -1411,8 +1357,6 @@ defmodule Benchmarks.GoogleMessage3.Message12820 do
   field :field12846, 6, optional: true, type: :int32
 
   field :field12847, 7, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message12821 do
   @moduledoc false
@@ -1441,8 +1385,6 @@ defmodule Benchmarks.GoogleMessage3.Message12821 do
   field :field12851, 4, optional: true, type: :int32
 
   field :field12852, 5, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message12818 do
   @moduledoc false
@@ -1471,8 +1413,6 @@ defmodule Benchmarks.GoogleMessage3.Message12818 do
   field :field12832, 5, optional: true, type: :int32
 
   field :field12833, 4, repeated: true, type: Benchmarks.GoogleMessage3.Message12817
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16479 do
   @moduledoc false
@@ -1505,8 +1445,6 @@ defmodule Benchmarks.GoogleMessage3.Message16479 do
   field :field16488, 3, optional: true, type: :bool
 
   field :field16489, 6, optional: true, type: :uint32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16722 do
   @moduledoc false
@@ -1535,8 +1473,6 @@ defmodule Benchmarks.GoogleMessage3.Message16722 do
   field :field16755, 5, optional: true, type: :int32
 
   field :field16756, 4, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16724 do
   @moduledoc false
@@ -1597,8 +1533,6 @@ defmodule Benchmarks.GoogleMessage3.Message16724 do
   field :field16772, 12, repeated: true, type: :int32
 
   field :field16773, 13, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message17728 do
   @moduledoc false
@@ -1607,8 +1541,6 @@ defmodule Benchmarks.GoogleMessage3.Message17728 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24356 do
   @moduledoc false
@@ -1677,8 +1609,6 @@ defmodule Benchmarks.GoogleMessage3.Message24356 do
   field :field24572, 11, repeated: true, type: :string
 
   field :field24573, 15, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24376 do
   @moduledoc false
@@ -1743,8 +1673,6 @@ defmodule Benchmarks.GoogleMessage3.Message24376 do
   field :field24601, 12, optional: true, type: :string
 
   field :field24602, 13, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24366 do
   @moduledoc false
@@ -1813,6 +1741,4 @@ defmodule Benchmarks.GoogleMessage3.Message24366 do
   field :field24587, 8, repeated: true, type: :string
 
   field :field24588, 11, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message3/benchmark_message3_4.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_4.pb.ex
@@ -5,8 +5,6 @@ defmodule Benchmarks.GoogleMessage3.Message24346 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24401 do
   @moduledoc false
@@ -19,8 +17,6 @@ defmodule Benchmarks.GoogleMessage3.Message24401 do
   defstruct field24679: nil
 
   field :field24679, 1, optional: true, type: Benchmarks.GoogleMessage3.Message24400
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24402 do
   @moduledoc false
@@ -33,8 +29,6 @@ defmodule Benchmarks.GoogleMessage3.Message24402 do
   defstruct field24680: nil
 
   field :field24680, 1, optional: true, type: Benchmarks.GoogleMessage3.Message24400
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24379 do
   @moduledoc false
@@ -115,8 +109,6 @@ defmodule Benchmarks.GoogleMessage3.Message24379 do
   field :field24619, 15, repeated: true, type: :string
 
   field :field24620, 18, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message27358 do
   @moduledoc false
@@ -133,8 +125,6 @@ defmodule Benchmarks.GoogleMessage3.Message27358 do
   field :field27415, 1, optional: true, type: :int32
 
   field :field27416, 2, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message34381 do
   @moduledoc false
@@ -183,8 +173,6 @@ defmodule Benchmarks.GoogleMessage3.Message34381 do
   field :field34406, 9, optional: true, type: :bool
 
   field :field34407, 10, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message34619 do
   @moduledoc false
@@ -221,8 +209,6 @@ defmodule Benchmarks.GoogleMessage3.Message34619 do
   field :field34646, 5, optional: true, type: :double
 
   field :field34647, 100, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message730 do
   @moduledoc false
@@ -366,8 +352,6 @@ defmodule Benchmarks.GoogleMessage3.Message730 do
 
   field :field929, 31, optional: true, type: :bytes
 
-  def transform_module(), do: nil
-
   extensions [{25, 26}, {29, 30}, {34, 35}, {15, 16}]
 end
 defmodule Benchmarks.GoogleMessage3.Message33958.Message33959 do
@@ -401,8 +385,6 @@ defmodule Benchmarks.GoogleMessage3.Message33958.Message33959 do
   field :field33986, 10, optional: true, type: :bool
 
   field :field33987, 6, optional: true, type: Benchmarks.GoogleMessage3.Message0
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message33958 do
   @moduledoc false
@@ -427,8 +409,6 @@ defmodule Benchmarks.GoogleMessage3.Message33958 do
   field :message33959, 2, repeated: true, type: :group
 
   field :field33980, 7, optional: true, type: Benchmarks.GoogleMessage3.Enum33960, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6637 do
   @moduledoc false
@@ -457,8 +437,6 @@ defmodule Benchmarks.GoogleMessage3.Message6637 do
   field :field6673, 4, repeated: true, type: :string
 
   field :field6674, 5, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6643 do
   @moduledoc false
@@ -539,8 +517,6 @@ defmodule Benchmarks.GoogleMessage3.Message6643 do
   field :field6699, 20, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
   field :field6700, 21, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6126 do
   @moduledoc false
@@ -625,8 +601,6 @@ defmodule Benchmarks.GoogleMessage3.Message6126 do
   field :field6169, 17, repeated: true, type: Benchmarks.GoogleMessage3.Message6054
 
   field :field6170, 19, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13083.Message13084 do
   @moduledoc false
@@ -651,8 +625,6 @@ defmodule Benchmarks.GoogleMessage3.Message13083.Message13084 do
   field :field13109, 5, optional: true, type: :float
 
   field :field13110, 6, repeated: true, type: Benchmarks.GoogleMessage3.Enum13092, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13083.Message13085 do
   @moduledoc false
@@ -661,8 +633,6 @@ defmodule Benchmarks.GoogleMessage3.Message13083.Message13085 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13083.Message13086 do
   @moduledoc false
@@ -671,8 +641,6 @@ defmodule Benchmarks.GoogleMessage3.Message13083.Message13086 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13083.Message13087 do
   @moduledoc false
@@ -681,8 +649,6 @@ defmodule Benchmarks.GoogleMessage3.Message13083.Message13087 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13083 do
   @moduledoc false
@@ -731,8 +697,6 @@ defmodule Benchmarks.GoogleMessage3.Message13083 do
   field :message13087, 29, repeated: true, type: :group
 
   field :field13105, 43, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13088.Message13089 do
   @moduledoc false
@@ -749,8 +713,6 @@ defmodule Benchmarks.GoogleMessage3.Message13088.Message13089 do
   field :field13139, 2, required: true, type: :string
 
   field :field13140, 3, optional: true, type: :float
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13088 do
   @moduledoc false
@@ -771,8 +733,6 @@ defmodule Benchmarks.GoogleMessage3.Message13088 do
   field :field13136, 4, optional: true, type: :int64
 
   field :field13137, 5, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10391 do
   @moduledoc false
@@ -817,8 +777,6 @@ defmodule Benchmarks.GoogleMessage3.Message10391 do
   field :field10418, 9, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
   field :field10419, 10, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message11873 do
   @moduledoc false
@@ -878,8 +836,6 @@ defmodule Benchmarks.GoogleMessage3.Message11873 do
 
   field :field11887, 15, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
-  def transform_module(), do: nil
-
   extensions [{9, 10}, {10, 11}]
 end
 defmodule Benchmarks.GoogleMessage3.Message35506 do
@@ -905,8 +861,6 @@ defmodule Benchmarks.GoogleMessage3.Message35506 do
   field :field35526, 3, optional: true, type: Benchmarks.GoogleMessage3.Enum35507, enum: true
 
   field :field35527, 4, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13151 do
   @moduledoc false
@@ -919,8 +873,6 @@ defmodule Benchmarks.GoogleMessage3.Message13151 do
   defstruct field13158: []
 
   field :field13158, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message13145
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message18253.Message18254 do
   @moduledoc false
@@ -937,8 +889,6 @@ defmodule Benchmarks.GoogleMessage3.Message18253.Message18254 do
   field :field18362, 2, required: true, type: :fixed64
 
   field :field18363, 3, required: true, type: :double
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message18253 do
   @moduledoc false
@@ -951,8 +901,6 @@ defmodule Benchmarks.GoogleMessage3.Message18253 do
   defstruct message18254: []
 
   field :message18254, 1, repeated: true, type: :group
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16685 do
   @moduledoc false
@@ -965,8 +913,6 @@ defmodule Benchmarks.GoogleMessage3.Message16685 do
   defstruct field16694: []
 
   field :field16694, 2, repeated: true, type: Benchmarks.GoogleMessage3.Message16686
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16816.Message16817 do
   @moduledoc false
@@ -975,8 +921,6 @@ defmodule Benchmarks.GoogleMessage3.Message16816.Message16817 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16816.Message16818 do
   @moduledoc false
@@ -985,8 +929,6 @@ defmodule Benchmarks.GoogleMessage3.Message16816.Message16818 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16816 do
   @moduledoc false
@@ -1035,8 +977,6 @@ defmodule Benchmarks.GoogleMessage3.Message16816 do
   field :field16834, 13, optional: true, type: :bool
 
   field :field16835, 14, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13168 do
   @moduledoc false
@@ -1089,8 +1029,6 @@ defmodule Benchmarks.GoogleMessage3.Message13168 do
   field :field13221, 5, required: true, type: :bool
 
   field :field13222, 6, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13167 do
   @moduledoc false
@@ -1151,8 +1089,6 @@ defmodule Benchmarks.GoogleMessage3.Message13167 do
   field :field13210, 6, optional: true, type: :int32
 
   field :field13211, 7, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message1374 do
   @moduledoc false
@@ -1169,8 +1105,6 @@ defmodule Benchmarks.GoogleMessage3.Message1374 do
   field :field1375, 1, required: true, type: :string
 
   field :field1376, 2, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message18943 do
   @moduledoc false
@@ -1179,8 +1113,6 @@ defmodule Benchmarks.GoogleMessage3.Message18943 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message18944 do
   @moduledoc false
@@ -1189,8 +1121,6 @@ defmodule Benchmarks.GoogleMessage3.Message18944 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message18856 do
   @moduledoc false
@@ -1323,8 +1253,6 @@ defmodule Benchmarks.GoogleMessage3.Message18856 do
   field :field18886, 27, optional: true, type: :string
 
   field :field18887, 28, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message3850 do
   @moduledoc false
@@ -1357,8 +1285,6 @@ defmodule Benchmarks.GoogleMessage3.Message3850 do
   field :field3928, 13, optional: true, type: :bool
 
   field :field3929, 14, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6721 do
   @moduledoc false
@@ -1383,8 +1309,6 @@ defmodule Benchmarks.GoogleMessage3.Message6721 do
   field :field6746, 3, optional: true, type: :bool
 
   field :field6747, 4, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6742 do
   @moduledoc false
@@ -1397,8 +1321,6 @@ defmodule Benchmarks.GoogleMessage3.Message6742 do
   defstruct field6758: nil
 
   field :field6758, 1, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6726 do
   @moduledoc false
@@ -1415,8 +1337,6 @@ defmodule Benchmarks.GoogleMessage3.Message6726 do
   field :field6752, 1, optional: true, type: :int64
 
   field :field6753, 2, repeated: true, type: Benchmarks.GoogleMessage3.Message6727
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6733 do
   @moduledoc false
@@ -1437,8 +1357,6 @@ defmodule Benchmarks.GoogleMessage3.Message6733 do
   field :field6755, 2, optional: true, type: :int64
 
   field :field6756, 3, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6723 do
   @moduledoc false
@@ -1455,8 +1373,6 @@ defmodule Benchmarks.GoogleMessage3.Message6723 do
   field :field6748, 1, optional: true, type: :int64
 
   field :field6749, 2, repeated: true, type: Benchmarks.GoogleMessage3.Message6724
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6725 do
   @moduledoc false
@@ -1473,8 +1389,6 @@ defmodule Benchmarks.GoogleMessage3.Message6725 do
   field :field6750, 1, optional: true, type: :int32
 
   field :field6751, 2, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6734 do
   @moduledoc false
@@ -1487,8 +1401,6 @@ defmodule Benchmarks.GoogleMessage3.Message6734 do
   defstruct field6757: []
 
   field :field6757, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message6735
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8184 do
   @moduledoc false
@@ -1509,8 +1421,6 @@ defmodule Benchmarks.GoogleMessage3.Message8184 do
   field :field8229, 2, optional: true, type: :bool
 
   field :field8230, 3, repeated: true, type: Benchmarks.GoogleMessage3.Message8183
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8477 do
   @moduledoc false
@@ -1531,8 +1441,6 @@ defmodule Benchmarks.GoogleMessage3.Message8477 do
   field :field8487, 2, optional: true, type: :int64
 
   field :field8488, 3, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8454 do
   @moduledoc false
@@ -1557,8 +1465,6 @@ defmodule Benchmarks.GoogleMessage3.Message8454 do
   field :field8467, 4, optional: true, type: :int32
 
   field :field8468, 5, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8476 do
   @moduledoc false
@@ -1579,8 +1485,6 @@ defmodule Benchmarks.GoogleMessage3.Message8476 do
   field :field8484, 2, optional: true, type: :string
 
   field :field8485, 3, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8455 do
   @moduledoc false
@@ -1605,8 +1509,6 @@ defmodule Benchmarks.GoogleMessage3.Message8455 do
   field :field8472, 5, optional: true, type: Benchmarks.GoogleMessage3.Message8457
 
   field :field8473, 6, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8475 do
   @moduledoc false
@@ -1623,8 +1525,6 @@ defmodule Benchmarks.GoogleMessage3.Message8475 do
   field :field8481, 1, optional: true, type: :string
 
   field :field8482, 2, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message12559 do
   @moduledoc false
@@ -1633,8 +1533,6 @@ defmodule Benchmarks.GoogleMessage3.Message12559 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message12817 do
   @moduledoc false
@@ -1655,8 +1553,6 @@ defmodule Benchmarks.GoogleMessage3.Message12817 do
   field :field12827, 2, optional: true, type: :int32
 
   field :field12828, 3, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message16480 do
   @moduledoc false
@@ -1701,8 +1597,6 @@ defmodule Benchmarks.GoogleMessage3.Message16480 do
   field :field16497, 8, optional: true, type: Benchmarks.GoogleMessage3.Message13358
 
   field :field16498, 9, optional: true, type: :fixed32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24317 do
   @moduledoc false
@@ -1827,8 +1721,6 @@ defmodule Benchmarks.GoogleMessage3.Message24317 do
   field :field24473, 27, repeated: true, type: :string
 
   field :field24474, 40, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.PbExtension do
   @moduledoc false

--- a/bench/lib/datasets/google_message3/benchmark_message3_5.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_5.pb.ex
@@ -5,8 +5,6 @@ defmodule Benchmarks.GoogleMessage3.Message24377 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24378 do
   @moduledoc false
@@ -15,8 +13,6 @@ defmodule Benchmarks.GoogleMessage3.Message24378 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24400 do
   @moduledoc false
@@ -45,8 +41,6 @@ defmodule Benchmarks.GoogleMessage3.Message24400 do
   field :field24677, 4, optional: true, type: :int32
 
   field :field24678, 5, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24380 do
   @moduledoc false
@@ -55,8 +49,6 @@ defmodule Benchmarks.GoogleMessage3.Message24380 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24381 do
   @moduledoc false
@@ -65,8 +57,6 @@ defmodule Benchmarks.GoogleMessage3.Message24381 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message719 do
   @moduledoc false
@@ -91,8 +81,6 @@ defmodule Benchmarks.GoogleMessage3.Message719 do
   field :field883, 3, repeated: true, type: :string
 
   field :field884, 4, optional: true, type: Benchmarks.GoogleMessage3.Enum720, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message728 do
   @moduledoc false
@@ -140,8 +128,6 @@ defmodule Benchmarks.GoogleMessage3.Message728 do
 
   field :field895, 9, repeated: true, type: :string
 
-  def transform_module(), do: nil
-
   extensions [{10, 11}, {11, 12}, {12, 13}]
 end
 defmodule Benchmarks.GoogleMessage3.Message704 do
@@ -179,8 +165,6 @@ defmodule Benchmarks.GoogleMessage3.Message704 do
   field :field805, 5, optional: true, type: :string
 
   field :field806, 6, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message697 do
   @moduledoc false
@@ -336,8 +320,6 @@ defmodule Benchmarks.GoogleMessage3.Message697 do
 
   field :field778, 38, optional: true, type: :int64
 
-  def transform_module(), do: nil
-
   extensions [{28, 29}, {26, 27}]
 end
 defmodule Benchmarks.GoogleMessage3.Message0 do
@@ -349,8 +331,6 @@ defmodule Benchmarks.GoogleMessage3.Message0 do
         }
 
   defstruct __pb_extensions__: nil
-
-  def transform_module(), do: nil
 
   extensions [{4, 2_147_483_647}]
 end
@@ -369,8 +349,6 @@ defmodule Benchmarks.GoogleMessage3.Message6578 do
   field :field6632, 1, optional: true, type: Benchmarks.GoogleMessage3.Enum6579, enum: true
 
   field :field6633, 2, optional: true, type: Benchmarks.GoogleMessage3.Enum6588, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6024 do
   @moduledoc false
@@ -391,8 +369,6 @@ defmodule Benchmarks.GoogleMessage3.Message6024 do
   field :field6049, 2, optional: true, type: :string
 
   field :field6050, 3, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6052 do
   @moduledoc false
@@ -409,8 +385,6 @@ defmodule Benchmarks.GoogleMessage3.Message6052 do
   field :field6084, 1, required: true, type: :string
 
   field :field6085, 2, required: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6054 do
   @moduledoc false
@@ -427,8 +401,6 @@ defmodule Benchmarks.GoogleMessage3.Message6054 do
   field :field6089, 1, required: true, type: :string
 
   field :field6090, 2, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10573 do
   @moduledoc false
@@ -448,8 +420,6 @@ defmodule Benchmarks.GoogleMessage3.Message10573 do
 
   field :field10581, 2, optional: true, type: :string
 
-  def transform_module(), do: nil
-
   extensions [{10000, 536_870_912}]
 end
 defmodule Benchmarks.GoogleMessage3.Message10824 do
@@ -467,8 +437,6 @@ defmodule Benchmarks.GoogleMessage3.Message10824 do
   field :field10825, 1, required: true, type: :string
 
   field :field10826, 2, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10582 do
   @moduledoc false
@@ -501,8 +469,6 @@ defmodule Benchmarks.GoogleMessage3.Message10582 do
   field :field10587, 5, optional: true, type: :double
 
   field :field10588, 6, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10155.Message10156 do
   @moduledoc false
@@ -527,8 +493,6 @@ defmodule Benchmarks.GoogleMessage3.Message10155.Message10156 do
   field :field10268, 53, optional: true, type: :int32
 
   field :field10269, 54, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10155 do
   @moduledoc false
@@ -824,8 +788,6 @@ defmodule Benchmarks.GoogleMessage3.Message10155 do
 
   field :field10264, 94, repeated: true, type: Benchmarks.GoogleMessage3.Message9628
 
-  def transform_module(), do: nil
-
   extensions [{57, 58}, {1000, 536_870_912}]
 end
 defmodule Benchmarks.GoogleMessage3.Message11866 do
@@ -855,8 +817,6 @@ defmodule Benchmarks.GoogleMessage3.Message11866 do
   field :field11871, 4, optional: true, type: :double
 
   field :field11872, 5, repeated: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10469 do
   @moduledoc false
@@ -901,8 +861,6 @@ defmodule Benchmarks.GoogleMessage3.Message10469 do
   field :field10480, 8, optional: true, type: :int32
 
   field :field10481, 9, optional: true, type: :float
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10818 do
   @moduledoc false
@@ -919,8 +877,6 @@ defmodule Benchmarks.GoogleMessage3.Message10818 do
   field :field10819, 1, optional: true, type: Benchmarks.GoogleMessage3.Message10800
 
   field :field10820, 2, optional: true, type: Benchmarks.GoogleMessage3.Message10801
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10773 do
   @moduledoc false
@@ -1021,8 +977,6 @@ defmodule Benchmarks.GoogleMessage3.Message10773 do
   field :field10795, 14, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
 
   field :field10796, 22, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13145 do
   @moduledoc false
@@ -1046,8 +1000,6 @@ defmodule Benchmarks.GoogleMessage3.Message13145 do
 
   field :field13157, 3, optional: true, type: :float
 
-  def transform_module(), do: nil
-
   extensions [{1000, 536_870_912}]
 end
 defmodule Benchmarks.GoogleMessage3.Message16686 do
@@ -1057,8 +1009,6 @@ defmodule Benchmarks.GoogleMessage3.Message16686 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message12796 do
   @moduledoc false
@@ -1075,8 +1025,6 @@ defmodule Benchmarks.GoogleMessage3.Message12796 do
   field :field12800, 1, repeated: true, type: :fixed64
 
   field :field12801, 2, optional: true, type: :uint64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6722 do
   @moduledoc false
@@ -1085,8 +1033,6 @@ defmodule Benchmarks.GoogleMessage3.Message6722 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6727 do
   @moduledoc false
@@ -1095,8 +1041,6 @@ defmodule Benchmarks.GoogleMessage3.Message6727 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6724 do
   @moduledoc false
@@ -1105,8 +1049,6 @@ defmodule Benchmarks.GoogleMessage3.Message6724 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message6735 do
   @moduledoc false
@@ -1115,8 +1057,6 @@ defmodule Benchmarks.GoogleMessage3.Message6735 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8183 do
   @moduledoc false
@@ -1133,8 +1073,6 @@ defmodule Benchmarks.GoogleMessage3.Message8183 do
   field :field8226, 1, optional: true, type: :string
 
   field :field8227, 2, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8301 do
   @moduledoc false
@@ -1190,8 +1128,6 @@ defmodule Benchmarks.GoogleMessage3.Message8301 do
 
   field :field8338, 11, optional: true, type: Benchmarks.GoogleMessage3.Message7965
 
-  def transform_module(), do: nil
-
   extensions [{64, 536_870_912}]
 end
 defmodule Benchmarks.GoogleMessage3.Message8456 do
@@ -1201,8 +1137,6 @@ defmodule Benchmarks.GoogleMessage3.Message8456 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8302 do
   @moduledoc false
@@ -1298,8 +1232,6 @@ defmodule Benchmarks.GoogleMessage3.Message8302 do
 
   field :field8359, 21, optional: true, type: Benchmarks.GoogleMessage3.Message7965
 
-  def transform_module(), do: nil
-
   extensions [{64, 536_870_912}]
 end
 defmodule Benchmarks.GoogleMessage3.Message8457 do
@@ -1309,8 +1241,6 @@ defmodule Benchmarks.GoogleMessage3.Message8457 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8449 do
   @moduledoc false
@@ -1347,8 +1277,6 @@ defmodule Benchmarks.GoogleMessage3.Message8449 do
   field :field8463, 6, optional: true, type: :string
 
   field :field8464, 7, optional: true, type: Benchmarks.GoogleMessage3.Message7966
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13358 do
   @moduledoc false
@@ -1369,8 +1297,6 @@ defmodule Benchmarks.GoogleMessage3.Message13358 do
   field :field13360, 2, required: true, type: :fixed64
 
   field :field13361, 3, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message13912 do
   @moduledoc false
@@ -1395,8 +1321,6 @@ defmodule Benchmarks.GoogleMessage3.Message13912 do
   field :field13915, 500, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
   field :field13916, 15, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24316 do
   @moduledoc false
@@ -1417,8 +1341,6 @@ defmodule Benchmarks.GoogleMessage3.Message24316 do
   field :field24444, 2, repeated: true, type: :string
 
   field :field24445, 3, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24312 do
   @moduledoc false
@@ -1451,8 +1373,6 @@ defmodule Benchmarks.GoogleMessage3.Message24312 do
   field :field24425, 5, repeated: true, type: :string
 
   field :field24426, 6, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24313 do
   @moduledoc false
@@ -1501,8 +1421,6 @@ defmodule Benchmarks.GoogleMessage3.Message24313 do
   field :field24435, 9, optional: true, type: :string
 
   field :field24436, 10, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message24315 do
   @moduledoc false
@@ -1523,8 +1441,6 @@ defmodule Benchmarks.GoogleMessage3.Message24315 do
   field :field24441, 2, repeated: true, type: :string
 
   field :field24442, 3, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message716 do
   @moduledoc false
@@ -1549,8 +1465,6 @@ defmodule Benchmarks.GoogleMessage3.Message716 do
   field :field874, 3, optional: true, type: :bool
 
   field :field875, 4, optional: true, type: Benchmarks.GoogleMessage3.Message717
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message718 do
   @moduledoc false
@@ -1571,8 +1485,6 @@ defmodule Benchmarks.GoogleMessage3.Message718 do
   field :field879, 2, repeated: true, type: :string
 
   field :field880, 3, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message703 do
   @moduledoc false
@@ -1601,8 +1513,6 @@ defmodule Benchmarks.GoogleMessage3.Message703 do
   field :field798, 4, optional: true, type: :string
 
   field :field799, 5, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message715 do
   @moduledoc false
@@ -1663,8 +1573,6 @@ defmodule Benchmarks.GoogleMessage3.Message715 do
   field :field870, 12, repeated: true, type: Benchmarks.GoogleMessage3.Message702
 
   field :field871, 13, repeated: true, type: Benchmarks.GoogleMessage3.Message706
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message700 do
   @moduledoc false
@@ -1681,8 +1589,6 @@ defmodule Benchmarks.GoogleMessage3.Message700 do
   field :field789, 1, repeated: true, type: :string
 
   field :field790, 2, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message699 do
   @moduledoc false
@@ -1699,8 +1605,6 @@ defmodule Benchmarks.GoogleMessage3.Message699 do
   field :field787, 1, required: true, type: :string
 
   field :field788, 2, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message698 do
   @moduledoc false
@@ -1741,6 +1645,4 @@ defmodule Benchmarks.GoogleMessage3.Message698 do
   field :field785, 7, optional: true, type: :int64
 
   field :field786, 8, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message3/benchmark_message3_6.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_6.pb.ex
@@ -5,8 +5,6 @@ defmodule Benchmarks.GoogleMessage3.Message10576 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10154 do
   @moduledoc false
@@ -23,8 +21,6 @@ defmodule Benchmarks.GoogleMessage3.Message10154 do
   field :field10192, 1, optional: true, type: :bytes
 
   field :field10193, 2, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8944 do
   @moduledoc false
@@ -281,8 +277,6 @@ defmodule Benchmarks.GoogleMessage3.Message8944 do
   field :field9105, 100, optional: true, type: Benchmarks.GoogleMessage3.Message8939
 
   field :field9106, 101, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message9182 do
   @moduledoc false
@@ -398,8 +392,6 @@ defmodule Benchmarks.GoogleMessage3.Message9182 do
 
   field :field9230, 39, optional: true, type: :float
 
-  def transform_module(), do: nil
-
   extensions [{3, 7}, {9, 16}, {23, 24}, {24, 25}, {1000, 536_870_912}]
 end
 defmodule Benchmarks.GoogleMessage3.Message9160 do
@@ -417,8 +409,6 @@ defmodule Benchmarks.GoogleMessage3.Message9160 do
   field :field9161, 1, optional: true, type: :int32
 
   field :field9162, 2, optional: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message9242 do
   @moduledoc false
@@ -431,8 +421,6 @@ defmodule Benchmarks.GoogleMessage3.Message9242 do
   defstruct field9327: []
 
   field :field9327, 1, repeated: true, type: Benchmarks.GoogleMessage3.Enum9243, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8890 do
   @moduledoc false
@@ -445,8 +433,6 @@ defmodule Benchmarks.GoogleMessage3.Message8890 do
   defstruct field8916: []
 
   field :field8916, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message8888
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message9123 do
   @moduledoc false
@@ -459,8 +445,6 @@ defmodule Benchmarks.GoogleMessage3.Message9123 do
   defstruct field9135: nil
 
   field :field9135, 1, optional: true, type: :float
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message9628 do
   @moduledoc false
@@ -485,8 +469,6 @@ defmodule Benchmarks.GoogleMessage3.Message9628 do
   field :field9675, 3, repeated: true, type: :int32
 
   field :field9676, 4, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message11014 do
   @moduledoc false
@@ -755,8 +737,6 @@ defmodule Benchmarks.GoogleMessage3.Message11014 do
   field :field11843, 45, optional: true, type: :int32
 
   field :field11844, 74, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10801 do
   @moduledoc false
@@ -777,8 +757,6 @@ defmodule Benchmarks.GoogleMessage3.Message10801 do
   field :field10813, 2, repeated: true, type: Benchmarks.GoogleMessage3.Message10802
 
   field :field10814, 3, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10749 do
   @moduledoc false
@@ -791,8 +769,6 @@ defmodule Benchmarks.GoogleMessage3.Message10749 do
   defstruct field10754: []
 
   field :field10754, 1, repeated: true, type: Benchmarks.GoogleMessage3.Message10748
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8298 do
   @moduledoc false
@@ -813,8 +789,6 @@ defmodule Benchmarks.GoogleMessage3.Message8298 do
   field :field8322, 2, optional: true, type: :int64
 
   field :field8323, 3, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8300 do
   @moduledoc false
@@ -831,8 +805,6 @@ defmodule Benchmarks.GoogleMessage3.Message8300 do
   field :field8326, 1, optional: true, type: :string
 
   field :field8327, 2, optional: true, type: Benchmarks.GoogleMessage3.Message7966
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8291 do
   @moduledoc false
@@ -861,8 +833,6 @@ defmodule Benchmarks.GoogleMessage3.Message8291 do
   field :field8309, 4, optional: true, type: :string
 
   field :field8310, 5, optional: true, type: Benchmarks.GoogleMessage3.Enum8292, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8296 do
   @moduledoc false
@@ -895,8 +865,6 @@ defmodule Benchmarks.GoogleMessage3.Message8296 do
   field :field8315, 5, optional: true, type: :int32
 
   field :field8316, 6, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7965 do
   @moduledoc false
@@ -913,8 +881,6 @@ defmodule Benchmarks.GoogleMessage3.Message7965 do
   field :field7967, 1, optional: true, type: :int32
 
   field :field7968, 2, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8290 do
   @moduledoc false
@@ -931,8 +897,6 @@ defmodule Benchmarks.GoogleMessage3.Message8290 do
   field :field8304, 1, optional: true, type: :string
 
   field :field8305, 2, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message717 do
   @moduledoc false
@@ -949,8 +913,6 @@ defmodule Benchmarks.GoogleMessage3.Message717 do
   field :field876, 1, repeated: true, type: :string
 
   field :field877, 2, optional: true, type: :double
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message713 do
   @moduledoc false
@@ -967,8 +929,6 @@ defmodule Benchmarks.GoogleMessage3.Message713 do
   field :field852, 1, required: true, type: Benchmarks.GoogleMessage3.Message708
 
   field :field853, 2, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message705 do
   @moduledoc false
@@ -1005,8 +965,6 @@ defmodule Benchmarks.GoogleMessage3.Message705 do
   field :field812, 6, optional: true, type: :string
 
   field :field813, 7, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message709 do
   @moduledoc false
@@ -1035,8 +993,6 @@ defmodule Benchmarks.GoogleMessage3.Message709 do
   field :field832, 4, repeated: true, type: :string
 
   field :field833, 5, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message702 do
   @moduledoc false
@@ -1053,8 +1009,6 @@ defmodule Benchmarks.GoogleMessage3.Message702 do
   field :field793, 1, optional: true, type: :string
 
   field :field794, 2, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message714 do
   @moduledoc false
@@ -1083,8 +1037,6 @@ defmodule Benchmarks.GoogleMessage3.Message714 do
   field :field857, 4, optional: true, type: :string
 
   field :field858, 5, optional: true, type: :uint32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message710 do
   @moduledoc false
@@ -1113,8 +1065,6 @@ defmodule Benchmarks.GoogleMessage3.Message710 do
   field :field837, 4, repeated: true, type: :string
 
   field :field838, 5, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message706 do
   @moduledoc false
@@ -1139,8 +1089,6 @@ defmodule Benchmarks.GoogleMessage3.Message706 do
   field :field816, 3, repeated: true, type: :string
 
   field :field817, 4, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message707 do
   @moduledoc false
@@ -1169,8 +1117,6 @@ defmodule Benchmarks.GoogleMessage3.Message707 do
   field :field821, 4, optional: true, type: :bool
 
   field :field822, 5, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message711 do
   @moduledoc false
@@ -1195,8 +1141,6 @@ defmodule Benchmarks.GoogleMessage3.Message711 do
   field :field841, 2, repeated: true, type: :string
 
   field :field842, 3, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message712 do
   @moduledoc false
@@ -1241,8 +1185,6 @@ defmodule Benchmarks.GoogleMessage3.Message712 do
   field :field850, 8, optional: true, type: :string
 
   field :field851, 9, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8939.Message8940 do
   @moduledoc false
@@ -1251,8 +1193,6 @@ defmodule Benchmarks.GoogleMessage3.Message8939.Message8940 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8939.Message8941 do
   @moduledoc false
@@ -1285,8 +1225,6 @@ defmodule Benchmarks.GoogleMessage3.Message8939.Message8941 do
   field :field9037, 36, optional: true, type: :string
 
   field :field9038, 37, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8939.Message8943 do
   @moduledoc false
@@ -1319,8 +1257,6 @@ defmodule Benchmarks.GoogleMessage3.Message8939.Message8943 do
   field :field9043, 5, optional: true, type: :string
 
   field :field9044, 6, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8939 do
   @moduledoc false
@@ -1417,8 +1353,6 @@ defmodule Benchmarks.GoogleMessage3.Message8939 do
   field :field9030, 49, optional: true, type: Benchmarks.GoogleMessage3.UnusedEnum, enum: true
 
   field :message8943, 51, optional: true, type: :group
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message9181 do
   @moduledoc false
@@ -1431,8 +1365,6 @@ defmodule Benchmarks.GoogleMessage3.Message9181 do
   defstruct field9204: nil
 
   field :field9204, 1, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message9164 do
   @moduledoc false
@@ -1453,8 +1385,6 @@ defmodule Benchmarks.GoogleMessage3.Message9164 do
   field :field9169, 2, optional: true, type: :int32
 
   field :field9170, 3, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message9165 do
   @moduledoc false
@@ -1471,8 +1401,6 @@ defmodule Benchmarks.GoogleMessage3.Message9165 do
   field :field9171, 1, optional: true, type: :float
 
   field :field9172, 2, optional: true, type: :float
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message9166 do
   @moduledoc false
@@ -1489,8 +1417,6 @@ defmodule Benchmarks.GoogleMessage3.Message9166 do
   field :field9173, 1, optional: true, type: :float
 
   field :field9174, 2, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message9151 do
   @moduledoc false
@@ -1531,8 +1457,6 @@ defmodule Benchmarks.GoogleMessage3.Message9151 do
   field :field9158, 7, optional: true, type: :float
 
   field :field9159, 8, optional: true, type: :float
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8888 do
   @moduledoc false
@@ -1557,8 +1481,6 @@ defmodule Benchmarks.GoogleMessage3.Message8888 do
   field :field8910, 2, repeated: true, type: :int32, packed: true
 
   field :field8911, 3, optional: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message9627 do
   @moduledoc false
@@ -1587,8 +1509,6 @@ defmodule Benchmarks.GoogleMessage3.Message9627 do
   field :field9671, 4, required: true, type: :int32
 
   field :field9672, 5, optional: true, type: :float
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message11020 do
   @moduledoc false
@@ -1597,8 +1517,6 @@ defmodule Benchmarks.GoogleMessage3.Message11020 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message11013 do
   @moduledoc false
@@ -1699,6 +1617,4 @@ defmodule Benchmarks.GoogleMessage3.Message11013 do
   field :field11778, 23, optional: true, type: Benchmarks.GoogleMessage3.UnusedEmptyMessage
 
   field :field11779, 22, repeated: true, type: Benchmarks.GoogleMessage3.Message11011
-
-  def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message3/benchmark_message3_7.pb.ex
+++ b/bench/lib/datasets/google_message3/benchmark_message3_7.pb.ex
@@ -5,8 +5,6 @@ defmodule Benchmarks.GoogleMessage3.Message11018 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10800 do
   @moduledoc false
@@ -31,8 +29,6 @@ defmodule Benchmarks.GoogleMessage3.Message10800 do
   field :field10810, 3, optional: true, type: :bool
 
   field :field10811, 4, optional: true, type: :float
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10802 do
   @moduledoc false
@@ -41,8 +37,6 @@ defmodule Benchmarks.GoogleMessage3.Message10802 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message10748 do
   @moduledoc false
@@ -67,8 +61,6 @@ defmodule Benchmarks.GoogleMessage3.Message10748 do
   field :field10752, 3, optional: true, type: :int32
 
   field :field10753, 4, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message7966 do
   @moduledoc false
@@ -85,8 +77,6 @@ defmodule Benchmarks.GoogleMessage3.Message7966 do
   field :field7969, 1, optional: true, type: :string
 
   field :field7970, 2, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message708 do
   @moduledoc false
@@ -119,8 +109,6 @@ defmodule Benchmarks.GoogleMessage3.Message708 do
   field :field827, 4, repeated: true, type: :string
 
   field :field828, 5, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message8942 do
   @moduledoc false
@@ -129,8 +117,6 @@ defmodule Benchmarks.GoogleMessage3.Message8942 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message11011 do
   @moduledoc false
@@ -147,8 +133,6 @@ defmodule Benchmarks.GoogleMessage3.Message11011 do
   field :field11752, 1, required: true, type: :bytes
 
   field :field11753, 2, required: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.UnusedEmptyMessage do
   @moduledoc false
@@ -157,8 +141,6 @@ defmodule Benchmarks.GoogleMessage3.UnusedEmptyMessage do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage3.Message741 do
   @moduledoc false
@@ -171,6 +153,4 @@ defmodule Benchmarks.GoogleMessage3.Message741 do
   defstruct field936: []
 
   field :field936, 1, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message4/benchmark_message4.pb.ex
+++ b/bench/lib/datasets/google_message4/benchmark_message4.pb.ex
@@ -69,8 +69,6 @@ defmodule Benchmarks.GoogleMessage4.GoogleMessage4 do
   field :field37517, 15, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
 
   field :field37518, 16, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message37489 do
   @moduledoc false
@@ -163,8 +161,6 @@ defmodule Benchmarks.GoogleMessage4.Message37489 do
   field :field37553, 39, optional: true, type: Benchmarks.GoogleMessage4.Message37333
 
   field :field37554, 40, optional: true, type: Benchmarks.GoogleMessage4.Message37335
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7319 do
   @moduledoc false
@@ -181,8 +177,6 @@ defmodule Benchmarks.GoogleMessage4.Message7319 do
   field :field7321, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
 
   field :field7322, 7, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12717 do
   @moduledoc false
@@ -227,8 +221,6 @@ defmodule Benchmarks.GoogleMessage4.Message12717 do
   field :field12726, 8, repeated: true, type: Benchmarks.GoogleMessage4.Message11948
 
   field :field12727, 9, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message37331 do
   @moduledoc false
@@ -253,8 +245,6 @@ defmodule Benchmarks.GoogleMessage4.Message37331 do
   field :field37369, 2, required: true, type: :int64
 
   field :field37370, 3, required: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message8815 do
   @moduledoc false
@@ -275,8 +265,6 @@ defmodule Benchmarks.GoogleMessage4.Message8815 do
   field :field8820, 2, repeated: true, type: Benchmarks.GoogleMessage4.Message8768
 
   field :field8821, 3, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7330 do
   @moduledoc false
@@ -309,8 +297,6 @@ defmodule Benchmarks.GoogleMessage4.Message7330 do
   field :field7336, 5, optional: true, type: :bool
 
   field :field7337, 6, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12960 do
   @moduledoc false
@@ -327,8 +313,6 @@ defmodule Benchmarks.GoogleMessage4.Message12960 do
   field :field12962, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
 
   field :field12963, 2, optional: true, type: Benchmarks.GoogleMessage4.Message12948
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message176.Message178 do
   @moduledoc false
@@ -337,8 +321,6 @@ defmodule Benchmarks.GoogleMessage4.Message176.Message178 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message176 do
   @moduledoc false
@@ -583,8 +565,6 @@ defmodule Benchmarks.GoogleMessage4.Message176 do
   field :field465, 63, repeated: true, type: :string
 
   field :field466, 65, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message8817 do
   @moduledoc false
@@ -605,8 +585,6 @@ defmodule Benchmarks.GoogleMessage4.Message8817 do
   field :field8826, 2, repeated: true, type: Benchmarks.GoogleMessage4.Message8768
 
   field :field8827, 3, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message8835 do
   @moduledoc false
@@ -627,8 +605,6 @@ defmodule Benchmarks.GoogleMessage4.Message8835 do
   field :field8838, 2, repeated: true, type: :string
 
   field :field8839, 3, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message37333 do
   @moduledoc false
@@ -649,8 +625,6 @@ defmodule Benchmarks.GoogleMessage4.Message37333 do
   field :field37373, 1, required: true, type: Benchmarks.GoogleMessage4.Message37326
 
   field :field37374, 2, optional: true, type: :uint64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message13000 do
   @moduledoc false
@@ -667,8 +641,6 @@ defmodule Benchmarks.GoogleMessage4.Message13000 do
   field :field13015, 1, optional: true, type: :int64
 
   field :field13016, 2, repeated: true, type: Benchmarks.GoogleMessage4.Message12979
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message37335 do
   @moduledoc false
@@ -693,8 +665,6 @@ defmodule Benchmarks.GoogleMessage4.Message37335 do
   field :field37378, 2, required: true, type: Benchmarks.GoogleMessage4.Message37173
 
   field :field37379, 3, optional: true, type: :uint64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message8848 do
   @moduledoc false
@@ -715,8 +685,6 @@ defmodule Benchmarks.GoogleMessage4.Message8848 do
   field :field8851, 2, optional: true, type: :string
 
   field :field8852, 3, optional: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message13035 do
   @moduledoc false
@@ -733,8 +701,6 @@ defmodule Benchmarks.GoogleMessage4.Message13035 do
   field :field13058, 1, optional: true, type: :int64
 
   field :field13059, 2, repeated: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message8856 do
   @moduledoc false
@@ -751,8 +717,6 @@ defmodule Benchmarks.GoogleMessage4.Message8856 do
   field :field8858, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
 
   field :field8859, 2, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12908 do
   @moduledoc false
@@ -785,8 +749,6 @@ defmodule Benchmarks.GoogleMessage4.Message12908 do
   field :field12916, 5, optional: true, type: Benchmarks.GoogleMessage4.Message3804
 
   field :field12917, 6, optional: true, type: Benchmarks.GoogleMessage4.Message12870
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12910 do
   @moduledoc false
@@ -807,8 +769,6 @@ defmodule Benchmarks.GoogleMessage4.Message12910 do
   field :field12921, 2, optional: true, type: Benchmarks.GoogleMessage4.Message12818
 
   field :field12922, 3, repeated: true, type: Benchmarks.GoogleMessage4.Message12903
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message37327 do
   @moduledoc false
@@ -861,8 +821,6 @@ defmodule Benchmarks.GoogleMessage4.Message37327 do
   field :field37356, 9, optional: true, type: :bool
 
   field :field37357, 10, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message37329 do
   @moduledoc false
@@ -891,8 +849,6 @@ defmodule Benchmarks.GoogleMessage4.Message37329 do
   field :field37362, 3, required: true, type: :int64
 
   field :field37363, 4, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message2517 do
   @moduledoc false
@@ -921,8 +877,6 @@ defmodule Benchmarks.GoogleMessage4.Message2517 do
   field :field2522, 4, optional: true, type: Benchmarks.GoogleMessage4.Message2463
 
   field :field2523, 5, repeated: true, type: Benchmarks.GoogleMessage4.Message971
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12748 do
   @moduledoc false
@@ -947,8 +901,6 @@ defmodule Benchmarks.GoogleMessage4.Message12748 do
   field :field12756, 3, optional: true, type: :string
 
   field :field12757, 4, optional: true, type: Benchmarks.GoogleMessage4.Enum12735, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12687 do
   @moduledoc false
@@ -961,8 +913,6 @@ defmodule Benchmarks.GoogleMessage4.Message12687 do
   defstruct field12701: []
 
   field :field12701, 1, repeated: true, type: Benchmarks.GoogleMessage4.Message12686
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message11948 do
   @moduledoc false
@@ -983,8 +933,6 @@ defmodule Benchmarks.GoogleMessage4.Message11948 do
   field :field11955, 2, repeated: true, type: Benchmarks.GoogleMessage4.Message11949
 
   field :field11956, 3, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message11976 do
   @moduledoc false
@@ -997,8 +945,6 @@ defmodule Benchmarks.GoogleMessage4.Message11976 do
   defstruct field12002: []
 
   field :field12002, 1, repeated: true, type: Benchmarks.GoogleMessage4.Message11975
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7320 do
   @moduledoc false
@@ -1015,8 +961,6 @@ defmodule Benchmarks.GoogleMessage4.Message7320 do
   field :field7323, 1, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
 
   field :field7324, 8, optional: true, type: Benchmarks.GoogleMessage4.Message7287
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3069.Message3070 do
   @moduledoc false
@@ -1033,8 +977,6 @@ defmodule Benchmarks.GoogleMessage4.Message3069.Message3070 do
   field :field3378, 4, required: true, type: Benchmarks.GoogleMessage4.Enum3071, enum: true
 
   field :field3379, 5, required: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3069 do
   @moduledoc false
@@ -1058,8 +1000,6 @@ defmodule Benchmarks.GoogleMessage4.Message3069 do
 
   field :message3070, 3, repeated: true, type: :group
 
-  def transform_module(), do: nil
-
   extensions [{10000, 536_870_912}]
 end
 defmodule Benchmarks.GoogleMessage4.Message12948 do
@@ -1073,8 +1013,6 @@ defmodule Benchmarks.GoogleMessage4.Message12948 do
   defstruct field12958: []
 
   field :field12958, 1, repeated: true, type: Benchmarks.GoogleMessage4.Message12949
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message8768 do
   @moduledoc false
@@ -1111,8 +1049,6 @@ defmodule Benchmarks.GoogleMessage4.Message8768 do
   field :field8787, 6, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
 
   field :field8788, 7, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12979 do
   @moduledoc false
@@ -1149,8 +1085,6 @@ defmodule Benchmarks.GoogleMessage4.Message12979 do
   field :field12986, 6, optional: true, type: :int32
 
   field :field12987, 7, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message37173 do
   @moduledoc false
@@ -1259,8 +1193,6 @@ defmodule Benchmarks.GoogleMessage4.Message37173 do
   field :field37275, 25, optional: true, type: :string
 
   field :field37276, 26, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12799 do
   @moduledoc false
@@ -1301,8 +1233,6 @@ defmodule Benchmarks.GoogleMessage4.Message12799 do
   field :field12815, 6, optional: true, type: :int32
 
   field :field12816, 7, optional: true, type: Benchmarks.GoogleMessage4.Message12797
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12870 do
   @moduledoc false
@@ -1391,8 +1321,6 @@ defmodule Benchmarks.GoogleMessage4.Message12870 do
   field :field12897, 17, optional: true, type: Benchmarks.GoogleMessage4.Enum12871, enum: true
 
   field :field12898, 19, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3804 do
   @moduledoc false
@@ -1429,8 +1357,6 @@ defmodule Benchmarks.GoogleMessage4.Message3804 do
   field :field3823, 7, optional: true, type: :int64
 
   field :field3824, 8, optional: true, type: Benchmarks.GoogleMessage4.Enum3783, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12903 do
   @moduledoc false
@@ -1451,8 +1377,6 @@ defmodule Benchmarks.GoogleMessage4.Message12903 do
   field :field12906, 2, optional: true, type: Benchmarks.GoogleMessage4.Message8587
 
   field :field12907, 3, repeated: true, type: Benchmarks.GoogleMessage4.Message8590
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message37326 do
   @moduledoc false
@@ -1469,8 +1393,6 @@ defmodule Benchmarks.GoogleMessage4.Message37326 do
   field :field37345, 1, required: true, type: :string
 
   field :field37346, 2, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message2356.Message2357 do
   @moduledoc false
@@ -1527,8 +1449,6 @@ defmodule Benchmarks.GoogleMessage4.Message2356.Message2357 do
   field :field2409, 122, optional: true, type: :bool
 
   field :field2410, 124, optional: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message2356.Message2358 do
   @moduledoc false
@@ -1537,8 +1457,6 @@ defmodule Benchmarks.GoogleMessage4.Message2356.Message2358 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message2356.Message2359 do
   @moduledoc false
@@ -1547,8 +1465,6 @@ defmodule Benchmarks.GoogleMessage4.Message2356.Message2359 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message2356 do
   @moduledoc false
@@ -1681,8 +1597,6 @@ defmodule Benchmarks.GoogleMessage4.Message2356 do
   field :field2397, 100, optional: true, type: :string
 
   field :field2398, 123, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message0 do
   @moduledoc false
@@ -1693,8 +1607,6 @@ defmodule Benchmarks.GoogleMessage4.Message0 do
         }
 
   defstruct __pb_extensions__: nil
-
-  def transform_module(), do: nil
 
   extensions [{4, 2_147_483_647}]
 end
@@ -1717,6 +1629,4 @@ defmodule Benchmarks.GoogleMessage4.Message971 do
   field :field973, 2, optional: true, type: :int32
 
   field :field974, 3, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message4/benchmark_message4_1.pb.ex
+++ b/bench/lib/datasets/google_message4/benchmark_message4_1.pb.ex
@@ -9,8 +9,6 @@ defmodule Benchmarks.GoogleMessage4.Message2463 do
   defstruct field2498: []
 
   field :field2498, 1, repeated: true, type: Benchmarks.GoogleMessage4.Message2462
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12686 do
   @moduledoc false
@@ -27,8 +25,6 @@ defmodule Benchmarks.GoogleMessage4.Message12686 do
   field :field12699, 1, optional: true, type: :string
 
   field :field12700, 2, optional: true, type: Benchmarks.GoogleMessage4.Message12685
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message11949 do
   @moduledoc false
@@ -37,8 +33,6 @@ defmodule Benchmarks.GoogleMessage4.Message11949 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message11975 do
   @moduledoc false
@@ -87,8 +81,6 @@ defmodule Benchmarks.GoogleMessage4.Message11975 do
   field :field12000, 9, repeated: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
 
   field :field12001, 11, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7287 do
   @moduledoc false
@@ -129,8 +121,6 @@ defmodule Benchmarks.GoogleMessage4.Message7287 do
   field :field7317, 7, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
 
   field :field7318, 9, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3061.Message3062 do
   @moduledoc false
@@ -151,8 +141,6 @@ defmodule Benchmarks.GoogleMessage4.Message3061.Message3062 do
   field :field3336, 6, optional: true, type: :int32
 
   field :field3337, 7, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3061.Message3063 do
   @moduledoc false
@@ -177,8 +165,6 @@ defmodule Benchmarks.GoogleMessage4.Message3061.Message3063 do
   field :field3340, 15, optional: true, type: :int64
 
   field :field3341, 23, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3061.Message3064 do
   @moduledoc false
@@ -263,8 +249,6 @@ defmodule Benchmarks.GoogleMessage4.Message3061.Message3064 do
   field :field3359, 19, optional: true, type: :int32
 
   field :field3360, 95, optional: true, type: Benchmarks.GoogleMessage4.Enum2834, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3061.Message3065 do
   @moduledoc false
@@ -273,8 +257,6 @@ defmodule Benchmarks.GoogleMessage4.Message3061.Message3065 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3061.Message3066 do
   @moduledoc false
@@ -315,8 +297,6 @@ defmodule Benchmarks.GoogleMessage4.Message3061.Message3066 do
   field :field3372, 85, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
 
   field :field3373, 96, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3061 do
   @moduledoc false
@@ -517,8 +497,6 @@ defmodule Benchmarks.GoogleMessage4.Message3061 do
   field :field3332, 59, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
 
   field :field3333, 17, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12949 do
   @moduledoc false
@@ -527,8 +505,6 @@ defmodule Benchmarks.GoogleMessage4.Message12949 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message8572 do
   @moduledoc false
@@ -737,8 +713,6 @@ defmodule Benchmarks.GoogleMessage4.Message8572 do
   field :field8695, 53, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
 
   field :field8696, 61, optional: true, type: Benchmarks.GoogleMessage4.Message8575
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message8774 do
   @moduledoc false
@@ -767,8 +741,6 @@ defmodule Benchmarks.GoogleMessage4.Message8774 do
   field :field8813, 4, optional: true, type: :string
 
   field :field8814, 5, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12776 do
   @moduledoc false
@@ -820,8 +792,6 @@ defmodule Benchmarks.GoogleMessage4.Message12776 do
 
   field :field12795, 12, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
 
-  def transform_module(), do: nil
-
   extensions [{2, 3}, {3, 4}, {4, 5}, {5, 6}, {7, 8}, {9, 10}]
 end
 defmodule Benchmarks.GoogleMessage4.Message12798 do
@@ -847,8 +817,6 @@ defmodule Benchmarks.GoogleMessage4.Message12798 do
   field :field12807, 6, optional: true, type: Benchmarks.GoogleMessage4.Message12774
 
   field :field12808, 7, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12797 do
   @moduledoc false
@@ -869,8 +837,6 @@ defmodule Benchmarks.GoogleMessage4.Message12797 do
   field :field12803, 2, repeated: true, type: Benchmarks.GoogleMessage4.Message12796
 
   field :field12804, 3, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12825 do
   @moduledoc false
@@ -907,8 +873,6 @@ defmodule Benchmarks.GoogleMessage4.Message12825 do
   field :field12867, 6, repeated: true, type: Benchmarks.GoogleMessage4.Message12821
 
   field :field12868, 7, repeated: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message8590 do
   @moduledoc false
@@ -917,8 +881,6 @@ defmodule Benchmarks.GoogleMessage4.Message8590 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message8587 do
   @moduledoc false
@@ -927,8 +889,6 @@ defmodule Benchmarks.GoogleMessage4.Message8587 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message1374 do
   @moduledoc false
@@ -945,8 +905,6 @@ defmodule Benchmarks.GoogleMessage4.Message1374 do
   field :field1375, 1, required: true, type: :string
 
   field :field1376, 2, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message2462 do
   @moduledoc false
@@ -963,8 +921,6 @@ defmodule Benchmarks.GoogleMessage4.Message2462 do
   field :field2496, 1, required: true, type: :bytes
 
   field :field2497, 2, required: true, type: :double
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12685 do
   @moduledoc false
@@ -1001,8 +957,6 @@ defmodule Benchmarks.GoogleMessage4.Message12685 do
   field :field12697, 6, optional: true, type: :string
 
   field :field12698, 7, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message10320 do
   @moduledoc false
@@ -1039,8 +993,6 @@ defmodule Benchmarks.GoogleMessage4.Message10320 do
   field :field10352, 6, optional: true, type: :int32
 
   field :field10353, 7, optional: true, type: Benchmarks.GoogleMessage4.Enum10337, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message11947 do
   @moduledoc false
@@ -1061,8 +1013,6 @@ defmodule Benchmarks.GoogleMessage4.Message11947 do
   field :field11952, 2, optional: true, type: :bool
 
   field :field11953, 3, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message11920 do
   @moduledoc false
@@ -1079,8 +1029,6 @@ defmodule Benchmarks.GoogleMessage4.Message11920 do
   field :field11945, 1, optional: true, type: Benchmarks.GoogleMessage4.Enum11901, enum: true
 
   field :field11946, 2, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message6643 do
   @moduledoc false
@@ -1161,8 +1109,6 @@ defmodule Benchmarks.GoogleMessage4.Message6643 do
   field :field6699, 20, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
 
   field :field6700, 21, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message6133 do
   @moduledoc false
@@ -1251,8 +1197,6 @@ defmodule Benchmarks.GoogleMessage4.Message6133 do
   field :field6191, 20, optional: true, type: :string
 
   field :field6192, 21, repeated: true, type: Benchmarks.GoogleMessage4.Message5881
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message6109 do
   @moduledoc false
@@ -1312,8 +1256,6 @@ defmodule Benchmarks.GoogleMessage4.Message6109 do
 
   field :field6151, 14, optional: true, type: :bool
 
-  def transform_module(), do: nil
-
   extensions [{1000, 536_870_912}]
 end
 defmodule Benchmarks.GoogleMessage4.Message3046 do
@@ -1331,8 +1273,6 @@ defmodule Benchmarks.GoogleMessage4.Message3046 do
   field :field3222, 1, required: true, type: Benchmarks.GoogleMessage4.Enum2593, enum: true
 
   field :field3223, 4, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3060 do
   @moduledoc false
@@ -1353,8 +1293,6 @@ defmodule Benchmarks.GoogleMessage4.Message3060 do
   field :field3284, 2, optional: true, type: :int64
 
   field :field3285, 3, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3041 do
   @moduledoc false
@@ -1371,8 +1309,6 @@ defmodule Benchmarks.GoogleMessage4.Message3041 do
   field :field3214, 1, optional: true, type: :string
 
   field :field3215, 2, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3040 do
   @moduledoc false
@@ -1401,8 +1337,6 @@ defmodule Benchmarks.GoogleMessage4.Message3040 do
   field :field3212, 2, optional: true, type: :fixed64
 
   field :field3213, 3, required: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3050 do
   @moduledoc false
@@ -1435,8 +1369,6 @@ defmodule Benchmarks.GoogleMessage4.Message3050 do
   field :field3249, 1, optional: true, type: :fixed32
 
   field :field3250, 3, optional: true, type: :fixed32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7905 do
   @moduledoc false
@@ -1473,8 +1405,6 @@ defmodule Benchmarks.GoogleMessage4.Message7905 do
   field :field7916, 6, optional: true, type: :bytes
 
   field :field7917, 7, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3886.Message3887 do
   @moduledoc false
@@ -1499,8 +1429,6 @@ defmodule Benchmarks.GoogleMessage4.Message3886.Message3887 do
   field :field3934, 3, optional: true, type: Benchmarks.GoogleMessage4.Message3850
 
   field :field3935, 8, optional: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3886 do
   @moduledoc false
@@ -1513,8 +1441,6 @@ defmodule Benchmarks.GoogleMessage4.Message3886 do
   defstruct message3887: []
 
   field :message3887, 1, repeated: true, type: :group
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7864 do
   @moduledoc false
@@ -1547,8 +1473,6 @@ defmodule Benchmarks.GoogleMessage4.Message7864 do
   field :field7870, 7, repeated: true, type: Benchmarks.GoogleMessage4.Message7865
 
   field :field7871, 8, repeated: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3922 do
   @moduledoc false
@@ -1561,8 +1485,6 @@ defmodule Benchmarks.GoogleMessage4.Message3922 do
   defstruct field4012: nil
 
   field :field4012, 1, optional: true, type: :uint64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3052 do
   @moduledoc false
@@ -1607,8 +1529,6 @@ defmodule Benchmarks.GoogleMessage4.Message3052 do
   field :field3261, 8, optional: true, type: :string
 
   field :field3262, 9, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message8575 do
   @moduledoc false
@@ -1617,8 +1537,6 @@ defmodule Benchmarks.GoogleMessage4.Message8575 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7843 do
   @moduledoc false
@@ -1691,8 +1609,6 @@ defmodule Benchmarks.GoogleMessage4.Message7843 do
   field :field7858, 20, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
 
   field :field7859, 2, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3919 do
   @moduledoc false
@@ -1705,8 +1621,6 @@ defmodule Benchmarks.GoogleMessage4.Message3919 do
   defstruct field4009: []
 
   field :field4009, 1, repeated: true, type: Benchmarks.GoogleMessage4.Message3920
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7929 do
   @moduledoc false
@@ -1795,6 +1709,4 @@ defmodule Benchmarks.GoogleMessage4.Message7929 do
   field :field7960, 11, repeated: true, type: :bytes
 
   field :field7961, 16, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end

--- a/bench/lib/datasets/google_message4/benchmark_message4_2.pb.ex
+++ b/bench/lib/datasets/google_message4/benchmark_message4_2.pb.ex
@@ -29,8 +29,6 @@ defmodule Benchmarks.GoogleMessage4.Message12774 do
   field :field12781, 5, optional: true, type: :uint32
 
   field :field12782, 6, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12796 do
   @moduledoc false
@@ -47,8 +45,6 @@ defmodule Benchmarks.GoogleMessage4.Message12796 do
   field :field12800, 1, repeated: true, type: :fixed64
 
   field :field12801, 2, optional: true, type: :uint64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12821 do
   @moduledoc false
@@ -77,8 +73,6 @@ defmodule Benchmarks.GoogleMessage4.Message12821 do
   field :field12851, 4, optional: true, type: :int32
 
   field :field12852, 5, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12820 do
   @moduledoc false
@@ -119,8 +113,6 @@ defmodule Benchmarks.GoogleMessage4.Message12820 do
   field :field12846, 6, optional: true, type: :int32
 
   field :field12847, 7, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12819 do
   @moduledoc false
@@ -153,8 +145,6 @@ defmodule Benchmarks.GoogleMessage4.Message12819 do
   field :field12838, 5, optional: true, type: :double
 
   field :field12839, 6, optional: true, type: :double
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12818 do
   @moduledoc false
@@ -183,8 +173,6 @@ defmodule Benchmarks.GoogleMessage4.Message12818 do
   field :field12832, 5, optional: true, type: :int32
 
   field :field12833, 4, repeated: true, type: Benchmarks.GoogleMessage4.Message12817
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message10319 do
   @moduledoc false
@@ -221,8 +209,6 @@ defmodule Benchmarks.GoogleMessage4.Message10319 do
   field :field10345, 6, optional: true, type: :string
 
   field :field10346, 7, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message6578 do
   @moduledoc false
@@ -239,8 +225,6 @@ defmodule Benchmarks.GoogleMessage4.Message6578 do
   field :field6632, 1, optional: true, type: Benchmarks.GoogleMessage4.Enum6579, enum: true
 
   field :field6633, 2, optional: true, type: Benchmarks.GoogleMessage4.Enum6588, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message6126 do
   @moduledoc false
@@ -325,8 +309,6 @@ defmodule Benchmarks.GoogleMessage4.Message6126 do
   field :field6169, 17, repeated: true, type: Benchmarks.GoogleMessage4.Message6054
 
   field :field6170, 19, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message5881 do
   @moduledoc false
@@ -359,8 +341,6 @@ defmodule Benchmarks.GoogleMessage4.Message5881 do
   field :field5901, 4, optional: true, type: Benchmarks.GoogleMessage4.Message5867
 
   field :field5902, 6, optional: true, type: Benchmarks.GoogleMessage4.Message5880
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message6110 do
   @moduledoc false
@@ -369,8 +349,6 @@ defmodule Benchmarks.GoogleMessage4.Message6110 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message6107 do
   @moduledoc false
@@ -403,8 +381,6 @@ defmodule Benchmarks.GoogleMessage4.Message6107 do
   field :field6138, 5, optional: true, type: :int32
 
   field :field6139, 6, repeated: true, type: Benchmarks.GoogleMessage4.Message6108
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message6129 do
   @moduledoc false
@@ -421,8 +397,6 @@ defmodule Benchmarks.GoogleMessage4.Message6129 do
   field :field6171, 1, required: true, type: Benchmarks.GoogleMessage4.Enum6130, enum: true
 
   field :field6172, 2, required: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message5908 do
   @moduledoc false
@@ -631,8 +605,6 @@ defmodule Benchmarks.GoogleMessage4.Message5908 do
   field :field6019, 44, optional: true, type: Benchmarks.GoogleMessage4.Message5907
 
   field :field6020, 46, optional: true, type: Benchmarks.GoogleMessage4.Enum5962, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3850 do
   @moduledoc false
@@ -665,8 +637,6 @@ defmodule Benchmarks.GoogleMessage4.Message3850 do
   field :field3928, 13, optional: true, type: :bool
 
   field :field3929, 14, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7865 do
   @moduledoc false
@@ -675,8 +645,6 @@ defmodule Benchmarks.GoogleMessage4.Message7865 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7511 do
   @moduledoc false
@@ -713,8 +681,6 @@ defmodule Benchmarks.GoogleMessage4.Message7511 do
   field :field7528, 6, optional: true, type: :int32
 
   field :field7529, 7, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message3920 do
   @moduledoc false
@@ -723,8 +689,6 @@ defmodule Benchmarks.GoogleMessage4.Message3920 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7928 do
   @moduledoc false
@@ -741,8 +705,6 @@ defmodule Benchmarks.GoogleMessage4.Message7928 do
   field :field7940, 1, optional: true, type: :string
 
   field :field7941, 2, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7921 do
   @moduledoc false
@@ -767,8 +729,6 @@ defmodule Benchmarks.GoogleMessage4.Message7921 do
   field :field7938, 3, optional: true, type: :float
 
   field :field7939, 4, optional: true, type: Benchmarks.GoogleMessage4.Enum7922, enum: true
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7920 do
   @moduledoc false
@@ -785,8 +745,6 @@ defmodule Benchmarks.GoogleMessage4.Message7920 do
   field :field7934, 1, optional: true, type: :int64
 
   field :field7935, 2, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message7919 do
   @moduledoc false
@@ -807,8 +765,6 @@ defmodule Benchmarks.GoogleMessage4.Message7919 do
   field :field7932, 2, optional: true, type: :int64
 
   field :field7933, 3, optional: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message12817 do
   @moduledoc false
@@ -829,8 +785,6 @@ defmodule Benchmarks.GoogleMessage4.Message12817 do
   field :field12827, 2, optional: true, type: :int32
 
   field :field12828, 3, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message6054 do
   @moduledoc false
@@ -847,8 +801,6 @@ defmodule Benchmarks.GoogleMessage4.Message6054 do
   field :field6089, 1, required: true, type: :string
 
   field :field6090, 2, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message6127 do
   @moduledoc false
@@ -857,8 +809,6 @@ defmodule Benchmarks.GoogleMessage4.Message6127 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message6052 do
   @moduledoc false
@@ -875,8 +825,6 @@ defmodule Benchmarks.GoogleMessage4.Message6052 do
   field :field6084, 1, required: true, type: :string
 
   field :field6085, 2, required: true, type: :bytes
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message6024 do
   @moduledoc false
@@ -897,8 +845,6 @@ defmodule Benchmarks.GoogleMessage4.Message6024 do
   field :field6049, 2, optional: true, type: :string
 
   field :field6050, 3, optional: true, type: Benchmarks.GoogleMessage4.UnusedEmptyMessage
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message5861 do
   @moduledoc false
@@ -923,8 +869,6 @@ defmodule Benchmarks.GoogleMessage4.Message5861 do
   field :field5884, 3, optional: true, type: :bool
 
   field :field5885, 4, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message5880 do
   @moduledoc false
@@ -937,8 +881,6 @@ defmodule Benchmarks.GoogleMessage4.Message5880 do
   defstruct field5896: nil
 
   field :field5896, 1, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message5867 do
   @moduledoc false
@@ -971,8 +913,6 @@ defmodule Benchmarks.GoogleMessage4.Message5867 do
   field :field5894, 5, optional: true, type: Benchmarks.GoogleMessage4.UnusedEnum, enum: true
 
   field :field5895, 6, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message4016 do
   @moduledoc false
@@ -997,8 +937,6 @@ defmodule Benchmarks.GoogleMessage4.Message4016 do
   field :field4019, 3, required: true, type: :int32
 
   field :field4020, 4, required: true, type: :int32
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message6108 do
   @moduledoc false
@@ -1007,8 +945,6 @@ defmodule Benchmarks.GoogleMessage4.Message6108 do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message5907 do
   @moduledoc false
@@ -1033,8 +969,6 @@ defmodule Benchmarks.GoogleMessage4.Message5907 do
   field :field5969, 3, optional: true, type: Benchmarks.GoogleMessage4.Message5903
 
   field :field5970, 4, optional: true, type: Benchmarks.GoogleMessage4.Message5903
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.UnusedEmptyMessage do
   @moduledoc false
@@ -1043,8 +977,6 @@ defmodule Benchmarks.GoogleMessage4.UnusedEmptyMessage do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 defmodule Benchmarks.GoogleMessage4.Message5903 do
   @moduledoc false
@@ -1061,6 +993,4 @@ defmodule Benchmarks.GoogleMessage4.Message5903 do
   field :field5965, 1, required: true, type: :int32
 
   field :field5966, 2, optional: true, type: Benchmarks.GoogleMessage4.Enum5904, enum: true
-
-  def transform_module(), do: nil
 end

--- a/lib/elixirpb.pb.ex
+++ b/lib/elixirpb.pb.ex
@@ -9,8 +9,6 @@ defmodule Elixirpb.FileOptions do
   defstruct module_prefix: nil
 
   field :module_prefix, 1, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 
 defmodule Elixirpb.PbExtension do

--- a/lib/google/compiler/plugin.pb.ex
+++ b/lib/google/compiler/plugin.pb.ex
@@ -31,8 +31,6 @@ defmodule Google.Protobuf.Compiler.Version do
   field :patch, 3, optional: true, type: :int32
 
   field :suffix, 4, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.Compiler.CodeGeneratorRequest do
@@ -58,8 +56,6 @@ defmodule Google.Protobuf.Compiler.CodeGeneratorRequest do
   field :proto_file, 15, repeated: true, type: Google.Protobuf.FileDescriptorProto
 
   field :compiler_version, 3, optional: true, type: Google.Protobuf.Compiler.Version
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.Compiler.CodeGeneratorResponse.File do
@@ -85,8 +81,6 @@ defmodule Google.Protobuf.Compiler.CodeGeneratorResponse.File do
   field :content, 15, optional: true, type: :string
 
   field :generated_code_info, 16, optional: true, type: Google.Protobuf.GeneratedCodeInfo
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.Compiler.CodeGeneratorResponse do
@@ -108,6 +102,4 @@ defmodule Google.Protobuf.Compiler.CodeGeneratorResponse do
   field :supported_features, 2, optional: true, type: :uint64
 
   field :file, 15, repeated: true, type: Google.Protobuf.Compiler.CodeGeneratorResponse.File
-
-  def transform_module(), do: nil
 end

--- a/lib/google/descriptor.pb.ex
+++ b/lib/google/descriptor.pb.ex
@@ -109,8 +109,6 @@ defmodule Google.Protobuf.FileDescriptorSet do
   defstruct file: []
 
   field :file, 1, repeated: true, type: Google.Protobuf.FileDescriptorProto
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.FileDescriptorProto do
@@ -168,8 +166,6 @@ defmodule Google.Protobuf.FileDescriptorProto do
   field :source_code_info, 9, optional: true, type: Google.Protobuf.SourceCodeInfo
 
   field :syntax, 12, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.DescriptorProto.ExtensionRange do
@@ -191,8 +187,6 @@ defmodule Google.Protobuf.DescriptorProto.ExtensionRange do
   field :end, 2, optional: true, type: :int32
 
   field :options, 3, optional: true, type: Google.Protobuf.ExtensionRangeOptions
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.DescriptorProto.ReservedRange do
@@ -210,8 +204,6 @@ defmodule Google.Protobuf.DescriptorProto.ReservedRange do
   field :start, 1, optional: true, type: :int32
 
   field :end, 2, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.DescriptorProto do
@@ -261,8 +253,6 @@ defmodule Google.Protobuf.DescriptorProto do
   field :reserved_range, 9, repeated: true, type: Google.Protobuf.DescriptorProto.ReservedRange
 
   field :reserved_name, 10, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.ExtensionRangeOptions do
@@ -278,8 +268,6 @@ defmodule Google.Protobuf.ExtensionRangeOptions do
             __pb_extensions__: nil
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
-
-  def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
 end
@@ -335,8 +323,6 @@ defmodule Google.Protobuf.FieldDescriptorProto do
   field :options, 8, optional: true, type: Google.Protobuf.FieldOptions
 
   field :proto3_optional, 17, optional: true, type: :bool
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.OneofDescriptorProto do
@@ -354,8 +340,6 @@ defmodule Google.Protobuf.OneofDescriptorProto do
   field :name, 1, optional: true, type: :string
 
   field :options, 2, optional: true, type: Google.Protobuf.OneofOptions
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.EnumDescriptorProto.EnumReservedRange do
@@ -373,8 +357,6 @@ defmodule Google.Protobuf.EnumDescriptorProto.EnumReservedRange do
   field :start, 1, optional: true, type: :int32
 
   field :end, 2, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.EnumDescriptorProto do
@@ -406,8 +388,6 @@ defmodule Google.Protobuf.EnumDescriptorProto do
     type: Google.Protobuf.EnumDescriptorProto.EnumReservedRange
 
   field :reserved_name, 5, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.EnumValueDescriptorProto do
@@ -429,8 +409,6 @@ defmodule Google.Protobuf.EnumValueDescriptorProto do
   field :number, 2, optional: true, type: :int32
 
   field :options, 3, optional: true, type: Google.Protobuf.EnumValueOptions
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.ServiceDescriptorProto do
@@ -452,8 +430,6 @@ defmodule Google.Protobuf.ServiceDescriptorProto do
   field :method, 2, repeated: true, type: Google.Protobuf.MethodDescriptorProto
 
   field :options, 3, optional: true, type: Google.Protobuf.ServiceOptions
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.MethodDescriptorProto do
@@ -487,8 +463,6 @@ defmodule Google.Protobuf.MethodDescriptorProto do
   field :client_streaming, 5, optional: true, type: :bool, default: false
 
   field :server_streaming, 6, optional: true, type: :bool, default: false
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.FileOptions do
@@ -589,8 +563,6 @@ defmodule Google.Protobuf.FileOptions do
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  def transform_module(), do: nil
-
   extensions [{1000, 536_870_912}]
 end
 
@@ -623,8 +595,6 @@ defmodule Google.Protobuf.MessageOptions do
   field :map_entry, 7, optional: true, type: :bool
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
-
-  def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
 end
@@ -675,8 +645,6 @@ defmodule Google.Protobuf.FieldOptions do
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  def transform_module(), do: nil
-
   extensions [{1000, 536_870_912}]
 end
 
@@ -693,8 +661,6 @@ defmodule Google.Protobuf.OneofOptions do
             __pb_extensions__: nil
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
-
-  def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
 end
@@ -721,8 +687,6 @@ defmodule Google.Protobuf.EnumOptions do
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  def transform_module(), do: nil
-
   extensions [{1000, 536_870_912}]
 end
 
@@ -744,8 +708,6 @@ defmodule Google.Protobuf.EnumValueOptions do
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  def transform_module(), do: nil
-
   extensions [{1000, 536_870_912}]
 end
 
@@ -766,8 +728,6 @@ defmodule Google.Protobuf.ServiceOptions do
   field :deprecated, 33, optional: true, type: :bool, default: false
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
-
-  def transform_module(), do: nil
 
   extensions [{1000, 536_870_912}]
 end
@@ -798,8 +758,6 @@ defmodule Google.Protobuf.MethodOptions do
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  def transform_module(), do: nil
-
   extensions [{1000, 536_870_912}]
 end
 
@@ -818,8 +776,6 @@ defmodule Google.Protobuf.UninterpretedOption.NamePart do
   field :name_part, 1, required: true, type: :string
 
   field :is_extension, 2, required: true, type: :bool
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.UninterpretedOption do
@@ -857,8 +813,6 @@ defmodule Google.Protobuf.UninterpretedOption do
   field :string_value, 7, optional: true, type: :bytes
 
   field :aggregate_value, 8, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.SourceCodeInfo.Location do
@@ -888,8 +842,6 @@ defmodule Google.Protobuf.SourceCodeInfo.Location do
   field :trailing_comments, 4, optional: true, type: :string
 
   field :leading_detached_comments, 6, repeated: true, type: :string
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.SourceCodeInfo do
@@ -903,8 +855,6 @@ defmodule Google.Protobuf.SourceCodeInfo do
   defstruct location: []
 
   field :location, 1, repeated: true, type: Google.Protobuf.SourceCodeInfo.Location
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.GeneratedCodeInfo.Annotation do
@@ -930,8 +880,6 @@ defmodule Google.Protobuf.GeneratedCodeInfo.Annotation do
   field :begin, 3, optional: true, type: :int32
 
   field :end, 4, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 
 defmodule Google.Protobuf.GeneratedCodeInfo do
@@ -945,6 +893,4 @@ defmodule Google.Protobuf.GeneratedCodeInfo do
   defstruct annotation: []
 
   field :annotation, 1, repeated: true, type: Google.Protobuf.GeneratedCodeInfo.Annotation
-
-  def transform_module(), do: nil
 end

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -29,7 +29,9 @@ defmodule <%= @module %> do
   field <%= f %>
   <% end %>
 
+  <%= if @transform_module do %>
   def transform_module(), do: <%= inspect(@transform_module) %>
+  <% end %>
 
   <%= if @extensions != [] do %>
   extensions <%= inspect(@extensions, limit: :infinity) %>

--- a/test/protobuf/protoc/generator/message_test.exs
+++ b/test/protobuf/protoc/generator/message_test.exs
@@ -33,7 +33,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     ctx = %Context{}
     desc = Google.Protobuf.DescriptorProto.new(name: "Foo")
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
-    assert msg =~ "def transform_module(), do: nil\n"
+    refute msg =~ "def transform_module()"
 
     ctx = %Context{transform_module: My.Transform.Module}
     desc = Google.Protobuf.DescriptorProto.new(name: "Foo")

--- a/test/protobuf/protoc/proto_gen/extension.pb.ex
+++ b/test/protobuf/protoc/proto_gen/extension.pb.ex
@@ -9,6 +9,4 @@ defmodule Protobuf.Protoc.ExtTest.Foo do
   defstruct a: nil
 
   field :a, 1, optional: true, type: :string
-
-  def transform_module(), do: nil
 end

--- a/test/protobuf/protoc/proto_gen/test.pb.ex
+++ b/test/protobuf/protoc/proto_gen/test.pb.ex
@@ -51,8 +51,6 @@ defmodule My.Test.Request.SomeGroup do
   defstruct group_field: nil
 
   field :group_field, 9, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 
 defmodule My.Test.Request.NameMappingEntry do
@@ -70,8 +68,6 @@ defmodule My.Test.Request.NameMappingEntry do
   field :key, 1, optional: true, type: :int32
 
   field :value, 2, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 
 defmodule My.Test.Request.MsgMappingEntry do
@@ -89,8 +85,6 @@ defmodule My.Test.Request.MsgMappingEntry do
   field :key, 1, optional: true, type: :sint64
 
   field :value, 2, optional: true, type: My.Test.Reply
-
-  def transform_module(), do: nil
 end
 
 defmodule My.Test.Request do
@@ -136,8 +130,6 @@ defmodule My.Test.Request do
   field :reset, 12, optional: true, type: :int32
 
   field :get_key, 16, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 
 defmodule My.Test.Reply.Entry do
@@ -159,8 +151,6 @@ defmodule My.Test.Reply.Entry do
   field :value, 2, optional: true, type: :int64, default: 7
 
   field :_my_field_name_2, 3, optional: true, type: :int64
-
-  def transform_module(), do: nil
 end
 
 defmodule My.Test.Reply do
@@ -181,8 +171,6 @@ defmodule My.Test.Reply do
 
   field :compact_keys, 2, repeated: true, type: :int32, packed: true
 
-  def transform_module(), do: nil
-
   extensions [{100, 536_870_912}]
 end
 
@@ -200,8 +188,6 @@ defmodule My.Test.OtherBase do
 
   field :name, 1, optional: true, type: :string
 
-  def transform_module(), do: nil
-
   extensions [{100, 536_870_912}]
 end
 
@@ -212,8 +198,6 @@ defmodule My.Test.ReplyExtensions do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 
 defmodule My.Test.OtherReplyExtensions do
@@ -227,8 +211,6 @@ defmodule My.Test.OtherReplyExtensions do
   defstruct key: nil
 
   field :key, 1, optional: true, type: :int32
-
-  def transform_module(), do: nil
 end
 
 defmodule My.Test.OldReply do
@@ -240,8 +222,6 @@ defmodule My.Test.OldReply do
         }
 
   defstruct __pb_extensions__: nil
-
-  def transform_module(), do: nil
 
   extensions [{100, 2_147_483_647}]
 end
@@ -257,8 +237,6 @@ defmodule My.Test.Communique.SomeGroup do
   defstruct member: nil
 
   field :member, 15, optional: true, type: :string
-
-  def transform_module(), do: nil
 end
 
 defmodule My.Test.Communique.Delta do
@@ -268,8 +246,6 @@ defmodule My.Test.Communique.Delta do
   @type t :: %__MODULE__{}
 
   defstruct []
-
-  def transform_module(), do: nil
 end
 
 defmodule My.Test.Communique do
@@ -317,8 +293,6 @@ defmodule My.Test.Communique do
   field :msg, 13, optional: true, type: My.Test.Reply, oneof: 0
 
   field :somegroup, 14, optional: true, type: :group, oneof: 0
-
-  def transform_module(), do: nil
 end
 
 defmodule My.Test.Options do
@@ -332,8 +306,6 @@ defmodule My.Test.Options do
   defstruct opt1: nil
 
   field :opt1, 1, optional: true, type: :string, deprecated: true
-
-  def transform_module(), do: nil
 end
 
 defmodule My.Test.PbExtension do


### PR DESCRIPTION
There is a default function implementation included in `use Protobuf` so there is no need to generate it.