### PR TITLE
Fix map fields contained in .proto files without a package

### DIFF
--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -196,7 +196,11 @@ defmodule Protobuf.Protoc.Generator.Message do
 
   # Map of protobuf are actually nested(one level) messages
   defp nested_maps(ctx, desc) do
-    fully_qualified_name = Enum.join([ctx.package | ctx.namespace] ++ [desc.name], ".")
+    fully_qualified_name =
+      ([ctx.package | ctx.namespace] ++ [desc.name])
+      |> Enum.reject(&is_nil/1)
+      |> Enum.join(".")
+
     prefix = "." <> fully_qualified_name
 
     Enum.reduce(desc.nested_type, %{}, fn desc, acc ->

--- a/mix.exs
+++ b/mix.exs
@@ -177,6 +177,12 @@ defmodule Protobuf.Mixfile do
       "./generated",
       ["test/protobuf/protoc/proto/custom_options.proto"]
     )
+
+    protoc!(
+      "-I test/protobuf/protoc/proto",
+      "./generated",
+      ["test/protobuf/protoc/proto/no_package.proto"]
+    )
   end
 
   defp gen_bench_protos(_args) do

--- a/test/protobuf/protoc/generator_integration_test.exs
+++ b/test/protobuf/protoc/generator_integration_test.exs
@@ -79,4 +79,13 @@ defmodule Protobuf.Protoc.GeneratorIntegrationTest do
                {:ok, "message_with_custom_options"}
     end
   end
+
+  test "maps without packages" do
+    input = NoPackageMessage.new(number_mapping: %{321 => 123, 1337 => 1})
+
+    output = NoPackageMessage.encode(input)
+    assert NoPackageMessage.__message_props__().field_props[1].map?
+    assert NoPackageMessage.NumberMappingEntry.__message_props__().map?
+    assert NoPackageMessage.decode(output) == input
+  end
 end

--- a/test/protobuf/protoc/proto/no_package.proto
+++ b/test/protobuf/protoc/proto/no_package.proto
@@ -1,0 +1,5 @@
+syntax = "proto3";
+
+message NoPackageMessage {
+  map<uint32, uint32> number_mapping = 1;
+}


### PR DESCRIPTION
In `nested_maps/2`, the fully qualified name was built without discarding the nil entries of the list. This meant that map fields worked correctly for .proto files that contained a package, but failed to do so in .proto files that did not, since the map key had then an extra `.` in front that made the lookup in `get_field/4` fail.

This also adds a test case (that was failing with the old version and is now succeeding) to avoid regressions.

Fix #321

Signed-off-by: Riccardo Binetti <rbino@gmx.com>