### PR TITLE
Add Protobuf.encode/2 and c:Protobuf.encode/2

### DIFF
--- a/bench/script/bench.exs
+++ b/bench/script/bench.exs
@@ -34,4 +34,4 @@ encode =
       into: %{},
       do: {name, module.decode(payload)}
 
-Benchee.run(%{"encode" => &Protobuf.Encoder.encode/1}, opts.("encode", encode))
+Benchee.run(%{"encode" => &Protobuf.Encoder.encode(&1, _opts = [])}, opts.("encode", encode))

--- a/conformance/protobuf/runner.ex
+++ b/conformance/protobuf/runner.ex
@@ -27,12 +27,12 @@ defmodule Conformance.Protobuf.Runner do
             mod = Conformance.ConformanceResponse
             result = handle_encoded_request(encoded_request)
             response = mod.new(result: result)
-            encoded_response = mod.encode(response)
+            encoded_response = mod.encode(response, iolist: true)
 
             :ok =
               IO.binwrite(
                 :stdio,
-                <<byte_size(encoded_response)::unsigned-little-32, encoded_response::binary>>
+                [<<IO.iodata_length(encoded_response)::unsigned-little-32>>, encoded_response]
               )
 
             loop()

--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -68,7 +68,10 @@ defmodule Protobuf do
       def decode(data), do: Protobuf.Decoder.decode(data, __MODULE__)
 
       @impl unquote(__MODULE__)
-      def encode(struct), do: Protobuf.Encoder.encode(struct)
+      def encode(struct), do: Protobuf.Encoder.encode(struct, _options = [])
+
+      @impl unquote(__MODULE__)
+      def encode(struct, options), do: Protobuf.Encoder.encode(struct, options)
     end
   end
 
@@ -98,11 +101,23 @@ defmodule Protobuf do
   @callback new!(Enum.t()) :: struct()
 
   @doc """
+  Same as `c:encode/2` but with empty options.
+  """
+  @callback encode(struct()) :: iodata()
+
+  @doc """
   Encodes the given struct into to a Protobuf binary.
 
   Errors may be raised if there's something wrong in the struct.
+
+  ## Options
+
+    * `:iolist` - Boolean. If `true`, the returned value is iodata. If `false`, it's a binary.
+      Defaults to `false`.
+
   """
-  @callback encode(struct()) :: binary()
+  @callback encode(struct(), options :: [encode_option]) :: iodata()
+            when encode_option: {:iolist, boolean()}
 
   @doc """
   Decodes a Protobuf binary into a struct.
@@ -144,9 +159,12 @@ defmodule Protobuf do
   @doc """
   Encodes the given Protobuf struct into a binary.
 
-  It's preferrable to use the message's `c:encode/1` function. For a message `MyMessage`:
+  It's preferrable to use the message's `c:encode/1` or `c:encode/2` functions. For a message
+  `MyMessage`:
 
       MyMessage.encode(MyMessage.new())
+
+  See `c:encode/2` for the supported options.
 
   ## Examples
 
@@ -156,7 +174,9 @@ defmodule Protobuf do
 
   """
   @spec encode(struct()) :: binary()
-  defdelegate encode(struct), to: Protobuf.Encoder
+  def encode(%_{} = struct, options \\ []) when is_list(options) do
+    Protobuf.Encoder.encode(struct, options)
+  end
 
   @doc """
   Loads extensions modules.

--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -7,8 +7,12 @@ defmodule Protobuf.Encoder do
   alias Protobuf.{FieldProps, MessageProps, Wire, Wire.Varint}
 
   @spec encode(struct(), keyword()) :: iodata()
-  def encode(%mod{} = struct, opts \\ []) when is_list(opts) do
-    iolist? = Keyword.get(opts, :iolist, false)
+  def encode(%mod{} = struct, opts) when is_list(opts) do
+    iolist? =
+      case Keyword.get(opts, :iolist, false) do
+        value when is_boolean(value) -> value
+        other -> raise ArgumentError, "expected bool for :iolist option, got: #{inspect(other)}"
+      end
 
     case encode_with_message_props(struct, mod.__message_props__()) do
       result when iolist? -> result

--- a/lib/protobuf/protoc/cli.ex
+++ b/lib/protobuf/protoc/cli.ex
@@ -59,9 +59,9 @@ defmodule Protobuf.Protoc.CLI do
         Protobuf.Protoc.Generator.generate(ctx, desc)
       end)
 
