### PR TITLE
Fixes typespecs for proto3_optional fields

### DIFF
--- a/lib/protobuf/dsl/typespecs.ex
+++ b/lib/protobuf/dsl/typespecs.ex
@@ -81,7 +81,7 @@ defmodule Protobuf.DSL.Typespecs do
         quote do: [unquote(spec)]
 
       prop.embedded? or (prop.optional? and is_nil(prop.oneof) and syntax != :proto3) or
-          (prop.proto3_optional? and syntax == :proto3) ->
+          prop.proto3_optional? ->
         quote do: unquote(spec) | nil
 
       true ->

--- a/lib/protobuf/dsl/typespecs.ex
+++ b/lib/protobuf/dsl/typespecs.ex
@@ -80,7 +80,8 @@ defmodule Protobuf.DSL.Typespecs do
       prop.repeated? ->
         quote do: [unquote(spec)]
 
-      prop.embedded? or (prop.optional? and is_nil(prop.oneof) and syntax != :proto3) ->
+      prop.embedded? or (prop.optional? and is_nil(prop.oneof) and syntax != :proto3) or
+          (prop.proto3_optional? and syntax == :proto3) ->
         quote do: unquote(spec) | nil
 
       true ->

--- a/test/protobuf/dsl/typespecs_test.exs
+++ b/test/protobuf/dsl/typespecs_test.exs
@@ -178,6 +178,20 @@ defmodule Protobuf.DSL.TypespecsTest do
                Macro.to_string(quote(do: %__MODULE__{unquote_splicing(fields)}))
     end
 
+    test "with a proto3_optional field" do
+      message_props = %MessageProps{
+        field_props: %{1 => %FieldProps{name_atom: :foo, type: :int32, proto3_optional?: true}},
+        syntax: :proto3
+      }
+
+      quoted = Typespecs.quoted_message_typespec(message_props)
+
+      fields = quote(do: [foo: integer() | nil]) ++ @unknown_fields_spec
+
+      assert Macro.to_string(quoted) ==
+               Macro.to_string(quote(do: %__MODULE__{unquote_splicing(fields)}))
+    end
+
     test "with extensions" do
       message_props = %MessageProps{
         field_props: %{},


### PR DESCRIPTION
Hey folks! 🖖 

Typespecs for fields with `proto3_optional` flag are missing `nil` as a possible value. This pull request fixes the issue by including `nil` as a possible typespec value when a field has the `proto3_optional` flag enabled. 

Closes #312.

### Scenario

Consider the proto3 message with an optional field: 

```proto
syntax = "proto3";
// ...
message Person {
  optional int32 identifier = 1;
}
```

Currently, the following type is generated for the above message:

```elixir
@type t :: %Person{
  identifier: integer(), # <-- note it is missing `| nil`, as `identifier` is optional 
  __unknown_fields__: [...]
}
```

After this pull request, typespecs for `optional` fields in proto3 will include `nil` as a possible value:

```elixir
@type t :: %Person{ 
  identifier: integer() | nil, 
  __unknown_fields__: [...]
}
```
