### PR TITLE
Fix compilation warning for Elixir 1.9.4

### DIFF
--- a/lib/protobuf/wire/varint.ex
+++ b/lib/protobuf/wire/varint.ex
@@ -138,7 +138,7 @@ defmodule Protobuf.Wire.Varint do
           x6::7, 1::1, x7::7, 1::1, x8::7, 0::1, x9::7>>
       end,
       quote(generated: true) do
-        band(
+        v =
           x0 +
             bsl(x1, 7) +
             bsl(x2, 14) +
@@ -148,9 +148,9 @@ defmodule Protobuf.Wire.Varint do
             bsl(x6, 42) +
             bsl(x7, 49) +
             bsl(x8, 56) +
-            bsl(x9, 63),
-          unquote(@mask64)
-        )
+            bsl(x9, 63)
+
+        _ = band(v, unquote(@mask64))
       end
     }
   ]


### PR DESCRIPTION
Compilation fails with 1.9.4 using the `--warnings-as-errors` with the
warning that "the result of the expression is ignored". This commit
simply assigns the result to `_` to suppress the warning.

Note: This warning doesn't appear in your CI but it does show on [this page](https://github.com/elixir-protobuf/protobuf/commit/fe11c65da7f8316faa01c4f4336557a8708b7a6e#diff-572680e4c3bdfcb24caac848aefec9c3065cdaa9d43c60d9dd343eb57d2cc4dd). It blocked our fork, hence the fix, but maybe you've already worked around it somehow?