-    response = Google.Protobuf.Compiler.CodeGeneratorResponse.new(file: files)
-
-    IO.binwrite(Protobuf.Encoder.encode(response))
+    Google.Protobuf.Compiler.CodeGeneratorResponse.new(file: files)
+    |> Protobuf.encode(iolist: true)
+    |> IO.binwrite()
   end
 
   def main(_args) do

--- a/test/pbt/encode_decode_type_test.exs
+++ b/test/pbt/encode_decode_type_test.exs
@@ -8,7 +8,7 @@ defmodule Protobuf.EncodeDecodeTypeTest.PropertyGenerator do
   def encode(type, val) do
     [{type, val}]
     |> TestMsg.Scalars.new!()
-    |> Protobuf.Encoder.encode(iolist: false)
+    |> Protobuf.encode(iolist: false)
   end
 
   defmacro make_properties(gen_func, field_type) do

--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -4,45 +4,45 @@ defmodule Protobuf.EncoderTest do
   alias Protobuf.Encoder
 
   test "encodes one simple field" do
-    bin = Encoder.encode(TestMsg.Foo.new(a: 42))
+    bin = Encoder.encode(TestMsg.Foo.new(a: 42), [])
     assert bin == <<8, 42>>
   end
 
   test "encodes full fields" do
     bin = <<8, 42, 17, 100, 0, 0, 0, 0, 0, 0, 0, 26, 3, 115, 116, 114, 45, 0, 0, 247, 66>>
-    res = Encoder.encode(TestMsg.Foo.new(a: 42, b: 100, c: "str", d: 123.5))
+    res = Encoder.encode(TestMsg.Foo.new(a: 42, b: 100, c: "str", d: 123.5), [])
     assert res == bin
   end
 
   test "skips a field with default value" do
     bin = <<8, 42, 26, 3, 115, 116, 114, 45, 0, 0, 247, 66>>
-    res = Encoder.encode(TestMsg.Foo.new(a: 42, c: "str", d: 123.5))
+    res = Encoder.encode(TestMsg.Foo.new(a: 42, c: "str", d: 123.5), [])
     assert res == bin
   end
 
   test "skips a field without default value" do
     bin = <<8, 42, 17, 100, 0, 0, 0, 0, 0, 0, 0, 45, 0, 0, 247, 66>>
-    res = Encoder.encode(TestMsg.Foo.new(a: 42, b: 100, d: 123.5))
+    res = Encoder.encode(TestMsg.Foo.new(a: 42, b: 100, d: 123.5), [])
     assert res == bin
   end
 
   test "encodes embedded message" do
-    bin = Encoder.encode(TestMsg.Foo.new(a: 42, e: %TestMsg.Foo.Bar{a: 12, b: "abc"}, f: 13))
+    bin = Encoder.encode(TestMsg.Foo.new(a: 42, e: %TestMsg.Foo.Bar{a: 12, b: "abc"}, f: 13), [])
     assert bin == <<8, 42, 50, 7, 8, 12, 18, 3, 97, 98, 99, 56, 13>>
   end
 
   test "encodes empty embedded message" do
-    bin = Encoder.encode(TestMsg.Foo.new(a: 42, e: TestMsg.Foo.Bar.new()))
+    bin = Encoder.encode(TestMsg.Foo.new(a: 42, e: TestMsg.Foo.Bar.new()), [])
     assert bin == <<8, 42, 50, 0>>
   end
 
   test "encodes repeated non-packed varint fields" do
-    bin = Encoder.encode(TestMsg.Foo.new(a: 123, g: [12, 13, 14]))
+    bin = Encoder.encode(TestMsg.Foo.new(a: 123, g: [12, 13, 14]), [])
     assert bin == <<8, 123, 64, 12, 64, 13, 64, 14>>
   end
 
   test "encodes repeated varint fields with all 0" do
-    bin = Encoder.encode(TestMsg.Foo.new(g: [0, 0, 0]))
+    bin = Encoder.encode(TestMsg.Foo.new(g: [0, 0, 0]), [])
     assert bin == <<64, 0, 64, 0, 64, 0>>
   end
 
