### PR TITLE
Remove pack/1 and unpack/2 from Protobuf.Any

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,8 +1,8 @@
+locals_without_parens = [field: 2, field: 3, oneof: 2, extend: 4, extensions: 1]
+
 [
   inputs: ["{mix,.formatter}.exs", "{config,lib,conformance,test}/**/*.{ex,exs}"],
-  locals_without_parens: [field: 2, field: 3, oneof: 2, extend: 4, extensions: 1],
-  export: [
-    locals_without_parens: [field: 2, field: 3, oneof: 2, extend: 4, extensions: 1]
-  ],
+  locals_without_parens: locals_without_parens,
+  export: [locals_without_parens: locals_without_parens],
   import_deps: [:stream_data]
 ]

--- a/lib/elixirpb.pb.ex
+++ b/lib/elixirpb.pb.ex
@@ -3,8 +3,6 @@ defmodule Elixirpb.FileOptions do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "elixirpb.FileOptions"
-
   field :module_prefix, 1, optional: true, type: :string
 end
 

--- a/lib/google/protobuf/compiler/plugin.pb.ex
+++ b/lib/google/protobuf/compiler/plugin.pb.ex
@@ -3,8 +3,6 @@ defmodule Google.Protobuf.Compiler.CodeGeneratorResponse.Feature do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.compiler.CodeGeneratorResponse.Feature"
-
   field :FEATURE_NONE, 0
   field :FEATURE_PROTO3_OPTIONAL, 1
 end
@@ -13,8 +11,6 @@ defmodule Google.Protobuf.Compiler.Version do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.compiler.Version"
 
   field :major, 1, optional: true, type: :int32
   field :minor, 2, optional: true, type: :int32
@@ -27,8 +23,6 @@ defmodule Google.Protobuf.Compiler.CodeGeneratorRequest do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.compiler.CodeGeneratorRequest"
-
   field :file_to_generate, 1, repeated: true, type: :string
   field :parameter, 2, optional: true, type: :string
   field :proto_file, 15, repeated: true, type: Google.Protobuf.FileDescriptorProto
@@ -40,8 +34,6 @@ defmodule Google.Protobuf.Compiler.CodeGeneratorResponse.File do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.compiler.CodeGeneratorResponse.File"
-
   field :name, 1, optional: true, type: :string
   field :insertion_point, 2, optional: true, type: :string
   field :content, 15, optional: true, type: :string
@@ -52,8 +44,6 @@ defmodule Google.Protobuf.Compiler.CodeGeneratorResponse do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.compiler.CodeGeneratorResponse"
 
   field :error, 1, optional: true, type: :string
   field :supported_features, 2, optional: true, type: :uint64

--- a/lib/google/protobuf/descriptor.pb.ex
+++ b/lib/google/protobuf/descriptor.pb.ex
@@ -3,8 +3,6 @@ defmodule Google.Protobuf.FieldDescriptorProto.Type do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.FieldDescriptorProto.Type"
-
   field :TYPE_DOUBLE, 1
   field :TYPE_FLOAT, 2
   field :TYPE_INT64, 3
@@ -30,8 +28,6 @@ defmodule Google.Protobuf.FieldDescriptorProto.Label do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.FieldDescriptorProto.Label"
-
   field :LABEL_OPTIONAL, 1
   field :LABEL_REQUIRED, 2
   field :LABEL_REPEATED, 3
@@ -41,8 +37,6 @@ defmodule Google.Protobuf.FileOptions.OptimizeMode do
   @moduledoc false
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.FileOptions.OptimizeMode"
 
   field :SPEED, 1
   field :CODE_SIZE, 2
@@ -54,8 +48,6 @@ defmodule Google.Protobuf.FieldOptions.CType do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.FieldOptions.CType"
-
   field :STRING, 0
   field :CORD, 1
   field :STRING_PIECE, 2
@@ -65,8 +57,6 @@ defmodule Google.Protobuf.FieldOptions.JSType do
   @moduledoc false
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.FieldOptions.JSType"
 
   field :JS_NORMAL, 0
   field :JS_STRING, 1
