### PR TITLE
Update Decoder - handle unknown wire_type

### DIFF
--- a/lib/protobuf/decoder.ex
+++ b/lib/protobuf/decoder.ex
@@ -115,6 +115,18 @@ defmodule Protobuf.Decoder do
       wire_64bits() ->
         <<_skip::bits-64, rest::bits>> = rest
         skip_field(rest, message, props, groups)
+
+      wire_type ->
+        message =
+          case props.field_props do
+            %{^field_number => %FieldProps{wire_type: expected, name: field}} ->
+              "field #{field}: got #{wire_type}, expected #{expected}"
+
+            _ ->
+              "field_number #{field_number}: got #{wire_type}"
+          end
+
+        raise DecodeError, message: "invalid wire_type for skipped " <> message
     end
   end
 

--- a/test/protobuf/decoder_test.exs
+++ b/test/protobuf/decoder_test.exs
@@ -255,5 +255,18 @@ defmodule Protobuf.DecoderTest do
         Decoder.decode(<<19>>, TestMsg.Foo)
       end
     end
+
+    test "raises when group contains unknown wire type" do
+      # field number 2, wire type 3
+      group_start = <<19>>
+      # field number 1, wire type 7, value 42
+      field = <<15, 42>>
+
+      bin = group_start <> field
+
+      assert_raise Protobuf.DecodeError,
+                   ~r{invalid wire_type for skipped field a: got 7, expected 0},
+                   fn -> Decoder.decode(bin, TestMsg.Foo) end
+    end
   end
 end

--- a/test/protobuf/decoder_test.exs
+++ b/test/protobuf/decoder_test.exs
@@ -265,7 +265,7 @@ defmodule Protobuf.DecoderTest do
       bin = group_start <> field
 
       assert_raise Protobuf.DecodeError,
-                   ~r{invalid wire_type for skipped field a: got 7, expected 0},
+                   "invalid wire_type for skipped field a: got 7, expected 0",
                    fn -> Decoder.decode(bin, TestMsg.Foo) end
     end
   end


### PR DESCRIPTION
Previously when an unknown wire_type was encountered a `CaseClauseError`
exception would be raised. This commit updates the decoder so that a
`Protobuf.DecodeError` with a slightly helpful error message is raised.