@@ -51,111 +51,115 @@ defmodule Protobuf.EncoderTest do
 
     res =
       Encoder.encode(
-        TestMsg.Foo.new(h: [%TestMsg.Foo.Bar{a: 12, b: "abc"}, TestMsg.Foo.Bar.new(a: 13)])
+        TestMsg.Foo.new(h: [%TestMsg.Foo.Bar{a: 12, b: "abc"}, TestMsg.Foo.Bar.new(a: 13)]),
+        []
       )
 
     assert res == bin
   end
 
   test "encodes repeated embedded fields with all empty struct" do
-    bin = Encoder.encode(TestMsg.Foo.new(h: [TestMsg.Foo.Bar.new(), TestMsg.Foo.Bar.new()]))
+    bin = Encoder.encode(TestMsg.Foo.new(h: [TestMsg.Foo.Bar.new(), TestMsg.Foo.Bar.new()]), [])
     assert bin == <<74, 0, 74, 0>>
   end
 
   test "encodes packed fields" do
-    bin = Encoder.encode(TestMsg.Foo.new(i: [12, 13, 14]))
+    bin = Encoder.encode(TestMsg.Foo.new(i: [12, 13, 14]), [])
     assert bin == <<82, 3, 12, 13, 14>>
   end
 
   test "encodes packed fields with all 0" do
-    bin = Encoder.encode(TestMsg.Foo.new(i: [0, 0, 0]))
+    bin = Encoder.encode(TestMsg.Foo.new(i: [0, 0, 0]), [])
     assert bin == <<82, 3, 0, 0, 0>>
   end
 
   test "encodes enum type" do
-    bin = Encoder.encode(TestMsg.Foo.new(j: 2))
+    bin = Encoder.encode(TestMsg.Foo.new(j: 2), [])
     assert bin == <<88, 2>>
-    bin = Encoder.encode(TestMsg.Foo.new(j: :A))
+    bin = Encoder.encode(TestMsg.Foo.new(j: :A), [])
     assert bin == <<88, 1>>
-    bin = Encoder.encode(TestMsg.Foo.new(j: :B))
+    bin = Encoder.encode(TestMsg.Foo.new(j: :B), [])
     assert bin == <<88, 2>>
   end
 
   test "encodes repeated enum fields using packed by default" do
-    bin = Encoder.encode(TestMsg.Foo.new(o: [:A, :B]))
+    bin = Encoder.encode(TestMsg.Foo.new(o: [:A, :B]), [])
     assert bin == <<130, 1, 2, 1, 2>>
   end
 
   test "encodes unknown enum type" do
-    bin = Encoder.encode(TestMsg.Foo.new(j: 3))
+    bin = Encoder.encode(TestMsg.Foo.new(j: 3), [])
     assert bin == <<88, 3>>
   end
 
   test "encodes 0" do
-    assert Encoder.encode(TestMsg.Foo.new(a: 0)) == <<>>
+    assert Encoder.encode(TestMsg.Foo.new(a: 0), []) == <<>>
   end
 
   test "encodes empty string" do
-    assert Encoder.encode(TestMsg.Foo.new(c: "")) == <<>>
+    assert Encoder.encode(TestMsg.Foo.new(c: ""), []) == <<>>
   end
 
   test "encodes bool" do
-    assert Encoder.encode(TestMsg.Foo.new(k: false)) == <<>>
-    assert Encoder.encode(TestMsg.Foo.new(k: true)) == <<96, 1>>
+    assert Encoder.encode(TestMsg.Foo.new(k: false), []) == <<>>
+    assert Encoder.encode(TestMsg.Foo.new(k: true), []) == <<96, 1>>
   end
 
   test "encode map type" do
     bin = <<106, 12, 10, 7, 102, 111, 111, 95, 107, 101, 121, 16, 213, 1>>
     struct = TestMsg.Foo.new(l: %{"foo_key" => 213})
-    assert Encoder.encode(struct) == bin
+    assert Encoder.encode(struct, []) == bin
   end
 
   test "encodes 0 for proto2" do
-    assert Encoder.encode(TestMsg.Foo2.new(a: 0)) == <<8, 0>>
+    assert Encoder.encode(TestMsg.Foo2.new(a: 0), []) == <<8, 0>>
   end
 
   test "encodes [] for proto2" do
