### PR TITLE
Add optional keys to Builder typespecs

### DIFF
--- a/lib/protobuf/builder.ex
+++ b/lib/protobuf/builder.ex
@@ -3,17 +3,20 @@ defmodule Protobuf.Builder do
 
   alias Protobuf.FieldProps
 
-  @spec new(module) :: %{required(:__struct__) => module} when module: module()
+  @spec new(module) :: %{required(:__struct__) => module, optional(atom()) => any()}
+        when module: module()
   def new(mod) when is_atom(mod) do
     struct(mod)
   end
 
-  @spec new(module, Enum.t()) :: %{required(:__struct__) => module} when module: module()
+  @spec new(module, Enum.t()) :: %{required(:__struct__) => module, optional(atom()) => any()}
+        when module: module()
   def new(mod, attrs) when is_atom(mod) do
     new_maybe_strict(mod, attrs, _strict? = false)
   end
 
-  @spec new!(module, Enum.t()) :: %{required(:__struct__) => module} when module: module()
+  @spec new!(module, Enum.t()) :: %{required(:__struct__) => module, optional(atom()) => any()}
+        when module: module()
   def new!(mod, attrs) when is_atom(mod) do
     new_maybe_strict(mod, attrs, _strict? = true)
   end


### PR DESCRIPTION
Related issue: https://github.com/elixir-protobuf/protobuf/issues/287

The previous typespecs weren't allowing types like:

```
  @spec not_fine :: Timestamp.t()
  def not_fine do
    Timestamp.new(seconds: 232_342, nanos: 232_342)
  end
```

Because the `Builder.new` typespecs were requiring a map with only the `:__struct__` key.