@@ -78,8 +68,6 @@ defmodule Google.Protobuf.MethodOptions.IdempotencyLevel do
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.MethodOptions.IdempotencyLevel"
-
   field :IDEMPOTENCY_UNKNOWN, 0
   field :NO_SIDE_EFFECTS, 1
   field :IDEMPOTENT, 2
@@ -89,8 +77,6 @@ defmodule Google.Protobuf.GeneratedCodeInfo.Annotation.Semantic do
   @moduledoc false
 
   use Protobuf, enum: true, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.GeneratedCodeInfo.Annotation.Semantic"
 
   field :NONE, 0
   field :SET, 1
@@ -102,8 +88,6 @@ defmodule Google.Protobuf.FileDescriptorSet do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.FileDescriptorSet"
-
   field :file, 1, repeated: true, type: Google.Protobuf.FileDescriptorProto
 end
 
@@ -111,8 +95,6 @@ defmodule Google.Protobuf.FileDescriptorProto do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.FileDescriptorProto"
 
   field :name, 1, optional: true, type: :string
   field :package, 2, optional: true, type: :string
@@ -134,8 +116,6 @@ defmodule Google.Protobuf.DescriptorProto.ExtensionRange do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.DescriptorProto.ExtensionRange"
-
   field :start, 1, optional: true, type: :int32
   field :end, 2, optional: true, type: :int32
   field :options, 3, optional: true, type: Google.Protobuf.ExtensionRangeOptions
@@ -146,8 +126,6 @@ defmodule Google.Protobuf.DescriptorProto.ReservedRange do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.DescriptorProto.ReservedRange"
-
   field :start, 1, optional: true, type: :int32
   field :end, 2, optional: true, type: :int32
 end
@@ -156,8 +134,6 @@ defmodule Google.Protobuf.DescriptorProto do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.DescriptorProto"
 
   field :name, 1, optional: true, type: :string
   field :field, 2, repeated: true, type: Google.Protobuf.FieldDescriptorProto
@@ -176,8 +152,6 @@ defmodule Google.Protobuf.ExtensionRangeOptions do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.ExtensionRangeOptions"
-
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
   extensions [{1000, 536_870_912}]
@@ -187,8 +161,6 @@ defmodule Google.Protobuf.FieldDescriptorProto do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.FieldDescriptorProto"
 
   field :name, 1, optional: true, type: :string
   field :number, 3, optional: true, type: :int32
@@ -208,8 +180,6 @@ defmodule Google.Protobuf.OneofDescriptorProto do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.OneofDescriptorProto"
-
   field :name, 1, optional: true, type: :string
   field :options, 2, optional: true, type: Google.Protobuf.OneofOptions
 end
@@ -219,8 +189,6 @@ defmodule Google.Protobuf.EnumDescriptorProto.EnumReservedRange do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.EnumDescriptorProto.EnumReservedRange"
-
   field :start, 1, optional: true, type: :int32
   field :end, 2, optional: true, type: :int32
 end
@@ -229,8 +197,6 @@ defmodule Google.Protobuf.EnumDescriptorProto do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.EnumDescriptorProto"
 
   field :name, 1, optional: true, type: :string
   field :value, 2, repeated: true, type: Google.Protobuf.EnumValueDescriptorProto
@@ -248,8 +214,6 @@ defmodule Google.Protobuf.EnumValueDescriptorProto do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.EnumValueDescriptorProto"
-
   field :name, 1, optional: true, type: :string
   field :number, 2, optional: true, type: :int32
   field :options, 3, optional: true, type: Google.Protobuf.EnumValueOptions
@@ -260,8 +224,6 @@ defmodule Google.Protobuf.ServiceDescriptorProto do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.ServiceDescriptorProto"
-
   field :name, 1, optional: true, type: :string
   field :method, 2, repeated: true, type: Google.Protobuf.MethodDescriptorProto
   field :options, 3, optional: true, type: Google.Protobuf.ServiceOptions
@@ -271,8 +233,6 @@ defmodule Google.Protobuf.MethodDescriptorProto do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.MethodDescriptorProto"
 
   field :name, 1, optional: true, type: :string
   field :input_type, 2, optional: true, type: :string
