### PR TITLE
Fix failing tests due to formatting

### DIFF
--- a/test/protobuf/dsl/typespecs_test.exs
+++ b/test/protobuf/dsl/typespecs_test.exs
@@ -5,7 +5,14 @@ defmodule Protobuf.DSL.TypespecsTest do
   alias Protobuf.{FieldProps, MessageProps}
   alias Protobuf.DSL.Typespecs
 
-  @unknown_fields_spec "__unknown_fields__: [{field_number :: integer(), Protobuf.Wire.Types.wire_type(), value :: term()}]"
+  @unknown_fields_spec quote(
+                         do: [
+                           __unknown_fields__: [
+                             {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
+                              value :: term()}
+                           ]
+                         ]
+                       )
 
   describe "quoted_enum_typespec/1" do
     test "returns integer() | ..." do
@@ -34,9 +41,14 @@ defmodule Protobuf.DSL.TypespecsTest do
           |> Map.new(fn {name, index} -> {index, %FieldProps{name_atom: name}} end)
 
         message_props = %MessageProps{field_props: field_props}
-        expected = "integer() | #{Enum.map_join(field_names, " | ", &inspect/1)}"
 
-        assert message_props |> Typespecs.quoted_enum_typespec() |> Macro.to_string() == expected
+        expected =
+          [quote(do: integer()) | field_names]
+          |> Enum.reverse()
+          |> Enum.reduce(&{:|, [], [&1, &2]})
+
+        assert message_props |> Typespecs.quoted_enum_typespec() |> Macro.to_string() ==
+                 Macro.to_string(expected)
       end
     end
   end
@@ -45,7 +57,9 @@ defmodule Protobuf.DSL.TypespecsTest do
     test "with an empty message" do
       message_props = %MessageProps{field_props: %{}, oneof: []}
       quoted = Typespecs.quoted_message_typespec(message_props)
-      assert Macro.to_string(quoted) == "%__MODULE__{#{@unknown_fields_spec}}"
+
+      assert Macro.to_string(quoted) ==
+               Macro.to_string(quote(do: %__MODULE__{unquote_splicing(@unknown_fields_spec)}))
     end
 
     test "with a field" do
@@ -55,7 +69,10 @@ defmodule Protobuf.DSL.TypespecsTest do
       }
 
       quoted = Typespecs.quoted_message_typespec(message_props)
-      assert Macro.to_string(quoted) == "%__MODULE__{foo: integer(), #{@unknown_fields_spec}}"
+      fields = quote(do: [foo: integer()]) ++ @unknown_fields_spec
+
+      assert Macro.to_string(quoted) ==
+               Macro.to_string(quote(do: %__MODULE__{unquote_splicing(fields)}))
     end
 
     test "with a oneof field" do
@@ -69,39 +86,43 @@ defmodule Protobuf.DSL.TypespecsTest do
 
       quoted = Typespecs.quoted_message_typespec(message_props)
 
+      fields =
+        quote(do: [my_oneof_field: {:foo, integer()} | {:bar, boolean()}]) ++ @unknown_fields_spec
+
       assert Macro.to_string(quoted) ==
