### PR TITLE
Enable PROTOBUF_ROOT env variable

### DIFF
--- a/.github/workflows/latest_conformance.yml
+++ b/.github/workflows/latest_conformance.yml
@@ -72,11 +72,12 @@ jobs:
           elixir-version: ${{ matrix.elixir }}
 
       - name: Get and compile dependencies
-        run: mix deps.get && mix deps.compile
+        run: mix do deps.get, deps.compile
 
       - name: Compile project
         run: mix compile
 
       - name: Run mix protobuf.conformance with the runner from Protobuf's main branch
-        run: |
-          mix conformance_test --runner=./protobuf/conformance/conformance-test-runner --verbose
+        run: mix conformance_test --verbose
+        env:
+          PROTOBUF_ROOT: ./protobuf


### PR DESCRIPTION
The issue here was that we are compiling from `.proto` files in the `deps/google_protobuf` directory, which is fixed to v3.17 of Protobuf right now (for reproducibility). However, the "latest conformance" CI job uses the latest `main` from Protobuf for the conformance tests, but not for the `.proto` source files. This means that some tests were failing because they expected the latest `.proto` source files.

This PR introduces `PROTOBUF_ROOT` so that we can use the conformance runner and `.proto` files from the same directory.