-    assert Encoder.encode(TestMsg.Foo2.new(a: 0, g: [])) == <<8, 0>>
+    assert Encoder.encode(TestMsg.Foo2.new(a: 0, g: []), []) == <<8, 0>>
   end
 
   test "encodes %{} for proto2" do
-    assert Encoder.encode(TestMsg.Foo2.new(a: 0, l: %{})) == <<8, 0>>
+    assert Encoder.encode(TestMsg.Foo2.new(a: 0, l: %{}), []) == <<8, 0>>
   end
 
   test "encodes custom default message for proto2" do
-    assert Encoder.encode(TestMsg.Foo2.new(a: 0, b: 0)) == <<8, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0>>
+    assert Encoder.encode(TestMsg.Foo2.new(a: 0, b: 0), []) ==
+             <<8, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0>>
   end
 
   test "encodes oneof fields" do
     msg = TestMsg.Oneof.new(%{first: {:a, 42}, second: {:d, "abc"}, other: "other"})
-    assert Encoder.encode(msg) == <<8, 42, 34, 3, 97, 98, 99, 42, 5, 111, 116, 104, 101, 114>>
+    assert Encoder.encode(msg, []) == <<8, 42, 34, 3, 97, 98, 99, 42, 5, 111, 116, 104, 101, 114>>
     msg = TestMsg.Oneof.new(%{first: {:b, "abc"}, second: {:c, 123}, other: "other"})
-    assert Encoder.encode(msg) == <<18, 3, 97, 98, 99, 24, 123, 42, 5, 111, 116, 104, 101, 114>>
+
+    assert Encoder.encode(msg, []) ==
+             <<18, 3, 97, 98, 99, 24, 123, 42, 5, 111, 116, 104, 101, 114>>
   end
 
   test "encodes oneof fields zero values" do
     # proto2
     # int and string
     msg = TestMsg.Oneof.new(first: {:a, 0}, second: {:d, ""})
-    assert Encoder.encode(msg) == <<8, 0, 34, 0>>
+    assert Encoder.encode(msg, []) == <<8, 0, 34, 0>>
     msg = TestMsg.Oneof.new(first: {:b, ""}, second: {:c, 0})
-    assert Encoder.encode(msg) == <<18, 0, 24, 0>>
+    assert Encoder.encode(msg, []) == <<18, 0, 24, 0>>
     # enum
     msg = TestMsg.Oneof.new(first: {:e, :UNKNOWN})
-    assert Encoder.encode(msg) == <<48, 0>>
+    assert Encoder.encode(msg, []) == <<48, 0>>
     assert TestMsg.Oneof.decode(<<48, 0>>) == msg
 
     # proto3
     # int and string
     msg = TestMsg.OneofProto3.new(first: {:a, 0}, second: {:d, ""})
-    assert Encoder.encode(msg) == <<8, 0, 34, 0>>
+    assert Encoder.encode(msg, []) == <<8, 0, 34, 0>>
     assert TestMsg.OneofProto3.encode(msg) == <<8, 0, 34, 0>>
     msg = TestMsg.OneofProto3.new(first: {:b, ""}, second: {:c, 0})
-    assert Encoder.encode(msg) == <<18, 0, 24, 0>>
+    assert Encoder.encode(msg, []) == <<18, 0, 24, 0>>
     assert TestMsg.OneofProto3.encode(msg) == <<18, 0, 24, 0>>
     # enum
     msg = TestMsg.OneofProto3.new(first: {:e, :UNKNOWN})
-    assert Encoder.encode(msg) == <<48, 0>>
+    assert Encoder.encode(msg, []) == <<48, 0>>
     assert TestMsg.OneofProto3.decode(<<48, 0>>) == msg
   end
 
@@ -172,67 +176,67 @@ defmodule Protobuf.EncoderTest do
   test "encodes enum default value for proto2" do
     # Includes required
     msg = TestMsg.EnumBar2.new(a: 0)
-    assert Encoder.encode(msg) == <<8, 0>>
+    assert Encoder.encode(msg, []) == <<8, 0>>
 
     # Missing required field `:a` occurs a runtime error
     msg = TestMsg.EnumBar2.new()
 
     assert_raise Protobuf.EncodeError, ~r/Got error when encoding TestMsg.EnumBar2/, fn ->
-      Encoder.encode(msg)
+      Encoder.encode(msg, [])
     end
 
     msg = TestMsg.EnumFoo2.new()
