### PR TITLE
fix(encoding): Ensure transform_module is called for struct passed into `Protobuf.Encoder.encode/2`

### DIFF
--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -14,6 +14,7 @@ defmodule Protobuf.Encoder do
   @spec encode(struct()) :: binary()
   def encode(%mod{} = struct) do
     struct
+    |> transform_module(mod)
     |> encode_with_message_props(mod.__message_props__())
     |> IO.iodata_to_binary()
   end

--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -254,6 +254,17 @@ defmodule Protobuf.EncoderTest do
     assert TestMsg.ContainsTransformModule.decode(Encoder.encode(msg)) == msg
   end
 
+  test "encodes with transformer module when encoding struct contains a transformer module" do
+    msg = TestMsg.ContainsIntegerStringTransformModule.new(field: "42")
+    assert msg == %TestMsg.ContainsIntegerStringTransformModule{field: "42"}
+
+    encoded = TestMsg.ContainsIntegerStringTransformModule.encode(msg)
+    assert encoded == "\b*"
+
+    assert %TestMsg.ContainsIntegerStringTransformModule{field: 42} ==
+             TestMsg.ContainsIntegerStringTransformModule.decode(encoded)
+  end
+
   test "encoding skips transformer module when field is not set" do
     msg = %TestMsg.ContainsTransformModule{field: nil}
     assert Encoder.encode(msg) == <<>>

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -273,6 +273,32 @@ defmodule TestMsg do
     end
   end
 
+  defmodule ContainsIntegerStringTransformModule do
+    use Protobuf, syntax: :proto3
+
+    field :field, 1, type: :int32
+
+    def transform_module(), do: TestMsg.TransformIntegerStrings
+  end
+
+  defmodule TransformIntegerStrings do
+    @behaviour Protobuf.TransformModule
+
+    @impl true
+    def encode(
+          %ContainsIntegerStringTransformModule{field: str},
+          ContainsIntegerStringTransformModule
+        )
+        when is_binary(str) do
+      %ContainsIntegerStringTransformModule{field: String.to_integer(str)}
+    end
+
+    @impl true
+    def decode(%ContainsIntegerStringTransformModule{} = value, _) do
+      value
+    end
+  end
+
   defmodule Ext.EnumFoo do
     @moduledoc false
     use Protobuf, enum: true, syntax: :proto2


### PR DESCRIPTION
Right now, `Protobuf.Encoder.encode/1` only attempts to invoke a custom `TransformModule` behaviour for nested structs in its recursive encoding iterations. If the struct passed into `encode/1` itself has a custom transformer, it is ignored.

This PR ensures that `encode/1` calls a custom transformer on the struct passed into the function, as well as its nested children. The approach I took mimics existing logic in `Protobuf.Decoder.decode/2` ([ref](https://github.com/elixir-protobuf/protobuf/blob/b84b9978c7e7007166d2b7ad7feb7b1ca780e556/lib/protobuf/decoder.ex#L20)).