### PR TITLE
Fix conformance tests for Google.Protobuf.Duration

### DIFF
--- a/conformance/exemptions.txt
+++ b/conformance/exemptions.txt
@@ -215,10 +215,6 @@ Recommended.Proto2.ProtobufInput.ValidDataScalarBinary.UINT32[9].ProtobufOutput
 Recommended.Proto2.ProtobufInput.ValidDataScalarBinary.UINT64[0].ProtobufOutput
 Recommended.Proto2.ProtobufInput.ValidDataScalarBinary.UINT64[1].ProtobufOutput
 Recommended.Proto2.ProtobufInput.ValidDataScalarBinary.UINT64[2].ProtobufOutput
-Recommended.Proto3.JsonInput.DurationHas3FractionalDigits.Validator
-Recommended.Proto3.JsonInput.DurationHas6FractionalDigits.Validator
-Recommended.Proto3.JsonInput.DurationHas9FractionalDigits.Validator
-Recommended.Proto3.JsonInput.DurationHasZeroFractionalDigit.Validator
 Recommended.Proto3.JsonInput.NullValueInOtherOneofNewFormat.Validator
 Recommended.Proto3.JsonInput.NullValueInOtherOneofOldFormat.Validator
 Recommended.Proto3.ProtobufInput.ValidDataOneofBinary.MESSAGE.Merge.ProtobufOutput
@@ -275,8 +271,6 @@ Recommended.Proto3.ProtobufInput.ValidDataRepeated.UINT64.UnpackedInput.Unpacked
 Recommended.Proto3.ProtobufInput.ValidDataScalarBinary.ENUM[4].ProtobufOutput
 Recommended.Proto3.ProtobufInput.ValidDataScalarBinary.ENUM[5].ProtobufOutput
 Recommended.Proto3.ProtobufInput.ValidDataScalarBinary.SINT32[4].ProtobufOutput
-Required.DurationProtoInputTooLarge.JsonOutput
-Required.DurationProtoInputTooSmall.JsonOutput
 Required.Proto2.JsonInput.StoresDefaultPrimitive.Validator
 Required.Proto2.ProtobufInput.IllegalZeroFieldNum_Case_0
 Required.Proto2.ProtobufInput.IllegalZeroFieldNum_Case_1
@@ -593,10 +587,6 @@ Required.Proto3.JsonInput.AnyWithValueForInteger.JsonOutput
 Required.Proto3.JsonInput.AnyWithValueForInteger.ProtobufOutput
 Required.Proto3.JsonInput.AnyWithValueForJsonObject.JsonOutput
 Required.Proto3.JsonInput.AnyWithValueForJsonObject.ProtobufOutput
-Required.Proto3.JsonInput.DurationJsonInputTooLarge
-Required.Proto3.JsonInput.DurationJsonInputTooSmall
-Required.Proto3.JsonInput.DurationMinValue.ProtobufOutput
-Required.Proto3.JsonInput.DurationRepeatedValue.ProtobufOutput
 Required.Proto3.JsonInput.EnumFieldWithAliasDifferentCase.JsonOutput
 Required.Proto3.JsonInput.EnumFieldWithAliasDifferentCase.ProtobufOutput
 Required.Proto3.JsonInput.EnumFieldWithAliasLowerCase.JsonOutput

--- a/lib/protobuf/json/encode.ex
+++ b/lib/protobuf/json/encode.ex
@@ -11,14 +11,22 @@ defmodule Protobuf.JSON.Encode do
             encode_enum: 3,
             safe_enum_key: 2}
 
+  @duration_seconds_range -315_576_000_000..315_576_000_000
+
   @doc false
   @spec to_encodable(struct, keyword) :: map | {:error, EncodeError.t()}
   def to_encodable(struct, opts)
 
   def to_encodable(%mod{} = struct, _opts) when mod == Google.Protobuf.Duration do
     case struct do
-      %{seconds: seconds, nanos: 0} -> Integer.to_string(seconds)
-      %{seconds: seconds, nanos: nanos} -> "#{seconds}.#{nanos}s"
+      %{seconds: seconds} when seconds not in @duration_seconds_range ->
+        throw({:bad_duration, :seconds_outside_of_range, seconds})
+
+      %{seconds: seconds, nanos: 0} ->
+        Integer.to_string(seconds) <> "s"
+
+      %{seconds: seconds, nanos: nanos} ->
+        "#{seconds}.#{Utils.format_nanoseconds(nanos)}s"
     end
   end
 

--- a/lib/protobuf/json/encode_error.ex
+++ b/lib/protobuf/json/encode_error.ex
@@ -11,6 +11,12 @@ defmodule Protobuf.JSON.EncodeError do
     %__MODULE__{message: "JSON library not loaded, make sure to add :jason to your mix.exs file"}
   end
 
