### PR TITLE
Force prod env for escript.build task

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -18,7 +18,8 @@ defmodule Protobuf.Mixfile do
       preferred_cli_env: [
         coveralls: :test,
         "coveralls.html": :test,
-        conformance_test: :test
+        conformance_test: :test,
+        "escript.build": :prod
       ],
       deps: deps(),
       escript: escript(),


### PR DESCRIPTION
When building protoc-gen-elixir plugin, we don't want to include
test/dev dependencies (stream_data, etc)