### PR TITLE
Add nicer oneof error messages

### DIFF
--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -208,7 +208,8 @@ defmodule Protobuf.Encoder do
 
               nil ->
                 raise Protobuf.EncodeError,
-                  message: "#{inspect(field_name)} wasn't found in #{inspect(struct.__struct__)}##{field}"
+                  message:
+                    "#{inspect(field_name)} wasn't found in #{inspect(struct.__struct__)}##{field}"
             end
 
           if oneof != index do

--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -201,7 +201,13 @@ defmodule Protobuf.Encoder do
     Enum.reduce(oneof, %{}, fn {field, index}, acc ->
       case Map.fetch(struct, field) do
         {:ok, {field_name, value}} when is_atom(field_name) ->
-          %FieldProps{oneof: oneof} = field_props[field_tags[field_name]]
+          oneof = case field_props[field_tags[field_name]] do
+            %FieldProps{oneof: oneof} -> oneof
+            nil ->
+              raise Protobuf.EncodeError,
+                message:
+                  "#{inspect(field_name)} wasn't found in #{inspect(struct.__struct__)}"
+            end
 
           if oneof != index do
             raise Protobuf.EncodeError,

--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -208,7 +208,7 @@ defmodule Protobuf.Encoder do
 
               nil ->
                 raise Protobuf.EncodeError,
-                  message: "#{inspect(field_name)} wasn't found in #{inspect(struct.__struct__)}"
+                  message: "#{inspect(field_name)} wasn't found in #{inspect(struct.__struct__)}##{field}"
             end
 
           if oneof != index do

--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -201,12 +201,14 @@ defmodule Protobuf.Encoder do
     Enum.reduce(oneof, %{}, fn {field, index}, acc ->
       case Map.fetch(struct, field) do
         {:ok, {field_name, value}} when is_atom(field_name) ->
-          oneof = case field_props[field_tags[field_name]] do
-            %FieldProps{oneof: oneof} -> oneof
-            nil ->
-              raise Protobuf.EncodeError,
-                message:
-                  "#{inspect(field_name)} wasn't found in #{inspect(struct.__struct__)}"
+          oneof =
+            case field_props[field_tags[field_name]] do
+              %FieldProps{oneof: oneof} ->
+                oneof
+
+              nil ->
+                raise Protobuf.EncodeError,
+                  message: "#{inspect(field_name)} wasn't found in #{inspect(struct.__struct__)}"
             end
 
           if oneof != index do

--- a/test/protobuf/encoder_validation_test.exs
+++ b/test/protobuf/encoder_validation_test.exs
@@ -124,6 +124,14 @@ defmodule Protobuf.EncoderTest.Validation do
     end
   end
 
+  test "oneof field is non-existent" do
+    msg = TestMsg.OneofProto3.new(first: {:x, "foo"})
+
+    assert_raise Protobuf.EncodeError, ~r/:x wasn't found in TestMsg.OneofProto3#first/, fn ->
+      Protobuf.Encoder.encode(msg)
+    end
+  end
+
   test "repeated field is not list" do
     msg = TestMsg.Foo.new(g: 1)
 


### PR DESCRIPTION
When using `oneof`'s in client stubs, an user can specify a non-existing field. 
For example:
Imagine we have this proto :
```proto
message LoginRequest {
        reserved 420, 69;
        string username = 1;
        oneof credential {
            string password = 2;
            string googleOauthCode = 3;
            string magicLinkToken = 4;
       }
}
```
And the user writes this code : 
```elixir
req = Service.LoginRequest.new(username: "foo", credential: {:undefined_credential, "stuff"}) #oops
```
If he tries to encode this message, he'll be met with an unfriendly error message : `(MatchError) no match of right hand side value: nil`.

This PR implements a more friendly error message in these cases.