-               "%__MODULE__{my_oneof_field: {:foo, integer()} | {:bar, boolean()}, #{@unknown_fields_spec}}"
+               Macro.to_string(quote(do: %__MODULE__{unquote_splicing(fields)}))
     end
 
     test "with fields of scalar types" do
       mappings = [
-        {:string, "String.t()"},
-        {:bytes, "binary()"},
-        {:bool, "boolean()"},
-        {:int32, "integer()"},
-        {:int64, "integer()"},
-        {:sint32, "integer()"},
-        {:sint64, "integer()"},
-        {:sfixed32, "integer()"},
-        {:sfixed64, "integer()"},
-        {:uint32, "non_neg_integer()"},
-        {:uint64, "non_neg_integer()"},
-        {:fixed32, "non_neg_integer()"},
-        {:fixed64, "non_neg_integer()"},
-        {:float, "float() | :infinity | :negative_infinity | :nan"},
-        {:double, "float() | :infinity | :negative_infinity | :nan"}
+        {:string, quote(do: String.t())},
+        {:bytes, quote(do: binary())},
+        {:bool, quote(do: boolean())},
+        {:int32, quote(do: integer())},
+        {:int64, quote(do: integer())},
+        {:sint32, quote(do: integer())},
+        {:sint64, quote(do: integer())},
+        {:sfixed32, quote(do: integer())},
+        {:sfixed64, quote(do: integer())},
+        {:uint32, quote(do: non_neg_integer())},
+        {:uint64, quote(do: non_neg_integer())},
+        {:fixed32, quote(do: non_neg_integer())},
+        {:fixed64, quote(do: non_neg_integer())},
+        {:float, quote(do: float() | :infinity | :negative_infinity | :nan)},
+        {:double, quote(do: float() | :infinity | :negative_infinity | :nan)}
       ]
 
-      for {proto_type, string_spec} <- mappings do
+      for {proto_type, quoted_spec} <- mappings do
         message_props = %MessageProps{
           field_props: %{1 => %FieldProps{name_atom: :foo, type: proto_type}},
           oneof: []
         }
 
         quoted = Typespecs.quoted_message_typespec(message_props)
+        fields = quote(do: [foo: unquote(quoted_spec)]) ++ @unknown_fields_spec
 
         assert Macro.to_string(quoted) ==
-                 "%__MODULE__{foo: #{string_spec}, #{@unknown_fields_spec}}"
+                 Macro.to_string(quote(do: %__MODULE__{unquote_splicing(fields)}))
       end
     end
 
@@ -112,8 +133,10 @@ defmodule Protobuf.DSL.TypespecsTest do
       }
 
       quoted = Typespecs.quoted_message_typespec(message_props)
+      fields = quote(do: [foo: Foo.t()]) ++ @unknown_fields_spec
 
-      assert Macro.to_string(quoted) == "%__MODULE__{foo: Foo.t(), #{@unknown_fields_spec}}"
+      assert Macro.to_string(quoted) ==
+               Macro.to_string(quote(do: %__MODULE__{unquote_splicing(fields)}))
     end
 
     test "with a group field" do
@@ -123,8 +146,10 @@ defmodule Protobuf.DSL.TypespecsTest do
       }
 
       quoted = Typespecs.quoted_message_typespec(message_props)
+      fields = quote(do: [foo: term()]) ++ @unknown_fields_spec
 
-      assert Macro.to_string(quoted) == "%__MODULE__{foo: term(), #{@unknown_fields_spec}}"
+      assert Macro.to_string(quoted) ==
+               Macro.to_string(quote(do: %__MODULE__{unquote_splicing(fields)}))
     end
 
     test "with an embedded field" do
@@ -134,9 +159,10 @@ defmodule Protobuf.DSL.TypespecsTest do
       }
 
       quoted = Typespecs.quoted_message_typespec(message_props)
+      fields = quote(do: [foo: EmbeddedFoo.t() | nil]) ++ @unknown_fields_spec
 
       assert Macro.to_string(quoted) ==
-               "%__MODULE__{foo: EmbeddedFoo.t() | nil, #{@unknown_fields_spec}}"
+               Macro.to_string(quote(do: %__MODULE__{unquote_splicing(fields)}))
     end
 
     test "with an optional field" do
@@ -146,9 +172,10 @@ defmodule Protobuf.DSL.TypespecsTest do
       }
 
       quoted = Typespecs.quoted_message_typespec(message_props)
+      fields = quote(do: [foo: integer() | nil]) ++ @unknown_fields_spec
 
       assert Macro.to_string(quoted) ==
-               "%__MODULE__{foo: integer() | nil, #{@unknown_fields_spec}}"
+               Macro.to_string(quote(do: %__MODULE__{unquote_splicing(fields)}))
     end
 
     test "with extensions" do
