### PR TITLE
Fix FunctionClauseError in in Protobuf.Protoc.CLI.parse_params/2

### DIFF
--- a/lib/protobuf/protoc/cli.ex
+++ b/lib/protobuf/protoc/cli.ex
@@ -48,7 +48,7 @@ defmodule Protobuf.Protoc.CLI do
 
     ctx =
       %Context{}
-      |> parse_params(request.parameter || "")
+      |> parse_params(request.parameter)
       |> find_types(request.proto_file)
 
     files =
@@ -68,6 +68,8 @@ defmodule Protobuf.Protoc.CLI do
 
   # Made public for testing.
   @doc false
+  def parse_params(%Context{} = ctx, nil), do: ctx
+
   def parse_params(%Context{} = ctx, params_str) when is_binary(params_str) do
     params_str
     |> String.split(",")

--- a/test/protobuf/protoc/cli_test.exs
+++ b/test/protobuf/protoc/cli_test.exs
@@ -79,6 +79,12 @@ defmodule Protobuf.Protoc.CLITest do
         parse_params(%Context{}, "package_prefix=,gen_descriptors=true")
       end
     end
+
+    test "won't raise when there are no arguments" do
+      assert parse_params(%Context{}, "") == %Context{}
+
+      assert parse_params(%Context{}, nil) == %Context{}
+    end
   end
 
   describe "find_types/2" do


### PR DESCRIPTION
I started to get this error after I upgraded the protobuf lib and tried to generate the proto files passing no arguments.

I'm using Elixir 1.11.2 and Erlang/OTP 23.

```elixir
** (FunctionClauseError) no function clause matching in Protobuf.Protoc.CLI.parse_params/2

    The following arguments were given to Protobuf.Protoc.CLI.parse_params/2:

        # 1
        %Protobuf.Protoc.Context{custom_file_options: %{}, dep_type_mapping: %{}, gen_descriptors?: false, global_type_mapping: %{}, module_prefix: nil, namespace: [], one_file_per_module?: false, package: nil, package_prefix: nil, plugins: [], syntax: nil, transform_module: nil}

        # 2
        nil

    (protobuf 0.9.0) lib/protobuf/protoc/cli.ex:73: Protobuf.Protoc.CLI.parse_params/2
    (protobuf 0.9.0) lib/protobuf/protoc/cli.ex:51: Protobuf.Protoc.CLI.main/1
    (elixir 1.11.2) lib/kernel/cli.ex:124: anonymous fn/3 in Kernel.CLI.exec_fun/2
--elixir_out: protoc-gen-elixir: Plugin failed with status code 1.
```