-    assert Encoder.encode(msg) == <<>>
+    assert Encoder.encode(msg, []) == <<>>
 
     # Explicitly set the enum default value should be encoded, should not return it as ""
     msg = TestMsg.EnumBar2.new(a: 0)
-    assert Encoder.encode(msg) == <<8, 0>>
+    assert Encoder.encode(msg, []) == <<8, 0>>
 
     msg = TestMsg.EnumBar2.new(a: 1)
-    assert Encoder.encode(msg) == <<8, 1>>
+    assert Encoder.encode(msg, []) == <<8, 1>>
 
     msg = TestMsg.EnumBar2.new(a: 0, b: 0)
-    assert Encoder.encode(msg) == <<8, 0, 16, 0>>
+    assert Encoder.encode(msg, []) == <<8, 0, 16, 0>>
 
     msg = TestMsg.EnumBar2.new(a: 0, b: 1)
-    assert Encoder.encode(msg) == <<8, 0, 16, 1>>
+    assert Encoder.encode(msg, []) == <<8, 0, 16, 1>>
 
     msg = TestMsg.EnumFoo2.new(a: 0)
-    assert Encoder.encode(msg) == <<8, 0>>
+    assert Encoder.encode(msg, []) == <<8, 0>>
 
     msg = TestMsg.EnumFoo2.new(a: 1)
-    assert Encoder.encode(msg) == <<8, 1>>
+    assert Encoder.encode(msg, []) == <<8, 1>>
 
     msg = TestMsg.EnumFoo2.new(b: 0)
-    assert Encoder.encode(msg) == <<16, 0>>
+    assert Encoder.encode(msg, []) == <<16, 0>>
 
     msg = TestMsg.EnumFoo2.new(a: 0, b: 1)
-    assert Encoder.encode(msg) == <<8, 0, 16, 1>>
+    assert Encoder.encode(msg, []) == <<8, 0, 16, 1>>
 
     # Proto2 enums that are not zero-based default to their first value declared.
     msg = My.Test.Request.new(deadline: nil)
-    assert Encoder.encode(msg) == <<>>
+    assert Encoder.encode(msg, []) == <<>>
 
     msg = My.Test.Request.new(deadline: nil, hat: 1)
-    assert Encoder.encode(msg) == <<32, 1>>
+    assert Encoder.encode(msg, []) == <<32, 1>>
 
     msg = My.Test.Request.new(deadline: nil, hat: :FEDORA)
-    assert Encoder.encode(msg) == <<>>
+    assert Encoder.encode(msg, []) == <<>>
   end
 
   test "encodes with transformer module" do
     msg = %TestMsg.ContainsTransformModule{field: 0}
-    assert Encoder.encode(msg) == <<10, 0>>
-    assert TestMsg.ContainsTransformModule.decode(Encoder.encode(msg)) == msg
+    assert Encoder.encode(msg, []) == <<10, 0>>
+    assert TestMsg.ContainsTransformModule.decode(Encoder.encode(msg, [])) == msg
 
     msg = %TestMsg.ContainsTransformModule{field: 42}
-    assert Encoder.encode(msg) == <<10, 2, 8, 42>>
-    assert TestMsg.ContainsTransformModule.decode(Encoder.encode(msg)) == msg
+    assert Encoder.encode(msg, []) == <<10, 2, 8, 42>>
+    assert TestMsg.ContainsTransformModule.decode(Encoder.encode(msg, [])) == msg
   end
 
   test "encoding skips transformer module when field is not set" do
     msg = %TestMsg.ContainsTransformModule{field: nil}
-    assert Encoder.encode(msg) == <<>>
-    assert TestMsg.ContainsTransformModule.decode(Encoder.encode(msg)) == msg
+    assert Encoder.encode(msg, []) == <<>>
+    assert TestMsg.ContainsTransformModule.decode(Encoder.encode(msg, [])) == msg
   end
 end

--- a/test/protobuf/encoder_validation_test.exs
+++ b/test/protobuf/encoder_validation_test.exs
@@ -82,7 +82,7 @@ defmodule Protobuf.EncoderTest.Validation do
     msg = TestMsg.Foo.new(a: "abc")
 
     assert_raise Protobuf.EncodeError, ~r/TestMsg.Foo#a.*Protobuf.TypeEncodeError/, fn ->
