### PR TITLE
Fix the enum default value

### DIFF
--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -414,7 +414,9 @@ defmodule Protobuf.DSL do
   defp type_default(:sint32), do: 0
   defp type_default(:sint64), do: 0
   defp type_default(:bool), do: false
-  defp type_default({:enum, mod}), do: Code.ensure_compiled!(mod) && mod.key(0)
+  defp type_default({:enum, mod}) do
+    if {:module, mod} == Code.ensure_compiled(mod), do: mod.key(0)
+  end
   defp type_default(:fixed32), do: 0
   defp type_default(:sfixed32), do: 0
   defp type_default(:fixed64), do: 0

--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -414,7 +414,7 @@ defmodule Protobuf.DSL do
   defp type_default(:sint32), do: 0
   defp type_default(:sint64), do: 0
   defp type_default(:bool), do: false
-  defp type_default({:enum, mod}), do: Code.ensure_loaded?(mod) && mod.key(0)
+  defp type_default({:enum, mod}), do: Code.ensure_compiled!(mod) && mod.key(0)
   defp type_default(:fixed32), do: 0
   defp type_default(:sfixed32), do: 0
   defp type_default(:fixed64), do: 0

--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -414,9 +414,11 @@ defmodule Protobuf.DSL do
   defp type_default(:sint32), do: 0
   defp type_default(:sint64), do: 0
   defp type_default(:bool), do: false
+
   defp type_default({:enum, mod}) do
     if {:module, mod} == Code.ensure_compiled(mod), do: mod.key(0)
   end
+
   defp type_default(:fixed32), do: 0
   defp type_default(:sfixed32), do: 0
   defp type_default(:fixed64), do: 0


### PR DESCRIPTION
Sometimes when compiling a proto the line `Code.ensure_loaded?(mod)` returns false, causing the default value for that value to be false (obvs causes the serialization to crash)