### PR TITLE
Don't log warning when decoding unknown enums

### DIFF
--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -167,6 +167,9 @@ defmodule Protobuf.DSL do
       end) ++
       [
         quote do
+          def key(int) when is_integer(int), do: int
+        end,
+        quote do
           def mapping(), do: unquote(Macro.escape(atom_to_num))
         end,
         quote do

--- a/test/protobuf/decoder_test.exs
+++ b/test/protobuf/decoder_test.exs
@@ -105,10 +105,8 @@ defmodule Protobuf.DecoderTest do
   end
 
   test "decodes unknown enum value" do
-    assert ExUnit.CaptureLog.capture_log(fn ->
-             struct = Decoder.decode(<<88, 3>>, TestMsg.Foo)
-             assert struct == TestMsg.Foo.new(j: 3)
-           end) =~ ~r/unknown enum value 3 when decoding for TestMsg\.EnumFoo/
+    struct = Decoder.decode(<<88, 3>>, TestMsg.Foo)
+    assert struct == TestMsg.Foo.new(j: 3)
   end
 
   test "decodes map type" do

--- a/test/protobuf/dsl_test.exs
+++ b/test/protobuf/dsl_test.exs
@@ -156,7 +156,7 @@ defmodule Protobuf.DSLTest do
     assert TestMsg.EnumFoo.key(1) == :A
     assert TestMsg.EnumFoo.key(2) == :B
     assert TestMsg.EnumFoo.key(4) == :C
-    assert_raise FunctionClauseError, fn -> TestMsg.EnumFoo.key(5) end
+    assert TestMsg.EnumFoo.key(213_123) == 213_123
     assert TestMsg.EnumFoo.mapping() == %{UNKNOWN: 0, A: 1, B: 2, C: 4, D: 4, E: 4}
 
     assert TestMsg.EnumFoo.__reverse_mapping__() == %{

--- a/test/protobuf/wire_test.exs
+++ b/test/protobuf/wire_test.exs
@@ -301,10 +301,7 @@ defmodule Protobuf.WireTest do
 
     test "enum known and unknown integer" do
       assert :A == Wire.decode({:enum, TestMsg.EnumFoo}, 1)
-
-      assert ExUnit.CaptureLog.capture_log(fn ->
-               assert 5 == Wire.decode({:enum, TestMsg.EnumFoo}, 5)
-             end) =~ ~r/unknown enum value 5 when decoding for TestMsg\.EnumFoo/
+      assert 5 == Wire.decode({:enum, TestMsg.EnumFoo}, 5)
     end
 
     test "enum wraps to an int32" do


### PR DESCRIPTION
Right now, the library warns if we decode an enum for which we don't know the **atom value**. That is, if you have an enum like this:

```protobuf
enum Status {
  LOGGED_IN = 0;
  LOGGED_OUT = 1;
}
```

and you decode it with a version of the schemas that don't have the `LOGGED_OUT = 1` definition, then the library is going to return `1` as the enum value. This is the correct thing to do to ensure backwards and forwards compatibility.

However, warning for this case is problematic. In many cases, applications want to handle these unknown enums *by design* and do their own thing or ignore the warning. Additionally, this is a 100% functional library so adding a "stateful" component (the logging) feels inappropriate.

When decoding enums, your business logic should always plan for unknown enums anyways, for backwards and forwards compatibility.

```elixir
case my_message.some_enum do
  :SOME_VALUE -> ...
  :SOME_OTHER_VALUE -> ...
  unknown -> ...
end
```

Since you need to handle this anyways, you might as well warn yourself if you are not equipped to handle unknown enums.