-      Protobuf.Encoder.encode(msg)
+      Protobuf.Encoder.encode(msg, [])
     end
   end
 
@@ -90,21 +90,21 @@ defmodule Protobuf.EncoderTest.Validation do
     msg = TestMsg.Foo2.new(a: nil)
 
     assert_raise Protobuf.EncodeError, ~r/TestMsg.Foo2#a.*Protobuf.TypeEncodeError/, fn ->
-      Protobuf.Encoder.encode(msg)
+      Protobuf.Encoder.encode(msg, [])
     end
   end
 
   test "proto2 valid optional field is nil" do
     msg = TestMsg.Foo2.new(a: 1, c: nil)
 
-    assert Protobuf.Encoder.encode(msg)
+    assert Protobuf.Encoder.encode(msg, [])
   end
 
   test "oneof invalid format" do
     msg = TestMsg.Oneof.new(first: 1)
 
     assert_raise Protobuf.EncodeError, ~r/TestMsg.Oneof#first should be {key, val}/, fn ->
-      Protobuf.Encoder.encode(msg)
+      Protobuf.Encoder.encode(msg, [])
     end
   end
 
@@ -112,7 +112,7 @@ defmodule Protobuf.EncoderTest.Validation do
     msg = TestMsg.Oneof.new(first: {:c, 42})
 
     assert_raise Protobuf.EncodeError, ~r/:c doesn't belong to TestMsg.Oneof#first/, fn ->
-      Protobuf.Encoder.encode(msg)
+      Protobuf.Encoder.encode(msg, [])
     end
   end
 
@@ -120,7 +120,7 @@ defmodule Protobuf.EncoderTest.Validation do
     msg = TestMsg.Oneof.new(first: {:a, "abc"})
 
     assert_raise Protobuf.EncodeError, ~r/TestMsg.Oneof#a.*Protobuf.TypeEncodeError/, fn ->
-      Protobuf.Encoder.encode(msg)
+      Protobuf.Encoder.encode(msg, [])
     end
   end
 
@@ -128,14 +128,14 @@ defmodule Protobuf.EncoderTest.Validation do
     msg = TestMsg.Foo.new(g: 1)
 
     assert_raise Protobuf.EncodeError, ~r/TestMsg.Foo#g.*Protocol.UndefinedError/, fn ->
-      Protobuf.Encoder.encode(msg)
+      Protobuf.Encoder.encode(msg, [])
     end
 
     msg = TestMsg.Foo.new()
     msg = %{msg | h: TestMsg.Foo.Bar.new()}
 
     assert_raise Protobuf.EncodeError, ~r/TestMsg.Foo#h.*Protocol.UndefinedError/, fn ->
-      Protobuf.Encoder.encode(msg)
+      Protobuf.Encoder.encode(msg, [])
     end
   end
 
@@ -144,6 +144,6 @@ defmodule Protobuf.EncoderTest.Validation do
     msg = %{msg | e: %{a: 1}}
     msg1 = TestMsg.Foo.new(e: %{a: 1})
 
-    assert Protobuf.Encoder.encode(msg) == Protobuf.Encoder.encode(msg1)
+    assert Protobuf.Encoder.encode(msg, []) == Protobuf.Encoder.encode(msg1, [])
   end
 end

--- a/test/protobuf/protobuf_test.exs
+++ b/test/protobuf/protobuf_test.exs
@@ -14,6 +14,19 @@ defmodule Protobuf.ProtobufTest do
     end
   end
 
+  describe "encode/2" do
+    test "encodes a struct as iodata with iolist: true" do
+      iodata = Protobuf.encode(TestMsg.Foo.new(a: 42), iolist: true)
+      assert IO.iodata_to_binary(iodata) == <<8, 42>>
+    end
+
+    test "raises an ArgumentError if the :iolist option is invalid" do
+      assert_raise ArgumentError, ~r/expected bool/, fn ->
+        Protobuf.encode(TestMsg.Foo.new(), iolist: :not_a_boolean)
+      end
+    end
+  end
+
   describe "decode/2" do
     test "decodes a struct" do
       struct = Protobuf.decode(<<8, 42>>, TestMsg.Foo)


### PR DESCRIPTION
These two new functions support options. Options were already supported
by `Protobuf.Encoder.encode/2`, but they were not public API.

For now, the only supported option is `:iolist`.

Closes #221.