@@ -159,9 +186,10 @@ defmodule Protobuf.DSL.TypespecsTest do
       }
 
       quoted = Typespecs.quoted_message_typespec(message_props)
+      fields = quote(do: [__pb_extensions__: map()]) ++ @unknown_fields_spec
 
       assert Macro.to_string(quoted) ==
-               "%__MODULE__{__pb_extensions__: map(), #{@unknown_fields_spec}}"
+               Macro.to_string(quote(do: %__MODULE__{unquote_splicing(fields)}))
     end
   end
 

--- a/test/protobuf/protoc/generator/message_test.exs
+++ b/test/protobuf/protoc/generator/message_test.exs
@@ -16,7 +16,17 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     assert [{compiled_mod, bytecode}] = Code.compile_string(msg)
 
     assert TestHelpers.get_type_spec_as_string(compiled_mod, bytecode, :t) ==
-             "t() :: %Foo{__unknown_fields__: [{field_number :: integer(), Protobuf.Wire.Types.wire_type(), value :: term()}]}"
+             Macro.to_string(
+               quote(
+                 do:
+                   t() :: %Foo{
+                     __unknown_fields__: [
+                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
+                        value :: term()}
+                     ]
+                   }
+               )
+             )
   after
     TestHelpers.purge_modules([Foo])
   end
@@ -33,7 +43,17 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     assert [{compiled_mod, bytecode}] = Code.compile_string(msg)
 
     assert TestHelpers.get_type_spec_as_string(compiled_mod, bytecode, :t) ==
-             "t() :: %Foo{__unknown_fields__: [{field_number :: integer(), Protobuf.Wire.Types.wire_type(), value :: term()}]}"
+             Macro.to_string(
+               quote(
+                 do:
+                   t() :: %Foo{
+                     __unknown_fields__: [
+                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
+                        value :: term()}
+                     ]
+                   }
+               )
+             )
   after
     TestHelpers.purge_modules([Foo])
   end
@@ -156,7 +176,20 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     assert [{compiled_mod, bytecode}] = Code.compile_string(msg)
 
     assert TestHelpers.get_type_spec_as_string(compiled_mod, bytecode, :t) ==
-             "t() :: %Foo{__unknown_fields__: [{field_number :: integer(), Protobuf.Wire.Types.wire_type(), value :: term()}], a: integer(), b: String.t(), c: [integer()]}"
+             Macro.to_string(
+               quote(
+                 do:
+                   t() :: %Foo{
+                     __unknown_fields__: [
+                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
+                        value :: term()}
+                     ],
+                     a: integer(),
+                     b: String.t(),
+                     c: [integer()]
+                   }
+               )
+             )
 
     assert msg =~ "field :a, 1, type: :int32\n"
     assert msg =~ "field :b, 2, type: :string\n"
@@ -321,7 +354,19 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     assert [{compiled_mod, bytecode}] = Code.compile_string(msg)
 
     assert TestHelpers.get_type_spec_as_string(compiled_mod, bytecode, :t) ==
-             "t() :: %Foo{__unknown_fields__: [{field_number :: integer(), Protobuf.Wire.Types.wire_type(), value :: term()}], bar: Bar.t() | nil, baz: [Baz.t()]}"
+             Macro.to_string(
+               quote(
+                 do:
+                   t() :: %Foo{
+                     __unknown_fields__: [
+                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
+                        value :: term()}
+                     ],
+                     bar: Bar.t() | nil,
+                     baz: [Baz.t()]
+                   }
+               )
+             )
   after
     TestHelpers.purge_modules([Foo])
   end
@@ -382,7 +427,18 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     assert [{compiled_mod, bytecode}] = Code.compile_string(msg)
 
     assert TestHelpers.get_type_spec_as_string(compiled_mod, bytecode, :t) ==
