### PR TITLE
Add support for any

### DIFF
--- a/lib/protobuf/any.ex
+++ b/lib/protobuf/any.ex
@@ -1,0 +1,37 @@
+defmodule Protobuf.Any do
+  @type_url_prefix "type.googleapis.com/"
+
+  def pack(%mod{} = data) do
+    Google.Protobuf.Any.new(%{
+      type_url: "#{@type_url_prefix}#{mod.full_name()}",
+      value: mod.encode(data)
+    })
+  end
+
+  def unpack(
+        %{__struct__: Google.Protobuf.Any, type_url: @type_url_prefix <> name, value: value},
+        options \\ []
+      ) do
+    prefix = Keyword.get(options, :prefix, nil)
+
+    parts =
+      name
+      |> String.split(".")
+      |> Enum.map(fn x ->
+        if String.match?(x, ~r/A-Z/) do
+          x
+        else
+          Macro.camelize(x)
+        end
+      end)
+
+    mod =
+      if prefix do
+        Module.concat([prefix] ++ parts)
+      else
+        Module.concat(parts)
+      end
+
+    mod.decode(value)
+  end
+end

--- a/lib/protobuf/protoc/generator/enum.ex
+++ b/lib/protobuf/protoc/generator/enum.ex
@@ -18,6 +18,11 @@ defmodule Protobuf.Protoc.Generator.Enum do
   def generate(%Context{namespace: ns} = ctx, %Google.Protobuf.EnumDescriptorProto{} = desc) do
     msg_name = Util.mod_name(ctx, ns ++ [Macro.camelize(desc.name)])
 
+    full_name =
+      [ctx.package | ns ++ [Macro.camelize(desc.name)]]
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(".")
+
     use_options =
       Util.options_to_str(%{
         syntax: ctx.syntax,
@@ -35,6 +40,8 @@ defmodule Protobuf.Protoc.Generator.Enum do
     content =
       enum_template(
         module: msg_name,
+        package: ctx.package,
+        full_name: full_name,
         use_options: use_options,
         fields: desc.value,
         descriptor_fun_body: descriptor_fun_body,

--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -31,6 +31,7 @@ defmodule Protobuf.Protoc.Generator.Message do
     msg_name = Util.mod_name(ctx, new_ns)
     fields = get_fields(ctx, desc)
     extensions = get_extensions(desc)
+    full_name = [ctx.package | new_ns] |> Enum.reject(&is_nil/1) |> Enum.join(".")
 
     descriptor_fun_body =
       if ctx.gen_descriptors? do
@@ -47,6 +48,8 @@ defmodule Protobuf.Protoc.Generator.Message do
        Util.format(
          message_template(
            module: msg_name,
+           package: ctx.package,
+           full_name: full_name,
            use_options: msg_opts_str(ctx, desc.options),
            oneofs: desc.oneof_decl,
            fields: gen_fields(ctx.syntax, fields),

--- a/lib/protobuf/protoc/generator/service.ex
+++ b/lib/protobuf/protoc/generator/service.ex
@@ -33,6 +33,7 @@ defmodule Protobuf.Protoc.Generator.Service do
        service_template(
          module: mod_name,
          service_name: name,
+         package: ctx.package,
          methods: methods,
          descriptor_fun_body: descriptor_fun_body,
          version: Util.version(),

--- a/priv/templates/enum.ex.eex
+++ b/priv/templates/enum.ex.eex
@@ -4,6 +4,9 @@ defmodule <%= @module %> do
   <% end %>
   use Protobuf, <%= @use_options %>
 
+  def package, do: "<%= @package %>"
+  def full_name, do: "<%= @full_name %>"
+
   <%= if @descriptor_fun_body do %>
   def descriptor do
     # credo:disable-for-next-line

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -4,6 +4,9 @@ defmodule <%= @module %> do
   <% end %>
   use Protobuf<%= @use_options %>
 
+  def package, do: "<%= @package %>"
+  def full_name, do: "<%= @full_name %>"
+
   <%= if @descriptor_fun_body do %>
   def descriptor do
     # credo:disable-for-next-line

--- a/priv/templates/service.ex.eex
+++ b/priv/templates/service.ex.eex
@@ -4,6 +4,9 @@ defmodule <%= @module %>.Service do
   <% end %>
   use GRPC.Service, name: <%= inspect(@service_name) %>, protoc_gen_elixir_version: "<%= @version %>"
 
+  def package, do: "<%= @package %>"
+  def full_name, do: "<%= @service_name %>"
+
   <%= if @descriptor_fun_body do %>
   def descriptor do
     # credo:disable-for-next-line

--- a/test/protobuf/any_test.exs
+++ b/test/protobuf/any_test.exs
@@ -1,0 +1,40 @@
+defmodule Protobuf.AnyTest do
+  use ExUnit.Case, async: true
+  require Google.Protobuf.Any
+
+  test "packs a message into an Any protobuf" do
+    message = Google.Protobuf.Duration.new(%{seconds: 42})
+    assert %Google.Protobuf.Any{} = result = Protobuf.Any.pack(message)
+    assert result.type_url == "type.googleapis.com/google.protobuf.Duration"
+    assert result.value == Google.Protobuf.Duration.encode(message)
+  end
+
+  test "packs a message into an Any protobuf with a prefix" do
+    message = My.Test.Request.SomeGroup.new(%{group_field: 42})
+    assert %Google.Protobuf.Any{} = result = Protobuf.Any.pack(message)
+    assert result.type_url == "type.googleapis.com/test.Request.SomeGroup"
+    assert result.value == My.Test.Request.SomeGroup.encode(message)
+  end
+
+  test "unpacks a message into an Any protobuf" do
+    message = Google.Protobuf.Duration.new(%{seconds: 42})
+
+    any = %Google.Protobuf.Any{
+      type_url: "type.googleapis.com/google.protobuf.Duration",
+      value: Protobuf.encode(message)
+    }
+
+    assert ^message = Protobuf.Any.unpack(any)
+  end
+
+  test "unpacks a message into an Any protobuf with a prefix" do
+    message = My.Test.Request.SomeGroup.new(%{group_field: 42})
+
+    any = %Google.Protobuf.Any{
+      type_url: "type.googleapis.com/test.Request.SomeGroup",
+      value: Protobuf.encode(message)
+    }
+
+    assert ^message = Protobuf.Any.unpack(any, prefix: My)
+  end
+end


### PR DESCRIPTION
Adds support for packing `google.protobuf.Any` messages. 

Wasn't entirely sure how to handle the prefix module when present and still have it map correctly so added as an option to append a prefix.