### PR TITLE
Improve code format generator

### DIFF
--- a/lib/protobuf/protoc/generator.ex
+++ b/lib/protobuf/protoc/generator.ex
@@ -29,6 +29,7 @@ defmodule Protobuf.Protoc.Generator do
         module_definitions
         |> Enum.map(fn {_mod_name, contents} -> [contents, ?\n] end)
         |> IO.iodata_to_binary()
+        |> Generator.Util.format()
 
       [
         Google.Protobuf.Compiler.CodeGeneratorResponse.File.new(


### PR DESCRIPTION
Consider this proto file:

    // helloworld.proto
    syntax = "proto3";

    package helloworld;

    // The greeting service definition.
    service Greeter {
      // Sends a greeting
      rpc SayHello (HelloRequest) returns (HelloReply) {}
      rpc CheckHeaders (HeaderRequest) returns (HeaderReply) {}
    }

    // The request message containing the user's name.
    message HelloRequest {
      string name = 1;
    }

    // The response message containing the greetings
    message HelloReply {
      string message = 1;
    }

    message HeaderRequest {
    }

    message HeaderReply {
      string authorization = 1;
    }

When running with current release protoc-gen-elixir (0.10.0). Code will
output as:

    defmodule Helloworld.HelloRequest do
      @moduledoc false
      use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3

      field :name, 1, type: :string
    end
    defmodule Helloworld.HelloReply do
      @moduledoc false
      use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3

      field :message, 1, type: :string
    end
    defmodule Helloworld.HeaderRequest do
      @moduledoc false
      use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
    end
    defmodule Helloworld.HeaderReply do
      @moduledoc false
      use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3

      field :authorization, 1, type: :string
    end
    defmodule Helloworld.Greeter.Service do
      @moduledoc false
      use GRPC.Service, name: "helloworld.Greeter", protoc_gen_elixir_version: "0.10.0"

      rpc :SayHello, Helloworld.HelloRequest, Helloworld.HelloReply

      rpc :CheckHeaders, Helloworld.HeaderRequest, Helloworld.HeaderReply
    end

    defmodule Helloworld.Greeter.Stub do
      @moduledoc false
      use GRPC.Stub, service: Helloworld.Greeter.Service
    end

In this changes improve by adding more \n between message modules. So
the new code will be:

    defmodule Helloworld.HelloRequest do
      @moduledoc false
      use Protobuf, protoc_gen_elixir_version: "0.10.1-dev", syntax: :proto3

      field :name, 1, type: :string
    end

    defmodule Helloworld.HelloReply do
      @moduledoc false
      use Protobuf, protoc_gen_elixir_version: "0.10.1-dev", syntax: :proto3

      field :message, 1, type: :string
    end

    defmodule Helloworld.HeaderRequest do
      @moduledoc false
      use Protobuf, protoc_gen_elixir_version: "0.10.1-dev", syntax: :proto3
    end

    defmodule Helloworld.HeaderReply do
      @moduledoc false
      use Protobuf, protoc_gen_elixir_version: "0.10.1-dev", syntax: :proto3

      field :authorization, 1, type: :string
    end

    defmodule Helloworld.Greeter.Service do
      @moduledoc false
      use GRPC.Service, name: "helloworld.Greeter", protoc_gen_elixir_version: "0.10.1-dev"

      rpc :SayHello, Helloworld.HelloRequest, Helloworld.HelloReply

      rpc :CheckHeaders, Helloworld.HeaderRequest, Helloworld.HeaderReply
    end

    defmodule Helloworld.Greeter.Stub do
      @moduledoc false
      use GRPC.Stub, service: Helloworld.Greeter.Service
    end