-             "t() :: %FooBar.AbCd.Foo{__unknown_fields__: [{field_number :: integer(), Protobuf.Wire.Types.wire_type(), value :: term()}], a: %{optional(integer()) => FooBar.AbCd.Bar.t() | nil}}"
+             Macro.to_string(
+               quote(
+                 do:
+                   t() :: %FooBar.AbCd.Foo{
+                     __unknown_fields__: [
+                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
+                        value :: term()}
+                     ],
+                     a: %{optional(integer()) => FooBar.AbCd.Bar.t() | nil}
+                   }
+               )
+             )
   after
     TestHelpers.purge_modules([FooBar.AbCd.Foo])
   end
@@ -466,7 +522,18 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     assert [{compiled_mod, bytecode}] = Code.compile_string(msg)
 
     assert TestHelpers.get_type_spec_as_string(compiled_mod, bytecode, :t) ==
-             "t() :: %FooBar.AbCd.Foo{__unknown_fields__: [{field_number :: integer(), Protobuf.Wire.Types.wire_type(), value :: term()}], a: OtherPkg.MsgFoo.t() | nil}"
+             Macro.to_string(
+               quote(
+                 do:
+                   t() :: %FooBar.AbCd.Foo{
+                     __unknown_fields__: [
+                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
+                        value :: term()}
+                     ],
+                     a: OtherPkg.MsgFoo.t() | nil
+                   }
+               )
+             )
   after
     TestHelpers.purge_modules([FooBar.AbCd.Foo])
   end
@@ -520,7 +587,18 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     assert [{compiled_mod, bytecode}] = Code.compile_string(main_msg)
 
     assert TestHelpers.get_type_spec_as_string(compiled_mod, bytecode, :t) ==
-             "t() :: %MyPkg.Foo{__unknown_fields__: [{field_number :: integer(), Protobuf.Wire.Types.wire_type(), value :: term()}], a: MyPkg.Foo.Nested.t() | nil}"
+             Macro.to_string(
+               quote(
+                 do:
+                   t() :: %MyPkg.Foo{
+                     __unknown_fields__: [
+                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
+                        value :: term()}
+                     ],
+                     a: MyPkg.Foo.Nested.t() | nil
+                   }
+               )
+             )
   after
     TestHelpers.purge_modules([MyPkg.Foo])
   end
@@ -615,7 +693,20 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     assert [{compiled_mod, bytecode}] = Code.compile_string(msg)
 
     assert TestHelpers.get_type_spec_as_string(compiled_mod, bytecode, :t) ==
-             "t() :: %Foo{__unknown_fields__: [{field_number :: integer(), Protobuf.Wire.Types.wire_type(), value :: term()}], first: {:a, integer()} | {:b, integer()}, other: integer() | nil, second: {:c, integer()} | {:d, integer()}}"
+             Macro.to_string(
+               quote(
+                 do:
+                   t() :: %Foo{
+                     __unknown_fields__: [
+                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
+                        value :: term()}
+                     ],
+                     first: {:a, integer()} | {:b, integer()},
+                     other: integer() | nil,
+                     second: {:c, integer()} | {:d, integer()}
+                   }
+               )
+             )
 
     refute msg =~ "a: integer,\n"
 
@@ -712,7 +803,18 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     assert [{compiled_mod, bytecode}] = Code.compile_string(msg)
 
     assert TestHelpers.get_type_spec_as_string(compiled_mod, bytecode, :t) ==
-             "t() :: %FooBar.AbCd.Foo{__unknown_fields__: [{field_number :: integer(), Protobuf.Wire.Types.wire_type(), value :: term()}], a: [FooBar.AbCd.EnumFoo.t()]}"
+             Macro.to_string(
+               quote(
+                 do:
+                   t() :: %FooBar.AbCd.Foo{
+                     __unknown_fields__: [
+                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
+                        value :: term()}
+                     ],
+                     a: [FooBar.AbCd.EnumFoo.t()]
+                   }
+               )
+             )
   after
     TestHelpers.purge_modules([FooBar.AbCd.Foo])
   end


### PR DESCRIPTION
By calling `Macro.to_string/1` on both sides of the assertion the tests will pass regardless if different Elixir versions format differently.