### PR TITLE
Fix Dialyzer Errors

### DIFF
--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -56,7 +56,45 @@ defmodule Protobuf.DSL do
     defines_defstruct? = Module.defines?(env.module, {:__struct__, 1})
 
     quote do
-      @spec __message_props__() :: Protobuf.MessageProps.t()
+      alias Protobuf.MessageProps
+      alias Protobuf.FieldProps
+
+      @typep field_props :: %FieldProps{
+               fnum: integer,
+               name: String.t(),
+               name_atom: atom,
+               json_name: String.t(),
+               wire_type: 0..5,
+               type: atom | tuple,
+               default: any,
+               oneof: non_neg_integer | nil,
+               required?: boolean,
+               optional?: boolean,
+               repeated?: boolean,
+               enum?: boolean,
+               embedded?: boolean,
+               packed?: boolean,
+               map?: boolean,
+               deprecated?: boolean,
+               encoded_fnum: iodata
+             }
+
+      @spec __message_props__() :: %MessageProps{
+              ordered_tags: [MessageProps.tag()],
+              tags_map: %{MessageProps.tag() => MessageProps.tag()},
+              field_props: %{MessageProps.tag() => field_props()},
+              field_tags: %{MessageProps.field_name() => MessageProps.tag()},
+              repeated_fields: [MessageProps.field_name()],
+              embedded_fields: [MessageProps.field_name()],
+              syntax: atom(),
+              oneof: [{MessageProps.field_name(), MessageProps.tag()}],
+              enum?: boolean(),
+              extendable?: boolean(),
+              map?: boolean(),
+              extension_range: [{non_neg_integer(), non_neg_integer()}] | nil
+            }
+
+      # @spec __message_props__() :: Protobuf.MessageProps.t()
       def __message_props__ do
         unquote(Macro.escape(msg_props))
       end

--- a/lib/protobuf/field_props.ex
+++ b/lib/protobuf/field_props.ex
@@ -7,7 +7,7 @@ defmodule Protobuf.FieldProps do
           name_atom: atom,
           json_name: String.t(),
           wire_type: 0..5,
-          type: atom,
+          type: atom | tuple,
           default: any,
           oneof: non_neg_integer | nil,
           required?: boolean,

--- a/lib/protobuf/message_props.ex
+++ b/lib/protobuf/message_props.ex
@@ -19,7 +19,7 @@ defmodule Protobuf.MessageProps do
           enum?: boolean(),
           extendable?: boolean(),
           map?: boolean(),
-          extension_range: [{non_neg_integer(), non_neg_integer()}]
+          extension_range: [{non_neg_integer(), non_neg_integer()}] | nil
         }
 
   defstruct ordered_tags: [],


### PR DESCRIPTION
I'm not suggesting we merge this, however I was forced to do this to get 
our library to compile, so I figured a PR would be best to show.

Using:

```
$ elixir -v
Erlang/OTP 24 [erts-12.0.3] [source] [64-bit] [smp:8:8] [ds:8:8:10] [async-threads:1] [jit]
Elixir 1.12.2 (compiled with Erlang/OTP 24)
```

With the latest version from github: 3d793cbe5889893d552faa2d47292741c0a6afd9

In order to pass `mix dialyzer` this commit defines the typespec for
`__message_props__/0` within the body of the quote block, along with any
dependent types. Any attempt to use the remote types defined in the
other modules results in a `does not match the success typing` error.
It's not clear why this is happening, but maybe related to
the fact we're inside a "before_compile" macro.

The following typespec changes were also required to achieve a pass:

- MessageProps.extension_range could be nil
- FieldProps.type could be a tuple

An example of the type of error from dialyzer:

```
lib/volta/schema/device.pb.ex:479:invalid_contract
The @spec for the function does not match the success typing of the function.

Function:
DeviceService.Volta.Protobuf.Schema.UnlockRsp.__message_props__/0

Success typing:
@spec __message_props__() :: %Protobuf.MessageProps{
  :embedded_fields => [],
  :enum? => false,
  :extendable? => false,
  :extension_range => nil,
  :field_props => %{
    1 => %Protobuf.FieldProps{
      :default => nil,
      :deprecated? => false,
      :embedded? => false,
      :encoded_fnum => <<_::8>>,
      :enum? => true,
      :fnum => 1,
      :json_name => <<_::48>>,
      :map? => false,
      :name => <<_::48>>,
      :name_atom => :result,
      :oneof => nil,
      :optional? => false,
      :packed? => false,
      :repeated? => false,
      :required? => true,
      :type => {_, _},
      :wire_type => 0
    }
  },
  :field_tags => %{:result => 1},
  :map? => false,
  :oneof => [],
  :ordered_tags => [1, ...],
  :repeated_fields => [],
  :syntax => :proto2,
  :tags_map => %{1 => 1}
}

```

With the changes in this PR, I'm able to run `mix dialyzer` and it passes!

I wonder if you have any ideas?


