### PR TITLE
Stop using deprecated ::set-output from GH Actions

### DIFF
--- a/.github/workflows/latest_conformance.yml
+++ b/.github/workflows/latest_conformance.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Get SHA of Protobuf repo's main branch
         id: get-protobuf-sha
         run: |
-          echo ::set-output name=sha::$( curl -u "u:${{github.token}}" https://api.github.com/repos/protocolbuffers/protobuf/git/ref/heads/main | jq .object.sha | tr -d '"' )
+          echo sha="$( curl -u "u:${{github.token}}" https://api.github.com/repos/protocolbuffers/protobuf/git/ref/heads/main | jq .object.sha | tr -d '"' )" >> $GITHUB_OUTPUT
 
       - name: Checkout Protobuf repo
         uses: actions/checkout@v2


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/.