@@ -286,8 +246,6 @@ defmodule Google.Protobuf.FileOptions do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.FileOptions"
 
   field :java_package, 1, optional: true, type: :string
   field :java_outer_classname, 8, optional: true, type: :string
@@ -325,8 +283,6 @@ defmodule Google.Protobuf.MessageOptions do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.MessageOptions"
-
   field :message_set_wire_format, 1, optional: true, type: :bool, default: false
   field :no_standard_descriptor_accessor, 2, optional: true, type: :bool, default: false
   field :deprecated, 3, optional: true, type: :bool, default: false
@@ -340,8 +296,6 @@ defmodule Google.Protobuf.FieldOptions do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.FieldOptions"
 
   field :ctype, 1,
     optional: true,
@@ -371,8 +325,6 @@ defmodule Google.Protobuf.OneofOptions do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.OneofOptions"
-
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
   extensions [{1000, 536_870_912}]
@@ -382,8 +334,6 @@ defmodule Google.Protobuf.EnumOptions do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.EnumOptions"
 
   field :allow_alias, 2, optional: true, type: :bool
   field :deprecated, 3, optional: true, type: :bool, default: false
@@ -397,8 +347,6 @@ defmodule Google.Protobuf.EnumValueOptions do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.EnumValueOptions"
-
   field :deprecated, 1, optional: true, type: :bool, default: false
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
@@ -410,8 +358,6 @@ defmodule Google.Protobuf.ServiceOptions do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.ServiceOptions"
-
   field :deprecated, 33, optional: true, type: :bool, default: false
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
@@ -422,8 +368,6 @@ defmodule Google.Protobuf.MethodOptions do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.MethodOptions"
 
   field :deprecated, 33, optional: true, type: :bool, default: false
 
@@ -443,8 +387,6 @@ defmodule Google.Protobuf.UninterpretedOption.NamePart do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.UninterpretedOption.NamePart"
-
   field :name_part, 1, required: true, type: :string
   field :is_extension, 2, required: true, type: :bool
 end
@@ -453,8 +395,6 @@ defmodule Google.Protobuf.UninterpretedOption do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.UninterpretedOption"
 
   field :name, 2, repeated: true, type: Google.Protobuf.UninterpretedOption.NamePart
   field :identifier_value, 3, optional: true, type: :string
@@ -470,8 +410,6 @@ defmodule Google.Protobuf.SourceCodeInfo.Location do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.SourceCodeInfo.Location"
-
   field :path, 1, repeated: true, type: :int32, packed: true, deprecated: false
   field :span, 2, repeated: true, type: :int32, packed: true, deprecated: false
   field :leading_comments, 3, optional: true, type: :string
@@ -484,8 +422,6 @@ defmodule Google.Protobuf.SourceCodeInfo do
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 
-  def fully_qualified_name, do: "google.protobuf.SourceCodeInfo"
-
   field :location, 1, repeated: true, type: Google.Protobuf.SourceCodeInfo.Location
 end
 
@@ -493,8 +429,6 @@ defmodule Google.Protobuf.GeneratedCodeInfo.Annotation do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.GeneratedCodeInfo.Annotation"
 
   field :path, 1, repeated: true, type: :int32, packed: true, deprecated: false
   field :source_file, 2, optional: true, type: :string
@@ -511,8 +445,6 @@ defmodule Google.Protobuf.GeneratedCodeInfo do
   @moduledoc false
 
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  def fully_qualified_name, do: "google.protobuf.GeneratedCodeInfo"
 
   field :annotation, 1, repeated: true, type: Google.Protobuf.GeneratedCodeInfo.Annotation
 end

--- a/lib/protobuf/any.ex
+++ b/lib/protobuf/any.ex
@@ -13,7 +13,7 @@ defmodule Protobuf.Any do
   You can build and decode the `Any` type yourself.
 
       encoded_any = Google.Protobuf.Any.new!(
-        type_url: "types.googleapis.com/google.protobuf.Duration",
+        type_url: "type.googleapis.com/google.protobuf.Duration",
         value: Google.Protobuf.Duration.encode(%Google.Protobuf.Duration{seconds: 1})
       )
 
