### PR TITLE
Fix decoding of proto3 optional zero/default values

### DIFF
--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -77,6 +77,10 @@ defmodule Protobuf.Encoder do
   defp skip_field?(_syntax, val, _prop) when is_map(val), do: map_size(val) == 0
   defp skip_field?(:proto2, nil, %FieldProps{optional?: optional?}), do: optional?
   defp skip_field?(:proto2, value, %FieldProps{default: value, oneof: nil}), do: true
+
+  defp skip_field?(:proto3, val, %FieldProps{proto3_optional?: true}),
+    do: is_nil(val)
+
   defp skip_field?(:proto3, nil, _prop), do: true
   defp skip_field?(:proto3, 0, %FieldProps{oneof: nil}), do: true
   defp skip_field?(:proto3, 0.0, %FieldProps{oneof: nil}), do: true
@@ -176,6 +180,7 @@ defmodule Protobuf.Encoder do
   defp apply_or_map(val, _repeated? = false, func), do: func.(val)
 
   defp skip_enum?(:proto2, _value, _prop), do: false
+  defp skip_enum?(:proto3, _value, %FieldProps{proto3_optional?: true}), do: false
   defp skip_enum?(_syntax, _value, %FieldProps{enum?: false}), do: false
 
   defp skip_enum?(_syntax, _value, %FieldProps{enum?: true, oneof: oneof}) when not is_nil(oneof),

--- a/test/protobuf/decoder_test.exs
+++ b/test/protobuf/decoder_test.exs
@@ -145,7 +145,12 @@ defmodule Protobuf.DecoderTest do
 
   test "decodes nil for proto3" do
     assert Decoder.decode(<<18, 1, 65>>, TestMsg.Proto3Optional) ==
-             TestMsg.Proto3Optional.new(a: nil, b: "A")
+             TestMsg.Proto3Optional.new(a: nil, b: "A", c: nil)
+  end
+
+  test "decodes default values for proto3 optional" do
+    assert Decoder.decode(<<8, 0, 18, 1, 65, 24, 0>>, TestMsg.Proto3Optional) ==
+             TestMsg.Proto3Optional.new(a: 0, b: "A", c: :UNKNOWN)
   end
 
   test "decodes unpacked binary with SignedInt32Repeated for proto2" do

--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -161,6 +161,16 @@ defmodule Protobuf.EncoderTest do
     assert TestMsg.OneofProto3.decode(<<48, 0>>) == msg
   end
 
+  test "encodes proto3 optional fields zero values" do
+    msg = TestMsg.Proto3Optional.new(a: 0, c: :UNKNOWN)
+    assert Encoder.encode(msg) == <<8, 0, 24, 0>>
+  end
+
+  test "skips a proto3 optional field with a nil value" do
+    msg = TestMsg.Proto3Optional.new(a: nil, c: nil)
+    assert Encoder.encode(msg) == <<>>
+  end
+
   test "encodes map with oneof" do
     msg = Google.Protobuf.Struct.new(fields: %{"valid" => %{kind: {:bool_value, true}}})
     bin = Google.Protobuf.Struct.encode(msg)

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -127,6 +127,7 @@ defmodule TestMsg do
 
     field :a, 1, proto3_optional: true, type: :int32
     field :b, 2, type: :string
+    field :c, 3, proto3_optional: true, type: EnumFoo, enum: true
   end
 
   defmodule Parent do


### PR DESCRIPTION
Currently with proto3 optional values, a zero/default value is skipped. This means that `decode(encode(msg))` is not identity for all messages with proto3 optional fields.

This PR ensures that only nil values for proto3_optional fields are skipped.