### PR TITLE
Don't skip storing the value of a oneof field even if it's the default value

### DIFF
--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -75,7 +75,7 @@ defmodule Protobuf.Encoder do
   defp skip_field?(_syntax, [], _prop), do: true
   defp skip_field?(_syntax, val, _prop) when is_map(val), do: map_size(val) == 0
   defp skip_field?(:proto2, nil, %FieldProps{optional?: optional?}), do: optional?
-  defp skip_field?(:proto2, value, %FieldProps{default: value}), do: true
+  defp skip_field?(:proto2, value, %FieldProps{default: value, oneof: nil}), do: true
   defp skip_field?(:proto3, nil, _prop), do: true
   defp skip_field?(:proto3, 0, %FieldProps{oneof: nil}), do: true
   defp skip_field?(:proto3, 0.0, %FieldProps{oneof: nil}), do: true

--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -222,6 +222,12 @@ defmodule Protobuf.EncoderTest do
     assert Encoder.encode(msg) == <<>>
   end
 
+  test "encodes oneof fields' default values for proto2" do
+    msg = TestMsg.Oneof.new(first: {:e, :A})
+    assert Encoder.encode(msg) == <<48, 1>>
+    assert TestMsg.Oneof.decode(<<48, 1>>) == msg
+  end
+
   test "encodes unknown fields" do
     msg = %TestMsg.Foo{
       __unknown_fields__: [

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -103,7 +103,7 @@ defmodule TestMsg do
     field :b, 2, optional: true, type: :string, oneof: 0
     field :c, 3, optional: true, type: :int32, oneof: 1
     field :d, 4, optional: true, type: :string, oneof: 1
-    field :e, 6, optional: true, type: EnumFoo, enum: true, oneof: 0
+    field :e, 6, optional: true, type: EnumFoo, enum: true, default: :A, oneof: 0
     field :other, 5, optional: true, type: :string
   end
 


### PR DESCRIPTION
Resolves #239.