### PR TITLE
Update Protobuf.MessageProps

### DIFF
--- a/lib/protobuf/message_props.ex
+++ b/lib/protobuf/message_props.ex
@@ -19,7 +19,7 @@ defmodule Protobuf.MessageProps do
           enum?: boolean(),
           extendable?: boolean(),
           map?: boolean(),
-          extension_range: [{non_neg_integer(), non_neg_integer()}]
+          extension_range: [{non_neg_integer(), non_neg_integer()}] | nil
         }
 
   defstruct ordered_tags: [],


### PR DESCRIPTION
This commit changes the typespec for MessageProps.extension_range to
allow nil value, which Dialyzer claims exists in the success typing.

This can be demonstrated by updating the DSL:

```
$ git d
diff --git a/lib/protobuf/dsl.ex b/lib/protobuf/dsl.ex
index 859bba1..4976ede 100644
--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -44,7 +44,7 @@ defmodule Protobuf.DSL do
     fields = Module.get_attribute(env.module, :fields)
     options = Module.get_attribute(env.module, :options)
     oneofs = Module.get_attribute(env.module, :oneofs)
-    extensions = Module.get_attribute(env.module, :extensions)
+    extensions = Module.get_attribute(env.module, :extensions) |> IO.inspect(label: "extensions")
 
     extension_props =
       Module.get_attribute(env.module, :extends)
```

And compiling:

```
$ mix compile
Compiling 35 files (.ex)
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: [{1000, 536870912}]
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: [{1000, 536870912}]
extensions: [{1000, 536870912}]
extensions: [{1000, 536870912}]
extensions: [{1000, 536870912}]
extensions: [{1000, 536870912}]
extensions: [{1000, 536870912}]
extensions: [{1000, 536870912}]
extensions: [{1000, 536870912}]
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
extensions: nil
Generated protobuf app
```