@@ -26,7 +26,7 @@ defmodule Protobuf.Any do
   @doc """
   Returns the module for a given `type_url`.
 
-  `type_url` must be in the form: `types.googleapis.com/<package>.<message name>`. The
+  `type_url` must be in the form: `type.googleapis.com/<package>.<message name>`. The
   returned module is determined by joining the package name and message name. See
   the examples.
 
@@ -45,13 +45,13 @@ defmodule Protobuf.Any do
       Google.Protobuf.Duration
 
       iex> Protobuf.Any.type_url_to_module("bad_type_url")
-      ** (ArgumentError) type_url must be in the form: types.googleapis.com/<package>.<message name>, got: "bad_type_url"
+      ** (ArgumentError) type_url must be in the form: type.googleapis.com/<package>.<message name>, got: "bad_type_url"
 
   """
   @spec type_url_to_module(String.t()) :: module()
   def type_url_to_module(type_url) when is_binary(type_url) do
     case type_url do
-      "types.googleapis.com/" <> package_and_message ->
+      "type.googleapis.com/" <> package_and_message ->
         package_and_message
         |> String.split(".")
         |> Enum.map(&Macro.camelize/1)
@@ -59,7 +59,7 @@ defmodule Protobuf.Any do
 
       _other ->
         raise ArgumentError,
-              "type_url must be in the form: types.googleapis.com/<package>.<message name>, " <>
+              "type_url must be in the form: type.googleapis.com/<package>.<message name>, " <>
                 "got: #{inspect(type_url)}"
     end
   end

