### PR TITLE
Improve parsing of floats in JSON

### DIFF
--- a/.github/workflows/conformance.yml
+++ b/.github/workflows/conformance.yml
@@ -74,5 +74,4 @@ jobs:
 
       - name: Run mix protobuf.conformance
         run: |
-          mix gen_conformance_protos
           mix conformance_test --runner=./protobuf/conformance/conformance-test-runner --verbose

--- a/conformance/exemptions.txt
+++ b/conformance/exemptions.txt
@@ -617,16 +617,6 @@ Required.Proto3.JsonInput.EnumFieldWithAliasUseAlias.JsonOutput
 Required.Proto3.JsonInput.EnumFieldWithAliasUseAlias.ProtobufOutput
 Required.Proto3.JsonInput.FieldMask.JsonOutput
 Required.Proto3.JsonInput.FieldMask.ProtobufOutput
-Required.Proto3.JsonInput.FloatFieldTooLarge
-Required.Proto3.JsonInput.FloatFieldTooSmall
-Required.Proto3.JsonInput.Int32FieldExponentialFormat.JsonOutput
-Required.Proto3.JsonInput.Int32FieldExponentialFormat.ProtobufOutput
-Required.Proto3.JsonInput.Int32FieldFloatTrailingZero.JsonOutput
-Required.Proto3.JsonInput.Int32FieldFloatTrailingZero.ProtobufOutput
-Required.Proto3.JsonInput.Int32FieldMaxFloatValue.JsonOutput
-Required.Proto3.JsonInput.Int32FieldMaxFloatValue.ProtobufOutput
-Required.Proto3.JsonInput.Int32FieldMinFloatValue.JsonOutput
-Required.Proto3.JsonInput.Int32FieldMinFloatValue.ProtobufOutput
 Required.Proto3.JsonInput.OptionalBoolWrapper.JsonOutput
 Required.Proto3.JsonInput.OptionalBoolWrapper.ProtobufOutput
 Required.Proto3.JsonInput.OptionalBytesWrapper.JsonOutput
@@ -685,8 +675,6 @@ Required.Proto3.JsonInput.TimestampWithNegativeOffset.JsonOutput
 Required.Proto3.JsonInput.TimestampWithNegativeOffset.ProtobufOutput
 Required.Proto3.JsonInput.TimestampWithPositiveOffset.JsonOutput
 Required.Proto3.JsonInput.TimestampWithPositiveOffset.ProtobufOutput
-Required.Proto3.JsonInput.Uint32FieldMaxFloatValue.JsonOutput
-Required.Proto3.JsonInput.Uint32FieldMaxFloatValue.ProtobufOutput
 Required.Proto3.JsonInput.ValueAcceptBool.JsonOutput
 Required.Proto3.JsonInput.ValueAcceptBool.ProtobufOutput
 Required.Proto3.JsonInput.ValueAcceptFloat.JsonOutput

--- a/test/protobuf/json/decode_test.exs
+++ b/test/protobuf/json/decode_test.exs
@@ -182,12 +182,35 @@ defmodule Protobuf.JSON.DecodeTest do
       assert decode(%{"uint64" => -1}, Scalars) == error(msg)
     end
 
-    # TODO: Jason decodes integers in E notation as floats, e.g. 1e2 becomes
-    # 100.0 rather than 100. We need to figure out how to make them integers.
-    # We could try to guess with Float.ratio matching to {_, 1} or maybe with
-    # to_string matching ~r|\.0$| but this might be a bad idea in the end.
-    @tag :skip
-    test "values in E notation are valid"
+    test "values in E notation are valid" do
+      int_types = [
+        :int32,
+        :sint32,
+        :fixed32,
+        :sfixed32,
+        :uint32,
+        :int32,
+        :sint32,
+        :fixed32,
+        :sfixed32,
+        :uint32,
+        :int64,
+        :sint64,
+        :fixed64,
+        :sfixed64,
+        :uint64,
+        :int64,
+        :sint64,
+        :fixed64,
+        :sfixed64,
+        :uint64
+      ]
+
+      for int_type <- int_types do
+        decoded = Scalars.new!([{int_type, 100_000}])
+        assert decode(%{Atom.to_string(int_type) => 1.0e5}, Scalars) == {:ok, decoded}
+      end
+    end
   end
 
   describe "floating point" do
@@ -253,10 +276,13 @@ defmodule Protobuf.JSON.DecodeTest do
       assert decode(data, Scalars) == error(msg)
     end
 
-    # TODO: `double` values out of bounds will already get caught by Jason, `float`
-    # values however will need to be range-limited.
-    @tag :skip
-    test "values outside upper and lower limits are invalid"
+    # Can't really test out of bound doubles since they're out of bound for Erlang too :).
+    test "values outside upper and lower limits are invalid" do
+      data = %{"float" => 1.0e39}
+
+      assert decode(data, Scalars) ==
+               error("Field 'float' has an invalid floating point (1.0e39)")
+    end
   end
 
   describe "bytes" do


### PR DESCRIPTION
* We now check that floats are in the valid float range when decoding JSON
* We now support "casting" of floats in JSON into integers if the type of the field in the schema is an integer