+  def new({:bad_duration, :seconds_outside_of_range, seconds}) do
+    %__MODULE__{
+      message: "invalid Google.Protobuf.Duration, seconds are outside of range: #{seconds}"
+    }
+  end
+
   def new({:invalid_timestamp, timestamp, reason}) do
     %__MODULE__{
       message:

--- a/lib/protobuf/json/utils.ex
+++ b/lib/protobuf/json/utils.ex
@@ -13,4 +13,52 @@ defmodule Protobuf.JSON.Utils do
       %Protobuf.MessageProps{syntax: syntax} -> throw({:unsupported_syntax, syntax})
     end
   end
+
+  # Used to encode nanoseconds for Google.Protobuf.Duration and Google.Protobuf.Timestamp.
+  # Examples:
+  # 1 -> "000000001"
+  # 1_000 -> "001000"
+  # 1_000_000 -> "001000000"
+  # 999_999_999 -> "999999999"
+  @doc false
+  @spec format_nanoseconds(integer()) :: String.t()
+  def format_nanoseconds(nanoseconds)
+      when nanoseconds >= -999_999_999 and nanoseconds <= 999_999_999 do
+    nanoseconds
+    |> abs()
+    |> Integer.to_string()
+    |> String.pad_leading(9, "0")
+    |> String.trim_trailing("000")
+    |> String.trim_trailing("000")
+  end
+
+  # Used to decode nanoseconds for Google.Protobuf.Duration and Google.Protobuf.Timestamp (in
+  # Protobuf.JSON.RFC3339). Has the same spec as Integer.parse/2.
+  # Examples:
+  # "100" -> 100_000_000 (nanosec)
+  # "000010" => 10_000 (nanosec)
+  # "000000001" => 1 (nanosec)
+  # "01" -> 10_000_000 (nanosec)
+  @doc false
+  @spec parse_nanoseconds(binary()) :: {nanoseconds :: integer(), rest :: binary()} | :error
+  def parse_nanoseconds(binary) when is_binary(binary) do
+    case parse_nanoseconds(binary, _acc = 0, _starting_power = 100_000_000) do
+      :error -> :error
+      {_, ^binary} -> :error
+      {_nanoseconds, _rest} = result -> result
+    end
+  end
+
+  defp parse_nanoseconds(<<digit, _rest::binary>>, _acc, _power = 0) when digit in ?0..?9 do
+    :error
+  end
+
+  defp parse_nanoseconds(<<digit, rest::binary>>, acc, power) when digit in ?0..?9 do
+    digit = digit - ?0
+    parse_nanoseconds(rest, acc + digit * power, div(power, 10))
+  end
+
+  defp parse_nanoseconds(rest, acc, _power) do
+    {acc, rest}
+  end
 end

--- a/test/protobuf/json/utils_test.exs
+++ b/test/protobuf/json/utils_test.exs
@@ -1,0 +1,54 @@
+defmodule Protobuf.JSON.UtilsTest do
+  use ExUnit.Case, async: true
+  use ExUnitProperties
+
+  alias Protobuf.JSON.Utils
+
+  @max_nanosec 999_999_999
+
+  property "format_nanoseconds/1 and parse_nanoseconds/1 are circular" do
+    check all nanoseconds <- integer(0..@max_nanosec) do
+      formatted = Utils.format_nanoseconds(nanoseconds)
+      assert {parsed, ""} = Utils.parse_nanoseconds(formatted)
+      assert parsed == nanoseconds
+    end
+  end
+
+  describe "format_nanoseconds/1" do
+    test "correctly pads the string and removes trailing zeros" do
+      assert Utils.format_nanoseconds(1) == "000000001"
+      assert Utils.format_nanoseconds(1_000) == "000001"
+      assert Utils.format_nanoseconds(1_000_000) == "001"
+      assert Utils.format_nanoseconds(999_999_999) == "999999999"
+    end
+
+    property "always formats nanoseconds as 3, 6, or 9 digits" do
+      check all nanoseconds <- integer(0..@max_nanosec), max_runs: 100 do
+        formatted = Utils.format_nanoseconds(nanoseconds)
+        assert byte_size(formatted) in [3, 6, 9]
+      end
+    end
+  end
+
+  describe "parse_nanoseconds/1" do
+    test "returns :error if no digits are present" do
+      assert Utils.parse_nanoseconds("foo") == :error
+    end
+
+    test "returns :error if more than 9 digits are passed" do
+      assert Utils.parse_nanoseconds("1234567899") == :error
+    end
+
+    property "returns whatever's left after parsing the digits" do
+      assert Utils.parse_nanoseconds("123456789foo") == {123_456_789, "foo"}
+      assert Utils.parse_nanoseconds("123456789") == {123_456_789, ""}
+
+      check all nanos <- string(?0..?9, min_length: 1, max_length: 9),
+                rest <- string([?a..?z, ?A..?Z], min_length: 0, max_length: 5),
+                max_runs: 10 do
+        assert {parsed_nanos, ^rest} = Utils.parse_nanoseconds(nanos <> rest)
+        assert parsed_nanos in 0..@max_nanosec
+      end
+    end
+  end
+end


### PR DESCRIPTION
I also added some unit tests for encoding and decoding `Google.Protobuf.Duration`. Nice!