--- a/lib/protobuf/any.ex
+++ b/lib/protobuf/any.ex
@@ -8,124 +8,25 @@ defmodule Protobuf.Any do
   See [Google's documentation for the `Any`a
   type](https://developers.google.com/protocol-buffers/docs/proto3#any).
 
-  Utilizing these functions allows you to pack and unpack any fields with any Protobuf
-  message.
-
   ## Examples
 
-  Imagine you have this Protobuf schema:
+  You can build and decode the `Any` type yourself.
 
-  ```protobuf
-  message ErrorStatus {
-    string message = 1;
-    repeated google.protobuf.Any details = 2;
-  }
-  ```
+      encoded_any = Google.Protobuf.Any.new!(
+        type_url: "types.googleapis.com/google.protobuf.Duration",
+        value: Google.Protobuf.Duration.encode(%Google.Protobuf.Duration{seconds: 1})
+      )
 
-  You can use `pack/1` to pack any message into an `Any` message.
-
-      details = some_list_of_protobuf_messages()
-
-      ErrorStatus.new(%{
-        message: "There was an error",
-        details: Enum.map(details, &Protobuf.Any.pack/1)
-      })
+      # Back to the original message:
+      decoded_any = decoded Google.Protobuf.Any.decode(encoded_any)
+      Google.Protobuf.Duration.decode(decoded_any.value)
 
   """
-
-  @type_url_prefix "type.googleapis.com/"
-  @type option() :: {:prefix, module()}
-
-  @doc """
-  Packs a Protobuf message into a `Google.Protobuf.Any` message.
-
-  This sets the correct `type_url` using the pattern:
-
-      type.googleapis.com/<package>.<message name>
-
-  This URL is obtained by calling the `fully_qualified_name/1` function
-  on the module for the `data` struct.
-
-  The `value` field of the `Google.Protobuf.Any` returned message is set to
-  the serialized original message.
-
-  ## Example
-
-      # This is the arbitrary message we want to pack.
-      encoded = MyPkg.MyMessage.encode(data)
-
-      any = Google.Protobuf.Any.new(%{
-        type_url: "type.googleapis.com/my_pkg.MyMessage",
-        value: encoded
-      })
-
-      any == Protobuf.Any.pack(data)
-      #=> true
-
-  """
-  @spec pack(struct()) :: Google.Protobuf.Any.t()
-  def pack(%mod{} = data) do
-    Google.Protobuf.Any.new(%{
-      type_url: "#{@type_url_prefix}#{mod.fully_qualified_name()}",
-      value: mod.encode(data)
-    })
-  end
-
-  @doc """
-  Unpacks a `Google.Protobuf.Any` message.
-
-  Uses the `type_url` to determine the type, and deserializes the binary data into that type.
-
-  > #### Existing modules {: .warning}
-  >
-  > The module for the message is determined via a **string** (the `type_url`),
-  > which is arbitrary user input that maps the package message name
-  > to a generated protocol buffer module.
-  >
-  > Because of this, this function uses `Module.safe_concat/1` is used to prevent arbitrary
-  > atom creation, which _requires_ that the message type is known and compiled into the
-  > application.
-  > If the inferred type is unknown, this function will raise an error.
-
-  ## Options
-
-  If you generated the protocol buffers with a module prefix, you can use
-  the `:prefix` option (a module) to unpack this correctly.
-
-  ## Example
-
-      any = %Google.Protobuf.Any{
-        type_url: "type.googleapis.com/my_pkg.MyMessage",
-        value: <<...>>
-      }
-
-      Protobuf.Any.unpack(any)
-      #=> %MyPkg.MyMessage{...}
-
-  """
-  @spec unpack(Google.Protobuf.Any.t(), keyword()) :: struct()
-  def unpack(
-        %{__struct__: Google.Protobuf.Any, type_url: @type_url_prefix <> name, value: value},
-        options \\ []
-      ) do
-    parts =
-      name
-      |> String.split(".")
-      |> Enum.map(&Macro.camelize/1)
-
-    parts =
-      case Keyword.fetch(options, :prefix) do
-        {:ok, prefix} -> [prefix] ++ parts
-        :error -> parts
-      end
-
-    Module.safe_concat(parts).decode(value)
-  end
 
   @doc """
   Returns the module for a given `type_url`.
 
-  `type_url` must be in the form: `#{@type_url_prefix}<package>.<message name>`. The
+  `type_url` must be in the form: `types.googleapis.com/<package>.<message name>`. The
   returned module is determined by joining the package name and message name. See
   the examples.
 
@@ -144,13 +45,13 @@ defmodule Protobuf.Any do
       Google.Protobuf.Duration
 
       iex> Protobuf.Any.type_url_to_module("bad_type_url")
-      ** (ArgumentError) type_url must be in the form: #{@type_url_prefix}<package>.<message name>
+      ** (ArgumentError) type_url must be in the form: types.googleapis.com/<package>.<message name>, got: "bad_type_url"
 
   """
   @spec type_url_to_module(String.t()) :: module()
   def type_url_to_module(type_url) when is_binary(type_url) do
     case type_url do
-      @type_url_prefix <> package_and_message ->
+      "types.googleapis.com/" <> package_and_message ->
         package_and_message
         |> String.split(".")
         |> Enum.map(&Macro.camelize/1)
@@ -158,7 +59,8 @@ defmodule Protobuf.Any do
 
       _other ->
         raise ArgumentError,
-              "type_url must be in the form: #{@type_url_prefix}<package>.<message name>"
+              "type_url must be in the form: types.googleapis.com/<package>.<message name>, " <>
+                "got: #{inspect(type_url)}"
     end
   end
 end

--- a/lib/protobuf/protoc/generator/enum.ex
+++ b/lib/protobuf/protoc/generator/enum.ex
@@ -18,11 +18,6 @@ defmodule Protobuf.Protoc.Generator.Enum do
   def generate(%Context{namespace: ns} = ctx, %Google.Protobuf.EnumDescriptorProto{} = desc) do
     msg_name = Util.mod_name(ctx, ns ++ [Macro.camelize(desc.name)])
 
-    fully_qualified_name =
-      [ctx.package | ns ++ [Macro.camelize(desc.name)]]
-      |> Enum.reject(&is_nil/1)
-      |> Enum.join(".")
-
     use_options =
       Util.options_to_str(%{
         syntax: ctx.syntax,
@@ -40,7 +35,6 @@ defmodule Protobuf.Protoc.Generator.Enum do
     content =
       enum_template(
         module: msg_name,
-        fully_qualified_name: fully_qualified_name,
         use_options: use_options,
         fields: desc.value,
         descriptor_fun_body: descriptor_fun_body,

--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -31,7 +31,6 @@ defmodule Protobuf.Protoc.Generator.Message do
     msg_name = Util.mod_name(ctx, new_ns)
     fields = get_fields(ctx, desc)
     extensions = get_extensions(desc)
-    fully_qualified_name = [ctx.package | new_ns] |> Enum.reject(&is_nil/1) |> Enum.join(".")
 
     descriptor_fun_body =
       if ctx.gen_descriptors? do
@@ -48,7 +47,6 @@ defmodule Protobuf.Protoc.Generator.Message do
        Util.format(
          message_template(
            module: msg_name,
-           fully_qualified_name: fully_qualified_name,
            use_options: msg_opts_str(ctx, desc.options),
            oneofs: desc.oneof_decl,
            fields: gen_fields(ctx.syntax, fields),

--- a/priv/templates/enum.ex.eex
+++ b/priv/templates/enum.ex.eex
@@ -4,8 +4,6 @@ defmodule <%= @module %> do
   <% end %>
   use Protobuf, <%= @use_options %>
 
-  def fully_qualified_name, do: <%= inspect(@fully_qualified_name) %>
-
   <%= if @descriptor_fun_body do %>
   def descriptor do
     # credo:disable-for-next-line

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -4,8 +4,6 @@ defmodule <%= @module %> do
   <% end %>
   use Protobuf<%= @use_options %>
 
-  def fully_qualified_name, do: <%= inspect(@fully_qualified_name) %>
-
   <%= if @descriptor_fun_body do %>
   def descriptor do
     # credo:disable-for-next-line

--- a/priv/templates/service.ex.eex
+++ b/priv/templates/service.ex.eex
@@ -4,8 +4,6 @@ defmodule <%= @module %>.Service do
   <% end %>
   use GRPC.Service, name: <%= inspect(@service_name) %>, protoc_gen_elixir_version: "<%= @version %>"
 
-  def fully_qualified_name, do: <%= inspect(@service_name) %>
-
   <%= if @descriptor_fun_body do %>
   def descriptor do
     # credo:disable-for-next-line

--- a/test/protobuf/any_test.exs
+++ b/test/protobuf/any_test.exs
@@ -2,44 +2,4 @@ defmodule Protobuf.AnyTest do
   use ExUnit.Case, async: true
 
   doctest Protobuf.Any
-
-  describe "pack/1" do
-    test "packs a message into Any" do
-      message = Google.Protobuf.Duration.new(seconds: 42)
-      assert %Google.Protobuf.Any{} = result = Protobuf.Any.pack(message)
-      assert result.type_url == "type.googleapis.com/google.protobuf.Duration"
-      assert result.value == Google.Protobuf.Duration.encode(message)
-    end
-
-    test "packs a message into Any with a prefix" do
-      message = My.Test.Request.SomeGroup.new(group_field: 42)
-      assert %Google.Protobuf.Any{} = result = Protobuf.Any.pack(message)
-      assert result.type_url == "type.googleapis.com/test.Request.SomeGroup"
-      assert result.value == My.Test.Request.SomeGroup.encode(message)
-    end
-  end
-
-  describe "unpack/2" do
-    test "unpacks a message into Any" do
-      message = Google.Protobuf.Duration.new(seconds: 42)
-
-      any = %Google.Protobuf.Any{
-        type_url: "type.googleapis.com/google.protobuf.Duration",
-        value: Protobuf.encode(message)
-      }
-
-      assert ^message = Protobuf.Any.unpack(any)
-    end
-
-    test "unpacks a message into Any with a prefix" do
-      message = My.Test.Request.SomeGroup.new(group_field: 42)
-
-      any = %Google.Protobuf.Any{
-        type_url: "type.googleapis.com/test.Request.SomeGroup",
-        value: Protobuf.encode(message)
-      }
-
-      assert ^message = Protobuf.Any.unpack(any, prefix: My)
-    end
-  end
 end


### PR DESCRIPTION
The idea here is to push people to use `Google.Protobuf.Any` directly more. The default `type_url` can be written down manually, and it's probably going to be a lot more accurate.

I'm thinking of removing `Protobuf.Any.type_url_to_module/1` too and make it a private function in this library instead of part of the public API. Thoughts @ericmj?