### PR TITLE
Deprecate the `new(!)/0,1` callbacks

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ end
 
       field :name, 1, type: :string
     end
-    
+
     defmodule Helloworld.HelloReply do
       @moduledoc false
       use Protobuf, protoc_gen_elixir_version: "0.10.0", syntax: :proto3
@@ -91,17 +91,13 @@ end
 ### Encode and decode in your code
 
 ```elixir
-struct = Foo.new(a: 3.2, c: Foo.Bar.new())
+struct = %Foo{a: 3.2, c: %Foo.Bar{}}
 encoded = Foo.encode(struct)
 struct = Foo.decode(encoded)
 ```
 
-Note:
-
-- Use `YourModule.new(field: "value")` to ensure default values are set correctly for all fields
-  instead of using the struct directly, as in `%YourModule{field: "value"}`.
-- Validation is done during encoding. An error will be raised if the struct is invalid: when it
-  misses a required field or has a mistyped value.
+Validation is done during encoding. An error will be raised if the struct is invalid: when it
+misses a required field or has a mistyped value.
 
 ### Descriptor support
 

--- a/conformance/protobuf/runner.ex
+++ b/conformance/protobuf/runner.ex
@@ -47,8 +47,10 @@ defmodule Conformance.Protobuf.Runner do
             raise "failed to read #{len} bytes from stdio: #{inspect(reason)}"
 
           encoded_request when byte_size(encoded_request) == len ->
-            mod = Conformance.ConformanceResponse
-            response = mod.new!(result: handle_encoded_request(encoded_request))
+            response =
+              struct!(Conformance.ConformanceResponse,
+                result: handle_encoded_request(encoded_request)
+              )
 
             encoded_response = Protobuf.encode(response)
 

--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -42,16 +42,19 @@ defmodule Protobuf do
 
       @behaviour Protobuf
 
+      @deprecated "Build the struct by hand with %MyMessage{...} or use struct/1"
       @impl unquote(__MODULE__)
       def new() do
         Protobuf.Builder.new(__MODULE__)
       end
 
+      @deprecated "Build the struct by hand with %MyMessage{...} or use struct/2"
       @impl unquote(__MODULE__)
       def new(attrs) do
         Protobuf.Builder.new(__MODULE__, attrs)
       end
 
+      @deprecated "Build the struct by hand with %MyMessage{...} or use struct!/2"
       @impl unquote(__MODULE__)
       def new!(attrs) do
         Protobuf.Builder.new!(__MODULE__, attrs)
@@ -73,10 +76,10 @@ defmodule Protobuf do
   end
 
   @doc """
-  Builds a blank struct with default values. This and other "new" functions are
-  preferred than raw building struct method like `%Foo{}`.
+  Builds a blank struct with default values.
 
-  In proto3, the zero values are the default values.
+  This is deprecated in favor of building the struct with `%MyMessage{...}` or using
+  `struct/1`.
   """
   @callback new() :: struct()
 
@@ -85,10 +88,13 @@ defmodule Protobuf do
 
   This function will:
 
-  * Recursively call `c:new/1` for embedded fields
-  * Create structs using `struct/2` for keyword lists and maps
-  * Create the correct struct if passed the wrong struct
-  * Call `c:new/1` for each element in the list for repeated fields
+    * Recursively call `c:new/1` for embedded fields
+    * Create structs using `struct/2` for keyword lists and maps
+    * Create the correct struct if passed the wrong struct
+    * Call `c:new/1` for each element in the list for repeated fields
+
+  This is deprecated in favor of building the struct with `%MyMessage{...}` or using
+  `struct/2`.
 
   ## Examples
 
@@ -110,6 +116,9 @@ defmodule Protobuf do
   @doc """
   Similar to `c:new/1`, but use `struct!/2` to build the struct, so
   errors will be raised if unknown keys are passed.
+
+  This is deprecated in favor of building the struct with `%MyMessage{...}` or using
+  `struct!/2` directly.
   """
   @callback new!(Enum.t()) :: struct()
 
@@ -167,8 +176,7 @@ defmodule Protobuf do
 
   ## Examples
 
-      struct = MyMessage.new()
-      Protobuf.encode(struct)
+      Protobuf.encode(%MyMessage{...})
       #=> <<...>>
 
   """
@@ -180,8 +188,7 @@ defmodule Protobuf do
 
   ## Examples
 
-      struct = MyMessage.new()
-      Protobuf.encode_to_iodata(struct)
+      Protobuf.encode_to_iodata(%MyMessage{...})
       #=> [...]
 
   """

--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -78,8 +78,11 @@ defmodule Protobuf do
   @doc """
   Builds a blank struct with default values.
 
-  This is deprecated in favor of building the struct with `%MyMessage{...}` or using
-  `struct/1`.
+  > #### Deprecated {: .warning}
+  >
+  > This is deprecated in favor of building the struct with `%MyMessage{...}` or using
+  > `struct/1`.
+
   """
   @callback new() :: struct()
 
@@ -93,8 +96,9 @@ defmodule Protobuf do
     * Create the correct struct if passed the wrong struct
     * Call `c:new/1` for each element in the list for repeated fields
 
-  This is deprecated in favor of building the struct with `%MyMessage{...}` or using
-  `struct/2`.
+  > #### Deprecated {: .warning}
+  > This is deprecated in favor of building the struct with `%MyMessage{...}` or using
+  > `struct/2`.
 
   ## Examples
 
@@ -111,16 +115,18 @@ defmodule Protobuf do
       #=> %MyMessage{repeated: [%MyRepeated{field1: "foo"}, %MyRepeated{field1: "bar"}]}
 
   """
-  @callback new(Enum.t()) :: struct
+  @callback new(attributes :: Enum.t()) :: struct
 
   @doc """
   Similar to `c:new/1`, but use `struct!/2` to build the struct, so
   errors will be raised if unknown keys are passed.
 
-  This is deprecated in favor of building the struct with `%MyMessage{...}` or using
-  `struct!/2` directly.
+  > #### Deprecated {: .warning}
+  > This is deprecated in favor of building the struct with `%MyMessage{...}` or using
+  > `struct!/2` directly.
+
   """
-  @callback new!(Enum.t()) :: struct()
+  @callback new!(attributes :: Enum.t()) :: struct()
 
   @doc """
   Encodes the given struct into to a Protobuf binary.

--- a/lib/protobuf/any.ex
+++ b/lib/protobuf/any.ex
@@ -12,14 +12,15 @@ defmodule Protobuf.Any do
 
   You can build and decode the `Any` type yourself.
 
-      encoded_any = Google.Protobuf.Any.new!(
-        type_url: "type.googleapis.com/google.protobuf.Duration",
-        value: Google.Protobuf.Duration.encode(%Google.Protobuf.Duration{seconds: 1})
-      )
-
-      # Back to the original message:
-      decoded_any = decoded Google.Protobuf.Any.decode(encoded_any)
-      Google.Protobuf.Duration.decode(decoded_any.value)
+      iex> value = %Google.Protobuf.Duration{seconds: 1}
+      iex> any = %Google.Protobuf.Any{
+      ...>   type_url: "type.googleapis.com/google.protobuf.Duration",
+      ...>   value: Google.Protobuf.Duration.encode(value)
+      ...> }
+      iex> encoded_any = Google.Protobuf.Any.encode(any)
+      iex> decoded_any = Google.Protobuf.Any.decode(encoded_any)
+      iex> Google.Protobuf.Duration.decode(decoded_any.value) == value
+      true
 
   """
 

--- a/lib/protobuf/decoder.ex
+++ b/lib/protobuf/decoder.ex
@@ -14,7 +14,7 @@ defmodule Protobuf.Decoder do
     %MessageProps{repeated_fields: repeated_fields} = props = module.__message_props__()
 
     bin
-    |> build_message(module.new(), props)
+    |> build_message(struct(module), props)
     |> reverse_repeated(repeated_fields)
     |> Map.update!(:__unknown_fields__, &Enum.reverse/1)
     |> transform_module(module)

--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -144,7 +144,8 @@ defmodule Protobuf.Encoder do
   defp encode_from_type(mod, msg) do
     case msg do
       %{__struct__: ^mod} -> encode_to_iodata(msg)
-      _ -> encode_to_iodata(mod.new(msg))
+      %_{} -> encode_to_iodata(struct(mod, Map.from_struct(msg)))
+      _ -> encode_to_iodata(struct(mod, msg))
     end
   end
 

--- a/lib/protobuf/extension.ex
+++ b/lib/protobuf/extension.ex
@@ -29,9 +29,10 @@ defmodule Protobuf.Extension do
         extend Foo, :my_custom, 1047, optional: true, type: :string
       end
 
-      foo = Foo.new()
+      foo = %Foo{}
       Foo.put_extension(foo, Ext.PbExtension, :my_custom, "Custom field")
       Foo.get_extension(foo, Ext.PbExtension, :my_custom)
+
   """
 
   @doc "The actual function for `put_extension`"

--- a/lib/protobuf/json.ex
+++ b/lib/protobuf/json.ex
@@ -49,7 +49,7 @@ defmodule Protobuf.JSON do
 
   With `encode/1` you can turn any `Protobuf` message struct into a JSON string:
 
-      iex> message = Car.new(color: :RED, top_speed: 125.3)
+      iex> message = %Car{color: :RED, top_speed: 125.3}
       iex> Protobuf.JSON.encode(message)
       {:ok, "{\\"color\\":\\"RED\\",\\"topSpeed\\":125.3}"}
 
@@ -101,7 +101,7 @@ defmodule Protobuf.JSON do
 
   ## Examples
 
-      iex> Car.new(top_speed: 80.0) |> Protobuf.JSON.encode!()
+      iex> Protobuf.JSON.encode!(%Car{top_speed: 80.0})
       ~S|{"topSpeed":80.0}|
 
   """
@@ -143,13 +143,13 @@ defmodule Protobuf.JSON do
 
   Encoding is as simple as:
 
-      iex> Car.new(color: :RED, top_speed: 125.3) |> Protobuf.JSON.encode()
+      iex> Protobuf.JSON.encode(%Car{color: :RED, top_speed: 125.3})
       {:ok, ~S|{"color":"RED","topSpeed":125.3}|}
 
-      iex> Car.new(color: :GREEN) |> Protobuf.JSON.encode()
+      iex> Protobuf.JSON.encode(%Car{color: :GREEN})
       {:ok, "{}"}
 
-      iex> Car.new() |> Protobuf.JSON.encode(emit_unpopulated: true)
+      iex> Protobuf.JSON.encode(%Car{}, emit_unpopulated: true)
       {:ok, ~S|{"color":"GREEN","topSpeed":0.0}|}
 
   """
@@ -174,13 +174,13 @@ defmodule Protobuf.JSON do
 
   ## Examples
 
-      iex> Car.new(color: :RED, top_speed: 125.3) |> Protobuf.JSON.to_encodable()
+      iex> Protobuf.JSON.to_encodable(%Car{color: :RED, top_speed: 125.3})
       {:ok, %{"color" => :RED, "topSpeed" => 125.3}}
 
-      iex> Car.new(color: :GREEN) |> Protobuf.JSON.to_encodable()
+      iex> Protobuf.JSON.to_encodable(%Car{color: :GREEN})
       {:ok, %{}}
 
-      iex> Car.new() |> Protobuf.JSON.to_encodable(emit_unpopulated: true)
+      iex> Protobuf.JSON.to_encodable(%Car{}, emit_unpopulated: true)
       {:ok, %{"color" => :GREEN, "topSpeed" => 0.0}}
 
   """

--- a/lib/protobuf/protoc/cli.ex
+++ b/lib/protobuf/protoc/cli.ex
@@ -57,10 +57,10 @@ defmodule Protobuf.Protoc.CLI do
         Protobuf.Protoc.Generator.generate(ctx, desc)
       end)
 
-    Google.Protobuf.Compiler.CodeGeneratorResponse.new(
+    %Google.Protobuf.Compiler.CodeGeneratorResponse{
       file: files,
       supported_features: supported_features()
-    )
+    }
     |> Protobuf.encode_to_iodata()
     |> IO.binwrite()
   end

--- a/lib/protobuf/protoc/context.ex
+++ b/lib/protobuf/protoc/context.ex
@@ -60,7 +60,7 @@ defmodule Protobuf.Protoc.Context do
       ) do
     custom_file_opts =
       Google.Protobuf.FileOptions.get_extension(options, Elixirpb.PbExtension, :file) ||
-        Elixirpb.PbExtension.new()
+        %Elixirpb.PbExtension{}
 
     %__MODULE__{
       ctx

--- a/lib/protobuf/protoc/generator.ex
+++ b/lib/protobuf/protoc/generator.ex
@@ -15,11 +15,7 @@ defmodule Protobuf.Protoc.Generator do
     if ctx.one_file_per_module? do
       Enum.map(module_definitions, fn {mod_name, content} ->
         file_name = Macro.underscore(mod_name) <> ".pb.ex"
-
-        Google.Protobuf.Compiler.CodeGeneratorResponse.File.new(
-          name: file_name,
-          content: content
-        )
+        %Google.Protobuf.Compiler.CodeGeneratorResponse.File{name: file_name, content: content}
       end)
     else
       # desc.name is the filename, ending in ".proto".
@@ -31,12 +27,7 @@ defmodule Protobuf.Protoc.Generator do
         |> IO.iodata_to_binary()
         |> Generator.Util.format()
 
-      [
-        Google.Protobuf.Compiler.CodeGeneratorResponse.File.new(
-          name: file_name,
-          content: content
-        )
-      ]
+      [%Google.Protobuf.Compiler.CodeGeneratorResponse.File{name: file_name, content: content}]
     end
   end
 

--- a/lib/protobuf/protoc/generator/util.ex
+++ b/lib/protobuf/protoc/generator/util.ex
@@ -67,10 +67,12 @@ defmodule Protobuf.Protoc.Generator.Util do
 
   @spec descriptor_fun_body(desc :: struct()) :: String.t()
   def descriptor_fun_body(%mod{} = desc) do
-    desc
-    |> Map.from_struct()
-    |> Enum.filter(fn {_key, val} -> not is_nil(val) end)
-    |> mod.new()
+    attributes =
+      desc
+      |> Map.from_struct()
+      |> Enum.filter(fn {_key, val} -> not is_nil(val) end)
+
+    struct!(mod, attributes)
     |> mod.encode()
     |> mod.decode()
     |> inspect(limit: :infinity)

--- a/test/pbt/encode_decode_type_test.exs
+++ b/test/pbt/encode_decode_type_test.exs
@@ -6,8 +6,8 @@ defmodule Protobuf.EncodeDecodeTypeTest.PropertyGenerator do
   end
 
   def encode(type, val) do
-    [{type, val}]
-    |> TestMsg.Scalars.new!()
+    TestMsg.Scalars
+    |> struct!([{type, val}])
     |> Protobuf.encode()
   end
 

--- a/test/pbt/unknown_fields_test.exs
+++ b/test/pbt/unknown_fields_test.exs
@@ -11,7 +11,7 @@ defmodule Protobuf.UnknownFieldsTest do
 
     check all unknown_fields <- unknown_fields_generator, max_runs: 20 do
       decoded =
-        TestAllTypesProto3.new!([])
+        %TestAllTypesProto3{}
         |> Map.put(:__unknown_fields__, unknown_fields)
         |> Protobuf.encode()
         |> Protobuf.decode(TestAllTypesProto3)

--- a/test/protobuf/decoder_test.exs
+++ b/test/protobuf/decoder_test.exs
@@ -7,62 +7,62 @@ defmodule Protobuf.DecoderTest do
 
   test "decodes one simple field" do
     struct = Decoder.decode(<<8, 42>>, TestMsg.Foo)
-    assert struct == TestMsg.Foo.new(a: 42)
+    assert struct == %TestMsg.Foo{a: 42}
   end
 
   test "decodes full fields" do
     bin = <<8, 42, 17, 100, 0, 0, 0, 0, 0, 0, 0, 26, 3, 115, 116, 114, 45, 0, 0, 247, 66>>
     struct = Decoder.decode(bin, TestMsg.Foo)
-    assert struct == TestMsg.Foo.new(a: 42, b: 100, c: "str", d: 123.5)
+    assert struct == %TestMsg.Foo{a: 42, b: 100, c: "str", d: 123.5}
   end
 
   test "skips a known fields" do
     bin = <<8, 42, 26, 3, 115, 116, 114, 45, 0, 0, 247, 66>>
     struct = Decoder.decode(bin, TestMsg.Foo)
-    assert struct == TestMsg.Foo.new(a: 42, c: "str", d: 123.5)
+    assert struct == %TestMsg.Foo{a: 42, c: "str", d: 123.5}
   end
 
   test "raises for wrong wire type" do
-    assert_raise(Protobuf.DecodeError, ~r{wrong wire_type for field a: got 1, expected 0}, fn ->
+    assert_raise Protobuf.DecodeError, ~r{wrong wire_type for field a: got 1, expected 0}, fn ->
       Decoder.decode(<<9, 42, 0, 0, 0, 0, 0, 0, 0>>, TestMsg.Foo)
-    end)
+    end
   end
 
   test "raises for bad binaries" do
-    assert_raise(Protobuf.DecodeError, ~r{invalid field number 0 when decoding binary data}, fn ->
+    assert_raise Protobuf.DecodeError, ~r{invalid field number 0 when decoding binary data}, fn ->
       Decoder.decode(<<0, 0, 0, 0, 0, 0, 0>>, TestMsg.Foo)
-    end)
+    end
   end
 
   test "raises for length-delimited string with wrong length" do
     # correct length is <<8, 1, 18, 2, 48, 48>>
     bin = <<8, 1, 18, 3, 48, 48>>
 
-    assert_raise(Protobuf.DecodeError, ~r{insufficient data decoding field b}, fn ->
+    assert_raise Protobuf.DecodeError, ~r{insufficient data decoding field b}, fn ->
       Decoder.decode(bin, TestMsg.Foo.Bar)
-    end)
+    end
   end
 
   test "skips unknown string fields" do
     struct = Decoder.decode(<<8, 42, 45, 0, 0, 247, 66>>, TestMsg.Foo)
-    assert struct == TestMsg.Foo.new(a: 42, d: 123.5)
+    assert struct == %TestMsg.Foo{a: 42, d: 123.5}
   end
 
   test "decodes embedded message" do
     struct = Decoder.decode(<<8, 42, 50, 7, 8, 12, 18, 3, 97, 98, 99, 56, 13>>, TestMsg.Foo)
-    assert struct == TestMsg.Foo.new(a: 42, e: %TestMsg.Foo.Bar{a: 12, b: "abc"}, f: 13)
+    assert struct == %TestMsg.Foo{a: 42, e: %TestMsg.Foo.Bar{a: 12, b: "abc"}, f: 13}
   end
 
   test "merges singular embedded messages for multiple fields" do
     # %{a: 12} + %{a: 21, b: "abc"}
     bin = <<50, 2, 8, 12, 50, 7, 8, 21, 18, 3, 97, 98, 99>>
     struct = Decoder.decode(bin, TestMsg.Foo)
-    assert struct == TestMsg.Foo.new(e: %TestMsg.Foo.Bar{a: 21, b: "abc"})
+    assert struct == %TestMsg.Foo{e: %TestMsg.Foo.Bar{a: 21, b: "abc"}}
   end
 
   test "decodes repeated varint fields" do
     struct = Decoder.decode(<<64, 12, 8, 123, 64, 13, 64, 14>>, TestMsg.Foo)
-    assert struct == TestMsg.Foo.new(a: 123, g: [12, 13, 14])
+    assert struct == %TestMsg.Foo{a: 123, g: [12, 13, 14]}
   end
 
   test "decodes unknown fields" do
@@ -88,25 +88,25 @@ defmodule Protobuf.DecoderTest do
     struct = Decoder.decode(bin, TestMsg.Foo)
 
     assert struct ==
-             TestMsg.Foo.new(h: [%TestMsg.Foo.Bar{a: 12, b: "abc"}, TestMsg.Foo.Bar.new(a: 13)])
+             %TestMsg.Foo{h: [%TestMsg.Foo.Bar{a: 12, b: "abc"}, %TestMsg.Foo.Bar{a: 13}]}
   end
 
   test "decodes packed fields" do
     struct = Decoder.decode(<<82, 2, 12, 13>>, TestMsg.Foo)
-    assert struct == TestMsg.Foo.new(i: [12, 13])
+    assert struct == %TestMsg.Foo{i: [12, 13]}
   end
 
   test "concat multiple packed fields" do
     struct = Decoder.decode(<<82, 2, 12, 13, 82, 2, 14, 15>>, TestMsg.Foo)
-    assert struct == TestMsg.Foo.new(i: [12, 13, 14, 15])
+    assert struct == %TestMsg.Foo{i: [12, 13, 14, 15]}
   end
 
   test "decodes enum type" do
     struct = Decoder.decode(<<88, 1>>, TestMsg.Foo)
-    assert struct == TestMsg.Foo.new(j: :A)
+    assert struct == %TestMsg.Foo{j: :A}
 
     struct = Decoder.decode(<<88, 2>>, TestMsg.Foo)
-    assert struct == TestMsg.Foo.new(j: :B)
+    assert struct == %TestMsg.Foo{j: :B}
 
     # Proto2 enums that are not zero-based default to their first value declared.
     struct = Decoder.decode(<<>>, My.Test.Request)
@@ -115,7 +115,7 @@ defmodule Protobuf.DecoderTest do
 
   test "decodes unknown enum value" do
     struct = Decoder.decode(<<88, 3>>, TestMsg.Foo)
-    assert struct == TestMsg.Foo.new(j: 3)
+    assert struct == %TestMsg.Foo{j: 3}
   end
 
   test "decodes map type" do
@@ -125,32 +125,32 @@ defmodule Protobuf.DecoderTest do
         TestMsg.Foo
       )
 
-    assert struct == TestMsg.Foo.new(l: %{"foo_key" => 213})
+    assert struct == %TestMsg.Foo{l: %{"foo_key" => 213}}
   end
 
   test "decodes 0 for proto2" do
     assert Decoder.decode(<<8, 0, 17, 5, 0, 0, 0, 0, 0, 0, 0>>, TestMsg.Foo2) ==
-             TestMsg.Foo2.new(a: 0)
+             %TestMsg.Foo2{a: 0}
   end
 
   test "decodes [] for proto2" do
     assert Decoder.decode(<<8, 0, 17, 5, 0, 0, 0, 0, 0, 0, 0>>, TestMsg.Foo2) ==
-             TestMsg.Foo2.new(a: 0, g: [])
+             %TestMsg.Foo2{a: 0, g: []}
   end
 
   test "decodes %{} for proto2" do
     assert Decoder.decode(<<8, 0, 17, 5, 0, 0, 0, 0, 0, 0, 0>>, TestMsg.Foo2) ==
-             TestMsg.Foo2.new(a: 0, l: %{})
+             %TestMsg.Foo2{a: 0, l: %{}}
   end
 
   test "decodes nil for proto3" do
     assert Decoder.decode(<<18, 1, 65>>, TestMsg.Proto3Optional) ==
-             TestMsg.Proto3Optional.new(a: nil, b: "A", c: nil)
+             %TestMsg.Proto3Optional{a: nil, b: "A", c: nil}
   end
 
   test "decodes default values for proto3 optional" do
     assert Decoder.decode(<<8, 0, 18, 1, 65, 24, 0>>, TestMsg.Proto3Optional) ==
-             TestMsg.Proto3Optional.new(a: 0, b: "A", c: :UNKNOWN)
+             %TestMsg.Proto3Optional{a: 0, b: "A", c: :UNKNOWN}
   end
 
   test "decodes unpacked binary with SignedInt32Repeated for proto2" do
@@ -173,9 +173,9 @@ defmodule Protobuf.DecoderTest do
 
   test "decodes custom default message for proto2" do
     assert Decoder.decode(<<8, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0>>, TestMsg.Foo2) ==
-             TestMsg.Foo2.new(a: 0, b: 0)
+             %TestMsg.Foo2{a: 0, b: 0}
 
-    assert Decoder.decode(<<8, 0>>, TestMsg.Foo2) == TestMsg.Foo2.new(a: 0, b: 5)
+    assert Decoder.decode(<<8, 0>>, TestMsg.Foo2) == %TestMsg.Foo2{a: 0, b: 5}
   end
 
   test "oneof only sets oneof fields" do
@@ -192,10 +192,10 @@ defmodule Protobuf.DecoderTest do
 
   test "oneof only sets oneof fields for zero values" do
     assert Decoder.decode(<<8, 0, 34, 0>>, TestMsg.Oneof) ==
-             TestMsg.Oneof.new(first: {:a, 0}, second: {:d, ""})
+             %TestMsg.Oneof{first: {:a, 0}, second: {:d, ""}}
 
     assert Decoder.decode(<<18, 0, 24, 0>>, TestMsg.Oneof) ==
-             TestMsg.Oneof.new(first: {:b, ""}, second: {:c, 0})
+             %TestMsg.Oneof{first: {:b, ""}, second: {:c, 0}}
   end
 
   test "decodes with transformer module" do
@@ -237,7 +237,7 @@ defmodule Protobuf.DecoderTest do
 
       bin = a <> b <> group <> group <> c <> d
       struct = Decoder.decode(bin, TestMsg.Foo)
-      assert struct == TestMsg.Foo.new(a: 42, b: 100, c: "str", d: 123.5)
+      assert struct == %TestMsg.Foo{a: 42, b: 100, c: "str", d: 123.5}
     end
 
     test "skips repeated and nested groups" do
@@ -248,7 +248,7 @@ defmodule Protobuf.DecoderTest do
 
       bin = group1_start <> group1_start <> group1_end <> group1_end
       struct = Decoder.decode(bin, TestMsg.Foo)
-      assert struct == TestMsg.Foo.new()
+      assert struct == %TestMsg.Foo{}
 
       a = <<8, 42>>
       b = <<17, 100, 0, 0, 0, 0, 0, 0, 0>>
@@ -262,7 +262,7 @@ defmodule Protobuf.DecoderTest do
 
       bin = a <> group1 <> group1 <> b
       struct = Decoder.decode(bin, TestMsg.Foo)
-      assert struct == TestMsg.Foo.new(a: 42, b: 100)
+      assert struct == %TestMsg.Foo{a: 42, b: 100}
     end
 
     test "raises when closing a group before opening" do
@@ -289,11 +289,11 @@ defmodule Protobuf.DecoderTest do
       # field number 1, wire type 7, value 42
       field = <<15, 42>>
 
-      bin = group_start <> field
+      message = "invalid wire_type for skipped field a: got 7, expected 0"
 
-      assert_raise Protobuf.DecodeError,
-                   "invalid wire_type for skipped field a: got 7, expected 0",
-                   fn -> Decoder.decode(bin, TestMsg.Foo) end
+      assert_raise Protobuf.DecodeError, message, fn ->
+        Decoder.decode(group_start <> field, TestMsg.Foo)
+      end
     end
   end
 end

--- a/test/protobuf/dsl_test.exs
+++ b/test/protobuf/dsl_test.exs
@@ -188,7 +188,8 @@ defmodule Protobuf.DSLTest do
     refute msg_props.field_props[11].embedded?
   end
 
-  test "generates new function" do
+  # TODO: remove once we remove new/0 and new/1.
+  test "generates new/0 and new/1 functions" do
     assert %Foo{
              a: 0,
              c: "",

--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -6,45 +6,45 @@ defmodule Protobuf.EncoderTest do
   alias Protobuf.Encoder
 
   test "encodes one simple field" do
-    bin = Encoder.encode(TestMsg.Foo.new(a: 42))
+    bin = Encoder.encode(%TestMsg.Foo{a: 42})
     assert bin == <<8, 42>>
   end
 
   test "encodes full fields" do
     bin = <<8, 42, 17, 100, 0, 0, 0, 0, 0, 0, 0, 26, 3, 115, 116, 114, 45, 0, 0, 247, 66>>
-    res = Encoder.encode(TestMsg.Foo.new(a: 42, b: 100, c: "str", d: 123.5))
+    res = Encoder.encode(%TestMsg.Foo{a: 42, b: 100, c: "str", d: 123.5})
     assert res == bin
   end
 
   test "skips a field with default value" do
     bin = <<8, 42, 26, 3, 115, 116, 114, 45, 0, 0, 247, 66>>
-    res = Encoder.encode(TestMsg.Foo.new(a: 42, c: "str", d: 123.5))
+    res = Encoder.encode(%TestMsg.Foo{a: 42, c: "str", d: 123.5})
     assert res == bin
   end
 
   test "skips a field without default value" do
     bin = <<8, 42, 17, 100, 0, 0, 0, 0, 0, 0, 0, 45, 0, 0, 247, 66>>
-    res = Encoder.encode(TestMsg.Foo.new(a: 42, b: 100, d: 123.5))
+    res = Encoder.encode(%TestMsg.Foo{a: 42, b: 100, d: 123.5})
     assert res == bin
   end
 
   test "encodes embedded message" do
-    bin = Encoder.encode(TestMsg.Foo.new(a: 42, e: %TestMsg.Foo.Bar{a: 12, b: "abc"}, f: 13))
+    bin = Encoder.encode(%TestMsg.Foo{a: 42, e: %TestMsg.Foo.Bar{a: 12, b: "abc"}, f: 13})
     assert bin == <<8, 42, 50, 7, 8, 12, 18, 3, 97, 98, 99, 56, 13>>
   end
 
   test "encodes empty embedded message" do
-    bin = Encoder.encode(TestMsg.Foo.new(a: 42, e: TestMsg.Foo.Bar.new()))
+    bin = Encoder.encode(%TestMsg.Foo{a: 42, e: %TestMsg.Foo.Bar{}})
     assert bin == <<8, 42, 50, 0>>
   end
 
   test "encodes repeated non-packed varint fields" do
-    bin = Encoder.encode(TestMsg.Foo.new(a: 123, g: [12, 13, 14]))
+    bin = Encoder.encode(%TestMsg.Foo{a: 123, g: [12, 13, 14]})
     assert bin == <<8, 123, 64, 12, 64, 13, 64, 14>>
   end
 
   test "encodes repeated varint fields with all 0" do
-    bin = Encoder.encode(TestMsg.Foo.new(g: [0, 0, 0]))
+    bin = Encoder.encode(%TestMsg.Foo{g: [0, 0, 0]})
     assert bin == <<64, 0, 64, 0, 64, 0>>
   end
 
@@ -52,188 +52,188 @@ defmodule Protobuf.EncoderTest do
     bin = <<74, 7, 8, 12, 18, 3, 97, 98, 99, 74, 2, 8, 13>>
 
     res =
-      Encoder.encode(
-        TestMsg.Foo.new(h: [%TestMsg.Foo.Bar{a: 12, b: "abc"}, TestMsg.Foo.Bar.new(a: 13)])
-      )
+      Encoder.encode(%TestMsg.Foo{
+        h: [%TestMsg.Foo.Bar{a: 12, b: "abc"}, %TestMsg.Foo.Bar{a: 13}]
+      })
 
     assert res == bin
   end
 
   test "encodes repeated embedded fields with all empty struct" do
-    bin = Encoder.encode(TestMsg.Foo.new(h: [TestMsg.Foo.Bar.new(), TestMsg.Foo.Bar.new()]))
+    bin = Encoder.encode(%TestMsg.Foo{h: [%TestMsg.Foo.Bar{}, %TestMsg.Foo.Bar{}]})
     assert bin == <<74, 0, 74, 0>>
   end
 
   test "encodes packed fields" do
-    bin = Encoder.encode(TestMsg.Foo.new(i: [12, 13, 14]))
+    bin = Encoder.encode(%TestMsg.Foo{i: [12, 13, 14]})
     assert bin == <<82, 3, 12, 13, 14>>
   end
 
   test "encodes packed fields with all 0" do
-    bin = Encoder.encode(TestMsg.Foo.new(i: [0, 0, 0]))
+    bin = Encoder.encode(%TestMsg.Foo{i: [0, 0, 0]})
     assert bin == <<82, 3, 0, 0, 0>>
   end
 
   test "encodes enum type" do
-    bin = Encoder.encode(TestMsg.Foo.new(j: 2))
+    bin = Encoder.encode(%TestMsg.Foo{j: 2})
     assert bin == <<88, 2>>
-    bin = Encoder.encode(TestMsg.Foo.new(j: :A))
+    bin = Encoder.encode(%TestMsg.Foo{j: :A})
     assert bin == <<88, 1>>
-    bin = Encoder.encode(TestMsg.Foo.new(j: :B))
+    bin = Encoder.encode(%TestMsg.Foo{j: :B})
     assert bin == <<88, 2>>
   end
 
   test "encodes repeated enum fields using packed by default" do
-    bin = Encoder.encode(TestMsg.Foo.new(o: [:A, :B]))
+    bin = Encoder.encode(%TestMsg.Foo{o: [:A, :B]})
     assert bin == <<130, 1, 2, 1, 2>>
   end
 
   test "encodes unknown enum type" do
-    bin = Encoder.encode(TestMsg.Foo.new(j: 3))
+    bin = Encoder.encode(%TestMsg.Foo{j: 3})
     assert bin == <<88, 3>>
   end
 
   test "encodes 0" do
-    assert Encoder.encode(TestMsg.Foo.new(a: 0)) == <<>>
+    assert Encoder.encode(%TestMsg.Foo{a: 0}) == <<>>
   end
 
   test "encodes empty string" do
-    assert Encoder.encode(TestMsg.Foo.new(c: "")) == <<>>
+    assert Encoder.encode(%TestMsg.Foo{c: ""}) == <<>>
   end
 
   test "encodes bool" do
-    assert Encoder.encode(TestMsg.Foo.new(k: false)) == <<>>
-    assert Encoder.encode(TestMsg.Foo.new(k: true)) == <<96, 1>>
+    assert Encoder.encode(%TestMsg.Foo{k: false}) == <<>>
+    assert Encoder.encode(%TestMsg.Foo{k: true}) == <<96, 1>>
   end
 
   test "encode map type" do
     bin = <<106, 12, 10, 7, 102, 111, 111, 95, 107, 101, 121, 16, 213, 1>>
-    struct = TestMsg.Foo.new(l: %{"foo_key" => 213})
+    struct = %TestMsg.Foo{l: %{"foo_key" => 213}}
     assert Encoder.encode(struct) == bin
   end
 
   test "encodes 0 for proto2" do
-    assert Encoder.encode(TestMsg.Foo2.new(a: 0)) == <<8, 0>>
+    assert Encoder.encode(%TestMsg.Foo2{a: 0}) == <<8, 0>>
   end
 
   test "encodes [] for proto2" do
-    assert Encoder.encode(TestMsg.Foo2.new(a: 0, g: [])) == <<8, 0>>
+    assert Encoder.encode(%TestMsg.Foo2{a: 0, g: []}) == <<8, 0>>
   end
 
   test "encodes %{} for proto2" do
-    assert Encoder.encode(TestMsg.Foo2.new(a: 0, l: %{})) == <<8, 0>>
+    assert Encoder.encode(%TestMsg.Foo2{a: 0, l: %{}}) == <<8, 0>>
   end
 
   test "encodes custom default message for proto2" do
-    assert Encoder.encode(TestMsg.Foo2.new(a: 0, b: 0)) == <<8, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0>>
+    assert Encoder.encode(%TestMsg.Foo2{a: 0, b: 0}) == <<8, 0, 17, 0, 0, 0, 0, 0, 0, 0, 0>>
   end
 
   test "encodes oneof fields" do
-    msg = TestMsg.Oneof.new(%{first: {:a, 42}, second: {:d, "abc"}, other: "other"})
+    msg = %TestMsg.Oneof{first: {:a, 42}, second: {:d, "abc"}, other: "other"}
     assert Encoder.encode(msg) == <<8, 42, 34, 3, 97, 98, 99, 42, 5, 111, 116, 104, 101, 114>>
-    msg = TestMsg.Oneof.new(%{first: {:b, "abc"}, second: {:c, 123}, other: "other"})
+    msg = %TestMsg.Oneof{first: {:b, "abc"}, second: {:c, 123}, other: "other"}
     assert Encoder.encode(msg) == <<18, 3, 97, 98, 99, 24, 123, 42, 5, 111, 116, 104, 101, 114>>
   end
 
   test "encodes oneof fields zero values" do
     # proto2
     # int and string
-    msg = TestMsg.Oneof.new(first: {:a, 0}, second: {:d, ""})
+    msg = %TestMsg.Oneof{first: {:a, 0}, second: {:d, ""}}
     assert Encoder.encode(msg) == <<8, 0, 34, 0>>
-    msg = TestMsg.Oneof.new(first: {:b, ""}, second: {:c, 0})
+    msg = %TestMsg.Oneof{first: {:b, ""}, second: {:c, 0}}
     assert Encoder.encode(msg) == <<18, 0, 24, 0>>
     # enum
-    msg = TestMsg.Oneof.new(first: {:e, :UNKNOWN})
+    msg = %TestMsg.Oneof{first: {:e, :UNKNOWN}}
     assert Encoder.encode(msg) == <<48, 0>>
     assert TestMsg.Oneof.decode(<<48, 0>>) == msg
 
     # proto3
     # int and string
-    msg = TestMsg.OneofProto3.new(first: {:a, 0}, second: {:d, ""})
+    msg = %TestMsg.OneofProto3{first: {:a, 0}, second: {:d, ""}}
     assert Encoder.encode(msg) == <<8, 0, 34, 0>>
     assert TestMsg.OneofProto3.encode(msg) == <<8, 0, 34, 0>>
-    msg = TestMsg.OneofProto3.new(first: {:b, ""}, second: {:c, 0})
+    msg = %TestMsg.OneofProto3{first: {:b, ""}, second: {:c, 0}}
     assert Encoder.encode(msg) == <<18, 0, 24, 0>>
     assert TestMsg.OneofProto3.encode(msg) == <<18, 0, 24, 0>>
     # enum
-    msg = TestMsg.OneofProto3.new(first: {:e, :UNKNOWN})
+    msg = %TestMsg.OneofProto3{first: {:e, :UNKNOWN}}
     assert Encoder.encode(msg) == <<48, 0>>
     assert TestMsg.OneofProto3.decode(<<48, 0>>) == msg
   end
 
   test "encodes proto3 optional fields zero values" do
-    msg = TestMsg.Proto3Optional.new(a: 0, c: :UNKNOWN)
+    msg = %TestMsg.Proto3Optional{a: 0, c: :UNKNOWN}
     assert Encoder.encode(msg) == <<8, 0, 24, 0>>
   end
 
   test "skips a proto3 optional field with a nil value" do
-    msg = TestMsg.Proto3Optional.new(a: nil, c: nil)
+    msg = %TestMsg.Proto3Optional{a: nil, c: nil}
     assert Encoder.encode(msg) == <<>>
   end
 
   test "encodes map with oneof" do
-    msg = Google.Protobuf.Struct.new(fields: %{"valid" => %{kind: {:bool_value, true}}})
+    msg = %Google.Protobuf.Struct{fields: %{"valid" => %{kind: {:bool_value, true}}}}
     bin = Google.Protobuf.Struct.encode(msg)
 
     assert Google.Protobuf.Struct.decode(bin) ==
-             Google.Protobuf.Struct.new(
+             %Google.Protobuf.Struct{
                fields: %{"valid" => %Google.Protobuf.Value{kind: {:bool_value, true}}}
-             )
+             }
   end
 
   test "encodes enum default value for proto2" do
     # Includes required
-    msg = TestMsg.EnumBar2.new(a: 0)
+    msg = %TestMsg.EnumBar2{a: 0}
     assert Encoder.encode(msg) == <<8, 0>>
 
     # Missing required field `:a` occurs a runtime error
-    msg = TestMsg.EnumBar2.new()
+    msg = %TestMsg.EnumBar2{}
 
     assert_raise Protobuf.EncodeError, ~r/Got error when encoding TestMsg.EnumBar2/, fn ->
       Encoder.encode(msg)
     end
 
-    msg = TestMsg.EnumFoo2.new()
+    msg = %TestMsg.EnumFoo2{}
     assert Encoder.encode(msg) == <<>>
 
     # Explicitly set the enum default value should be encoded, should not return it as ""
-    msg = TestMsg.EnumBar2.new(a: 0)
+    msg = %TestMsg.EnumBar2{a: 0}
     assert Encoder.encode(msg) == <<8, 0>>
 
-    msg = TestMsg.EnumBar2.new(a: 1)
+    msg = %TestMsg.EnumBar2{a: 1}
     assert Encoder.encode(msg) == <<8, 1>>
 
-    msg = TestMsg.EnumBar2.new(a: 0, b: 0)
+    msg = %TestMsg.EnumBar2{a: 0, b: 0}
     assert Encoder.encode(msg) == <<8, 0, 16, 0>>
 
-    msg = TestMsg.EnumBar2.new(a: 0, b: 1)
+    msg = %TestMsg.EnumBar2{a: 0, b: 1}
     assert Encoder.encode(msg) == <<8, 0, 16, 1>>
 
-    msg = TestMsg.EnumFoo2.new(a: 0)
+    msg = %TestMsg.EnumFoo2{a: 0}
     assert Encoder.encode(msg) == <<8, 0>>
 
-    msg = TestMsg.EnumFoo2.new(a: 1)
+    msg = %TestMsg.EnumFoo2{a: 1}
     assert Encoder.encode(msg) == <<8, 1>>
 
-    msg = TestMsg.EnumFoo2.new(b: 0)
+    msg = %TestMsg.EnumFoo2{b: 0}
     assert Encoder.encode(msg) == <<16, 0>>
 
-    msg = TestMsg.EnumFoo2.new(a: 0, b: 1)
+    msg = %TestMsg.EnumFoo2{a: 0, b: 1}
     assert Encoder.encode(msg) == <<8, 0, 16, 1>>
 
     # Proto2 enums that are not zero-based default to their first value declared.
-    msg = My.Test.Request.new(deadline: nil)
+    msg = %My.Test.Request{deadline: nil}
     assert Encoder.encode(msg) == <<>>
 
-    msg = My.Test.Request.new(deadline: nil, hat: 1)
+    msg = %My.Test.Request{deadline: nil, hat: 1}
     assert Encoder.encode(msg) == <<32, 1>>
 
-    msg = My.Test.Request.new(deadline: nil, hat: :FEDORA)
+    msg = %My.Test.Request{deadline: nil, hat: :FEDORA}
     assert Encoder.encode(msg) == <<>>
   end
 
   test "encodes oneof fields' default values for proto2" do
-    msg = TestMsg.Oneof.new(first: {:e, :A})
+    msg = %TestMsg.Oneof{first: {:e, :A}}
     assert Encoder.encode(msg) == <<48, 1>>
     assert TestMsg.Oneof.decode(<<48, 1>>) == msg
   end
@@ -265,7 +265,7 @@ defmodule Protobuf.EncoderTest do
   end
 
   test "encodes with transformer module when encoding struct contains a transformer module" do
-    msg = TestMsg.ContainsIntegerStringTransformModule.new(field: "42")
+    msg = %TestMsg.ContainsIntegerStringTransformModule{field: "42"}
     assert msg == %TestMsg.ContainsIntegerStringTransformModule{field: "42"}
 
     encoded = TestMsg.ContainsIntegerStringTransformModule.encode(msg)
@@ -282,7 +282,7 @@ defmodule Protobuf.EncoderTest do
   end
 
   test "NewTransform calls new/2 before encoding" do
-    msg = TestMsg.ContainsNewTransformModule.new(field: [field: 123])
+    msg = %TestMsg.ContainsNewTransformModule{field: [field: 123]}
     assert msg == %TestMsg.ContainsNewTransformModule{field: [field: 123]}
 
     assert TestMsg.ContainsNewTransformModule.decode(Encoder.encode(msg)) ==

--- a/test/protobuf/encoder_validation_test.exs
+++ b/test/protobuf/encoder_validation_test.exs
@@ -79,7 +79,7 @@ defmodule Protobuf.EncoderTest.Validation do
   end
 
   test "field is invalid" do
-    msg = TestMsg.Foo.new(a: "abc")
+    msg = %TestMsg.Foo{a: "abc"}
 
     assert_raise Protobuf.EncodeError, ~r/TestMsg.Foo#a.*Protobuf.EncodeError/, fn ->
       Protobuf.Encoder.encode(msg)
@@ -87,7 +87,7 @@ defmodule Protobuf.EncoderTest.Validation do
   end
 
   test "proto2 invalid when required field is nil" do
-    msg = TestMsg.Foo2.new(a: nil)
+    msg = %TestMsg.Foo2{a: nil}
 
     assert_raise Protobuf.EncodeError, ~r/TestMsg.Foo2#a.*Protobuf.EncodeError/, fn ->
       Protobuf.Encoder.encode(msg)
@@ -95,13 +95,13 @@ defmodule Protobuf.EncoderTest.Validation do
   end
 
   test "proto2 valid optional field is nil" do
-    msg = TestMsg.Foo2.new(a: 1, c: nil)
+    msg = %TestMsg.Foo2{a: 1, c: nil}
 
     assert Protobuf.Encoder.encode(msg)
   end
 
   test "oneof invalid format" do
-    msg = TestMsg.Oneof.new(first: 1)
+    msg = %TestMsg.Oneof{first: 1}
 
     assert_raise Protobuf.EncodeError, ~r/TestMsg.Oneof#first should be {key, val}/, fn ->
       Protobuf.Encoder.encode(msg)
@@ -109,7 +109,7 @@ defmodule Protobuf.EncoderTest.Validation do
   end
 
   test "oneof field doesn't match" do
-    msg = TestMsg.Oneof.new(first: {:c, 42})
+    msg = %TestMsg.Oneof{first: {:c, 42}}
 
     assert_raise Protobuf.EncodeError, ~r/:c doesn't belong to TestMsg.Oneof#first/, fn ->
       Protobuf.Encoder.encode(msg)
@@ -117,7 +117,7 @@ defmodule Protobuf.EncoderTest.Validation do
   end
 
   test "oneof field is invalid" do
-    msg = TestMsg.Oneof.new(first: {:a, "abc"})
+    msg = %TestMsg.Oneof{first: {:a, "abc"}}
 
     assert_raise Protobuf.EncodeError, ~r/TestMsg.Oneof#a.*Protobuf.EncodeError/, fn ->
       Protobuf.Encoder.encode(msg)
@@ -125,7 +125,7 @@ defmodule Protobuf.EncoderTest.Validation do
   end
 
   test "oneof field is non-existent" do
-    msg = TestMsg.OneofProto3.new(first: {:x, "foo"})
+    msg = %TestMsg.OneofProto3{first: {:x, "foo"}}
 
     assert_raise Protobuf.EncodeError, ~r/:x wasn't found in TestMsg.OneofProto3#first/, fn ->
       Protobuf.Encoder.encode(msg)
@@ -133,14 +133,14 @@ defmodule Protobuf.EncoderTest.Validation do
   end
 
   test "repeated field is not list" do
-    msg = TestMsg.Foo.new(g: 1)
+    msg = %TestMsg.Foo{g: 1}
 
     assert_raise Protobuf.EncodeError, ~r/TestMsg.Foo#g.*Protocol.UndefinedError/, fn ->
       Protobuf.Encoder.encode(msg)
     end
 
-    msg = TestMsg.Foo.new()
-    msg = %{msg | h: TestMsg.Foo.Bar.new()}
+    msg = %TestMsg.Foo{}
+    msg = %{msg | h: %TestMsg.Foo.Bar{}}
 
     assert_raise Protobuf.EncodeError, ~r/TestMsg.Foo#h.*Protocol.UndefinedError/, fn ->
       Protobuf.Encoder.encode(msg)
@@ -148,9 +148,9 @@ defmodule Protobuf.EncoderTest.Validation do
   end
 
   test "build embedded field map when encode" do
-    msg = TestMsg.Foo.new()
-    msg = %{msg | e: %{a: 1}}
-    msg1 = TestMsg.Foo.new(e: %{a: 1})
+    msg = %TestMsg.Foo{}
+    msg = %TestMsg.Foo{msg | e: %{a: 1}}
+    msg1 = %TestMsg.Foo{e: %{a: 1}}
 
     assert Protobuf.Encoder.encode(msg) == Protobuf.Encoder.encode(msg1)
   end

--- a/test/protobuf/extension_test.exs
+++ b/test/protobuf/extension_test.exs
@@ -29,7 +29,7 @@ defmodule Protobuf.ExtensionTest do
 
   test "simple types work" do
     bin = <<186, 65, 3, 97, 98, 99>>
-    msg = Ext.Foo2.new()
+    msg = %Ext.Foo2{}
     msg = Ext.Foo2.put_extension(msg, Ext.PbExtension, :bar, "abc")
     assert bin == Ext.Foo2.encode(msg)
 
@@ -40,8 +40,8 @@ defmodule Protobuf.ExtensionTest do
 
   test "nested types work" do
     bin = <<186, 65, 5, 10, 3, 97, 98, 99>>
-    msg = Ext.Foo1.new()
-    ext_msg = Ext.Options.new(a: "abc")
+    msg = %Ext.Foo1{}
+    ext_msg = %Ext.Options{a: "abc"}
     msg = Ext.Foo1.put_extension(msg, Ext.PbExtension, :foo, ext_msg)
     assert bin == Ext.Foo2.encode(msg)
 
@@ -52,7 +52,7 @@ defmodule Protobuf.ExtensionTest do
 
   test "enum types work" do
     bin = <<192, 65, 2>>
-    msg = Ext.Foo1.new()
+    msg = %Ext.Foo1{}
     msg = Ext.Foo1.put_extension(msg, Ext.PbExtension, :"Parent.foo", :B)
     assert bin == Ext.Foo1.encode(msg)
 

--- a/test/protobuf/json/decode_test.exs
+++ b/test/protobuf/json/decode_test.exs
@@ -26,7 +26,7 @@ defmodule Protobuf.JSON.DecodeTest do
   describe "strings" do
     test "utf-8 is valid" do
       data = %{"string" => "エリクサー"}
-      decoded = Scalars.new!(string: "エリクサー")
+      decoded = %Scalars{string: "エリクサー"}
       assert decode(data, Scalars) == {:ok, decoded}
     end
 
@@ -46,7 +46,7 @@ defmodule Protobuf.JSON.DecodeTest do
   describe "booleans" do
     test "actual boolean is valid" do
       data = %{"bool" => true}
-      decoded = Scalars.new!(bool: true)
+      decoded = %Scalars{bool: true}
       assert decode(data, Scalars) == {:ok, decoded}
     end
 
@@ -66,53 +66,53 @@ defmodule Protobuf.JSON.DecodeTest do
   describe "integers" do
     test "integer value is valid" do
       data = %{"int32" => 999}
-      decoded = Scalars.new!(int32: 999)
+      decoded = %Scalars{int32: 999}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"sint32" => 999}
-      decoded = Scalars.new!(sint32: 999)
+      decoded = %Scalars{sint32: 999}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"fixed64" => 999}
-      decoded = Scalars.new!(fixed64: 999)
+      decoded = %Scalars{fixed64: 999}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"sfixed64" => 999}
-      decoded = Scalars.new!(sfixed64: 999)
+      decoded = %Scalars{sfixed64: 999}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"int32" => -999}
-      decoded = Scalars.new!(int32: -999)
+      decoded = %Scalars{int32: -999}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"sint32" => -999}
-      decoded = Scalars.new!(sint32: -999)
+      decoded = %Scalars{sint32: -999}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"fixed64" => -999}
-      decoded = Scalars.new!(fixed64: -999)
+      decoded = %Scalars{fixed64: -999}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"sfixed64" => -999}
-      decoded = Scalars.new!(sfixed64: -999)
+      decoded = %Scalars{sfixed64: -999}
       assert decode(data, Scalars) == {:ok, decoded}
     end
 
     test "string value is valid" do
       data = %{"fixed32" => "999"}
-      decoded = Scalars.new!(fixed32: 999)
+      decoded = %Scalars{fixed32: 999}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"sfixed32" => "-999"}
-      decoded = Scalars.new!(sfixed32: -999)
+      decoded = %Scalars{sfixed32: -999}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"int64" => "\u0031\u0032"}
-      decoded = Scalars.new!(int64: 12)
+      decoded = %Scalars{int64: 12}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"sint64" => "\u0031\u0032"}
-      decoded = Scalars.new!(sint64: 12)
+      decoded = %Scalars{sint64: 12}
       assert decode(data, Scalars) == {:ok, decoded}
     end
 
@@ -219,7 +219,7 @@ defmodule Protobuf.JSON.DecodeTest do
       ]
 
       for int_type <- int_types do
-        decoded = Scalars.new!([{int_type, 100_000}])
+        decoded = struct!(Scalars, [{int_type, 100_000}])
         assert decode(%{Atom.to_string(int_type) => 1.0e5}, Scalars) == {:ok, decoded}
       end
     end
@@ -228,43 +228,43 @@ defmodule Protobuf.JSON.DecodeTest do
   describe "floating point" do
     test "float value is valid" do
       data = %{"float" => 1.234, "double" => 5.6789}
-      decoded = Scalars.new!(float: 1.234, double: 5.6789)
+      decoded = %Scalars{float: 1.234, double: 5.6789}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"float" => -1.234, "double" => -5.6789}
-      decoded = Scalars.new!(float: -1.234, double: -5.6789)
+      decoded = %Scalars{float: -1.234, double: -5.6789}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"float" => 1.23e3, "double" => 1.23e-2}
-      decoded = Scalars.new!(float: 1230.0, double: 0.0123)
+      decoded = %Scalars{float: 1230.0, double: 0.0123}
       assert decode(data, Scalars) == {:ok, decoded}
     end
 
     test "constants are valid" do
       data = %{"float" => "NaN", "double" => "NaN"}
-      decoded = Scalars.new!(float: :nan, double: :nan)
+      decoded = %Scalars{float: :nan, double: :nan}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"float" => "Infinity", "double" => "Infinity"}
-      decoded = Scalars.new!(float: :infinity, double: :infinity)
+      decoded = %Scalars{float: :infinity, double: :infinity}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"float" => "-Infinity", "double" => "-Infinity"}
-      decoded = Scalars.new!(float: :negative_infinity, double: :negative_infinity)
+      decoded = %Scalars{float: :negative_infinity, double: :negative_infinity}
       assert decode(data, Scalars) == {:ok, decoded}
     end
 
     test "string value is valid" do
       data = %{"float" => "1.234", "double" => "5.6789"}
-      decoded = Scalars.new!(float: 1.234, double: 5.6789)
+      decoded = %Scalars{float: 1.234, double: 5.6789}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"float" => "-1.234", "double" => "-5.6789"}
-      decoded = Scalars.new!(float: -1.234, double: -5.6789)
+      decoded = %Scalars{float: -1.234, double: -5.6789}
       assert decode(data, Scalars) == {:ok, decoded}
 
       data = %{"float" => "1.23e3", "double" => "1.23e-2"}
-      decoded = Scalars.new!(float: 1230.0, double: 0.0123)
+      decoded = %Scalars{float: 1230.0, double: 0.0123}
       assert decode(data, Scalars) == {:ok, decoded}
     end
 
@@ -300,25 +300,25 @@ defmodule Protobuf.JSON.DecodeTest do
   describe "bytes" do
     test "Base64 encoded string with padding is valid" do
       data = %{"bytes" => "dGhpcyB3b3Jrcw=="}
-      decoded = Scalars.new!(bytes: "this works")
+      decoded = %Scalars{bytes: "this works"}
       assert decode(data, Scalars) == {:ok, decoded}
     end
 
     test "Base64 encoded string without padding is valid" do
       data = %{"bytes" => "dGhpcyB3b3Jrcw"}
-      decoded = Scalars.new!(bytes: "this works")
+      decoded = %Scalars{bytes: "this works"}
       assert decode(data, Scalars) == {:ok, decoded}
     end
 
     test "Base64 URL-encoded string with padding is valid" do
       data = %{"bytes" => "cGx1cyBzaWduICsgc2xhc2ggLw=="}
-      decoded = Scalars.new!(bytes: "plus sign + slash /")
+      decoded = %Scalars{bytes: "plus sign + slash /"}
       assert decode(data, Scalars) == {:ok, decoded}
     end
 
     test "Base64 URL-encoded string without padding is valid" do
       data = %{"bytes" => "cGx1cyBzaWduICsgc2xhc2ggLw"}
-      decoded = Scalars.new!(bytes: "plus sign + slash /")
+      decoded = %Scalars{bytes: "plus sign + slash /"}
       assert decode(data, Scalars) == {:ok, decoded}
     end
 
@@ -342,19 +342,19 @@ defmodule Protobuf.JSON.DecodeTest do
   describe "enums" do
     test "known integer value is valid" do
       data = %{"j" => 4}
-      decoded = Foo.new!(j: :E)
+      decoded = %Foo{j: :E}
       assert decode(data, Foo) == {:ok, decoded}
     end
 
     test "known string value is valid" do
       data = %{"j" => "C"}
-      decoded = Foo.new!(j: :C)
+      decoded = %Foo{j: :C}
       assert decode(data, Foo) == {:ok, decoded}
     end
 
     test "unknown integer value is valid" do
       data = %{"j" => 999}
-      decoded = Foo.new!(j: 999)
+      decoded = %Foo{j: 999}
       assert decode(data, Foo) == {:ok, decoded}
     end
 
@@ -400,7 +400,7 @@ defmodule Protobuf.JSON.DecodeTest do
       mapii = %{-1 => -1, 0 => 0, 1 => 1, 999_999_999 => 999_999_999}
       mapbi = %{true => 1, false => 0}
       mapsi = %{"" => 0, "三" => 3, "meaning" => 42}
-      decoded = Maps.new!(mapii: mapii, mapbi: mapbi, mapsi: mapsi)
+      decoded = %Maps{mapii: mapii, mapbi: mapbi, mapsi: mapsi}
 
       assert decode(data, Maps) == {:ok, decoded}
     end
@@ -462,21 +462,21 @@ defmodule Protobuf.JSON.DecodeTest do
   describe "embedded" do
     test "decodes embedded messages" do
       data = %{"e" => %{"a" => 12, "b" => "abc"}, "f" => 2}
-      decoded = Foo.new!(e: Bar.new!(a: 12, b: "abc"), f: 2)
+      decoded = %Foo{e: %Bar{a: 12, b: "abc"}, f: 2}
       assert decode(data, Foo) == {:ok, decoded}
     end
 
     test "empty map is valid" do
-      assert decode(%{}, Parent) == {:ok, Parent.new()}
+      assert decode(%{}, Parent) == {:ok, %Parent{}}
 
       data = %{"child" => %{"parent" => %{}}}
-      decoded = Parent.new!(child: Child.new!(parent: Parent.new()))
+      decoded = %Parent{child: %Child{parent: %Parent{}}}
       assert decode(data, Parent) == {:ok, decoded}
     end
 
     test "null value is ignored" do
       data = %{"child" => nil}
-      decoded = Parent.new()
+      decoded = %Parent{}
       assert decode(data, Parent) == {:ok, decoded}
     end
 
@@ -502,19 +502,19 @@ defmodule Protobuf.JSON.DecodeTest do
   describe "oneofs" do
     test "decodes oneof fields" do
       data = %{"a" => 1, "d" => "d", "other" => "other"}
-      decoded = OneofProto3.new!(first: {:a, 1}, second: {:d, "d"}, other: "other")
+      decoded = %OneofProto3{first: {:a, 1}, second: {:d, "d"}, other: "other"}
       assert decode(data, OneofProto3) == {:ok, decoded}
     end
 
     test "unset" do
       data = %{}
-      decoded = OneofProto3.new()
+      decoded = %OneofProto3{}
       assert decode(data, OneofProto3) == {:ok, decoded}
     end
 
     test "set to default value" do
       data = %{"a" => 0, "d" => ""}
-      decoded = OneofProto3.new(first: {:a, 0}, second: {:d, ""})
+      decoded = %OneofProto3{first: {:a, 0}, second: {:d, ""}}
       assert decode(data, OneofProto3) == {:ok, decoded}
 
       defmodule BooleanOneof do
@@ -523,9 +523,11 @@ defmodule Protobuf.JSON.DecodeTest do
         field :bool, 1, type: :bool, oneof: 0
       end
 
+      mod = BooleanOneof
+
       data = %{"bool" => false}
-      decoded = BooleanOneof.new(zero: {:bool, false})
-      assert decode(data, BooleanOneof) == {:ok, decoded}
+      decoded = struct!(mod, zero: {:bool, false})
+      assert decode(data, mod) == {:ok, decoded}
     end
 
     test "multiple non-null fields set in a single oneof is invalid" do
@@ -536,11 +538,11 @@ defmodule Protobuf.JSON.DecodeTest do
 
     test "multiple fields set in a single oneof, one being non-null, is valid" do
       data = %{"a" => 42, "b" => nil}
-      decoded = OneofProto3.new(first: {:a, 42})
+      decoded = %OneofProto3{first: {:a, 42}}
       assert decode(data, OneofProto3) == {:ok, decoded}
 
       data = %{"a" => nil, "b" => "valid"}
-      decoded = OneofProto3.new(first: {:b, "valid"})
+      decoded = %OneofProto3{first: {:b, "valid"}}
       assert decode(data, OneofProto3) == {:ok, decoded}
     end
   end
@@ -553,8 +555,7 @@ defmodule Protobuf.JSON.DecodeTest do
         "o" => ["UNKNOWN", 1, "B", 999]
       }
 
-      decoded =
-        Foo.new!(g: [1, 2], h: [Bar.new(a: 1), Bar.new(b: "b")], o: [:UNKNOWN, :A, :B, 999])
+      decoded = %Foo{g: [1, 2], h: [%Bar{a: 1}, %Bar{b: "b"}], o: [:UNKNOWN, :A, :B, 999]}
 
       assert decode(data, Foo) == {:ok, decoded}
     end
@@ -582,7 +583,7 @@ defmodule Protobuf.JSON.DecodeTest do
 
   test "unknown fields are ignored" do
     data = %{"a" => 1, "unknown" => 2, false => true, "e" => %{"a" => 2, 3 => 4}}
-    decoded = Foo.new!(a: 1, e: Bar.new!(a: 2))
+    decoded = %Foo{a: 1, e: %Bar{a: 2}}
     assert decode(data, Foo) == {:ok, decoded}
   end
 
@@ -607,7 +608,7 @@ defmodule Protobuf.JSON.DecodeTest do
       "p" => nil
     }
 
-    assert decode(data, Foo) == {:ok, Foo.new(e: Bar.new())}
+    assert decode(data, Foo) == {:ok, %Foo{e: %Bar{}}}
   end
 
   test "recognizes default values" do
@@ -631,7 +632,7 @@ defmodule Protobuf.JSON.DecodeTest do
       "p" => ""
     }
 
-    assert decode(data, Foo) == {:ok, Foo.new(e: Bar.new())}
+    assert decode(data, Foo) == {:ok, %Foo{e: %Bar{}}}
   end
 
   test "decodes with transformer module" do
@@ -657,7 +658,7 @@ defmodule Protobuf.JSON.DecodeTest do
       data = %{}
 
       assert decode(data, Google.Protobuf.Empty) ==
-               {:ok, Google.Protobuf.Empty.new!([])}
+               {:ok, %Google.Protobuf.Empty{}}
     end
 
     test "Google.Protobuf.BoolValue" do
@@ -667,9 +668,9 @@ defmodule Protobuf.JSON.DecodeTest do
 
       assert decode(data, TestAllTypesProto3) ==
                {:ok,
-                TestAllTypesProto3.new(
-                  optional_bool_wrapper: Google.Protobuf.BoolValue.new!(value: true)
-                )}
+                %TestAllTypesProto3{
+                  optional_bool_wrapper: %Google.Protobuf.BoolValue{value: true}
+                }}
     end
 
     test "Google.Protobuf.Int32Value" do
@@ -679,9 +680,9 @@ defmodule Protobuf.JSON.DecodeTest do
 
       assert decode(data, TestAllTypesProto3) ==
                {:ok,
-                TestAllTypesProto3.new(
-                  optional_int32_wrapper: Google.Protobuf.Int32Value.new!(value: 100)
-                )}
+                %TestAllTypesProto3{
+                  optional_int32_wrapper: %Google.Protobuf.Int32Value{value: 100}
+                }}
     end
 
     test "Google.Protobuf.UInt32Value" do
@@ -691,9 +692,9 @@ defmodule Protobuf.JSON.DecodeTest do
 
       assert decode(data, TestAllTypesProto3) ==
                {:ok,
-                TestAllTypesProto3.new(
-                  optional_uint32_wrapper: Google.Protobuf.UInt32Value.new!(value: 100)
-                )}
+                %TestAllTypesProto3{
+                  optional_uint32_wrapper: %Google.Protobuf.UInt32Value{value: 100}
+                }}
     end
 
     test "Google.Protobuf.Int64Value" do
@@ -703,9 +704,9 @@ defmodule Protobuf.JSON.DecodeTest do
 
       assert decode(data, TestAllTypesProto3) ==
                {:ok,
-                TestAllTypesProto3.new(
-                  optional_int64_wrapper: Google.Protobuf.Int64Value.new!(value: 100)
-                )}
+                %TestAllTypesProto3{
+                  optional_int64_wrapper: %Google.Protobuf.Int64Value{value: 100}
+                }}
     end
 
     test "Google.Protobuf.UInt64Value" do
@@ -715,9 +716,9 @@ defmodule Protobuf.JSON.DecodeTest do
 
       assert decode(data, TestAllTypesProto3) ==
                {:ok,
-                TestAllTypesProto3.new(
-                  optional_uint64_wrapper: Google.Protobuf.UInt64Value.new!(value: 100)
-                )}
+                %TestAllTypesProto3{
+                  optional_uint64_wrapper: %Google.Protobuf.UInt64Value{value: 100}
+                }}
     end
 
     test "Google.Protobuf.FloatValue" do
@@ -727,9 +728,9 @@ defmodule Protobuf.JSON.DecodeTest do
 
       assert decode(data, TestAllTypesProto3) ==
                {:ok,
-                TestAllTypesProto3.new(
-                  optional_float_wrapper: Google.Protobuf.FloatValue.new!(value: 3.14)
-                )}
+                %TestAllTypesProto3{
+                  optional_float_wrapper: %Google.Protobuf.FloatValue{value: 3.14}
+                }}
     end
 
     test "Google.Protobuf.DoubleValue" do
@@ -739,9 +740,9 @@ defmodule Protobuf.JSON.DecodeTest do
 
       assert decode(data, TestAllTypesProto3) ==
                {:ok,
-                TestAllTypesProto3.new(
-                  optional_double_wrapper: Google.Protobuf.DoubleValue.new!(value: 3.14444)
-                )}
+                %TestAllTypesProto3{
+                  optional_double_wrapper: %Google.Protobuf.DoubleValue{value: 3.14444}
+                }}
     end
 
     test "Google.Protobuf.StringValue" do
@@ -751,9 +752,9 @@ defmodule Protobuf.JSON.DecodeTest do
 
       assert decode(data, TestAllTypesProto3) ==
                {:ok,
-                TestAllTypesProto3.new(
-                  optional_string_wrapper: Google.Protobuf.StringValue.new!(value: "my string")
-                )}
+                %TestAllTypesProto3{
+                  optional_string_wrapper: %Google.Protobuf.StringValue{value: "my string"}
+                }}
     end
 
     test "Google.Protobuf.BytesValue" do
@@ -763,9 +764,9 @@ defmodule Protobuf.JSON.DecodeTest do
 
       assert decode(data, TestAllTypesProto3) ==
                {:ok,
-                TestAllTypesProto3.new(
-                  optional_bytes_wrapper: Google.Protobuf.BytesValue.new!(value: <<1, 2, 3>>)
-                )}
+                %TestAllTypesProto3{
+                  optional_bytes_wrapper: %Google.Protobuf.BytesValue{value: <<1, 2, 3>>}
+                }}
     end
 
     test "Google.Protobuf.FieldMask with empty field mask" do
@@ -780,9 +781,9 @@ defmodule Protobuf.JSON.DecodeTest do
 
         assert decode(data, TestAllTypesProto3) ==
                  {:ok,
-                  TestAllTypesProto3.new(
-                    optional_field_mask: Google.Protobuf.FieldMask.new!(paths: expected_paths)
-                  )}
+                  %TestAllTypesProto3{
+                    optional_field_mask: %Google.Protobuf.FieldMask{paths: expected_paths}
+                  }}
       end
 
       # Error with bad type.
@@ -805,35 +806,35 @@ defmodule Protobuf.JSON.DecodeTest do
 
       assert decode(data, TestAllTypesProto3) ==
                {:ok,
-                TestAllTypesProto3.new(
+                %TestAllTypesProto3{
                   repeated_list_value: [
-                    Google.Protobuf.ListValue.new!(
+                    %Google.Protobuf.ListValue{
                       values: [
-                        Google.Protobuf.Value.new!(kind: {:number_value, 1.0}),
-                        Google.Protobuf.Value.new!(kind: {:string_value, "two"}),
-                        Google.Protobuf.Value.new!(kind: {:number_value, 3.14}),
-                        Google.Protobuf.Value.new!(kind: {:bool_value, true}),
-                        Google.Protobuf.Value.new!(kind: {:null_value, :NULL_VALUE})
+                        %Google.Protobuf.Value{kind: {:number_value, 1.0}},
+                        %Google.Protobuf.Value{kind: {:string_value, "two"}},
+                        %Google.Protobuf.Value{kind: {:number_value, 3.14}},
+                        %Google.Protobuf.Value{kind: {:bool_value, true}},
+                        %Google.Protobuf.Value{kind: {:null_value, :NULL_VALUE}}
                       ]
-                    ),
-                    Google.Protobuf.ListValue.new!(
+                    },
+                    %Google.Protobuf.ListValue{
                       values: [
-                        Google.Protobuf.Value.new!(
+                        %Google.Protobuf.Value{
                           kind:
                             {:struct_value,
-                             Google.Protobuf.Struct.new!(
+                             %Google.Protobuf.Struct{
                                fields: %{
-                                 "foo" => Google.Protobuf.Value.new!(kind: {:string_value, "bar"})
+                                 "foo" => %Google.Protobuf.Value{kind: {:string_value, "bar"}}
                                }
-                             )}
-                        ),
-                        Google.Protobuf.Value.new!(
-                          kind: {:list_value, Google.Protobuf.ListValue.new!(values: [])}
-                        )
+                             }}
+                        },
+                        %Google.Protobuf.Value{
+                          kind: {:list_value, %Google.Protobuf.ListValue{values: []}}
+                        }
                       ]
-                    )
+                    }
                   ]
-                )}
+                }}
     end
 
     test "Google.Protobuf.Duration" do
@@ -850,8 +851,10 @@ defmodule Protobuf.JSON.DecodeTest do
       for %{string: string, seconds: expected_seconds, nanos: expected_nanos} <- cases do
         data = %{"optionalDuration" => string}
 
-        expected_duration =
-          Google.Protobuf.Duration.new!(seconds: expected_seconds, nanos: expected_nanos)
+        expected_duration = %Google.Protobuf.Duration{
+          seconds: expected_seconds,
+          nanos: expected_nanos
+        }
 
         assert {:ok, decoded} = decode(data, TestAllTypesProto3)
         assert decoded.optional_duration == expected_duration
@@ -898,11 +901,11 @@ defmodule Protobuf.JSON.DecodeTest do
       assert {:ok, decoded} = decode(data, TestAllTypesProto3)
 
       assert decoded.optional_any ==
-               Google.Protobuf.Any.new!(
+               %Google.Protobuf.Any{
                  type_url: "type.googleapis.com/google.protobuf.Int32Value",
                  value:
-                   Google.Protobuf.Int32Value.encode(Google.Protobuf.Int32Value.new!(value: 1234))
-               )
+                   Google.Protobuf.Int32Value.encode(%Google.Protobuf.Int32Value{value: 1234})
+               }
     end
 
     test "with nested Any with Int32Value inside" do
@@ -919,19 +922,15 @@ defmodule Protobuf.JSON.DecodeTest do
       assert {:ok, decoded} = decode(data, TestAllTypesProto3)
 
       assert decoded.optional_any ==
-               Google.Protobuf.Any.new!(
+               %Google.Protobuf.Any{
                  type_url: "type.googleapis.com/google.protobuf.Any",
                  value:
-                   Google.Protobuf.Any.encode(
-                     Google.Protobuf.Any.new(
-                       type_url: "type.googleapis.com/google.protobuf.Int32Value",
-                       value:
-                         Google.Protobuf.Int32Value.encode(
-                           Google.Protobuf.Int32Value.new!(value: 1234)
-                         )
-                     )
-                   )
-               )
+                   Google.Protobuf.Any.encode(%Google.Protobuf.Any{
+                     type_url: "type.googleapis.com/google.protobuf.Int32Value",
+                     value:
+                       Google.Protobuf.Int32Value.encode(%Google.Protobuf.Int32Value{value: 1234})
+                   })
+               }
     end
   end
 end

--- a/test/protobuf/json/encode_test.exs
+++ b/test/protobuf/json/encode_test.exs
@@ -14,17 +14,13 @@ defmodule Protobuf.JSON.EncodeTest do
     Scalars
   }
 
-  def encode(struct, opts \\ []) do
-    Protobuf.JSON.Encode.to_encodable(struct, opts)
-  end
-
   test "encodes strings and booleans as they are" do
-    message = Scalars.new!(string: "エリクサー", bool: true)
+    message = %Scalars{string: "エリクサー", bool: true}
     assert encode(message) == %{"string" => "エリクサー", "bool" => true}
   end
 
   test "encodes 32-bit integers as they are" do
-    message = Scalars.new!(int32: 42, uint32: 42, sint32: 42, fixed32: 42, sfixed32: 42)
+    message = %Scalars{int32: 42, uint32: 42, sint32: 42, fixed32: 42, sfixed32: 42}
 
     encoded = %{
       "int32" => 42,
@@ -36,7 +32,7 @@ defmodule Protobuf.JSON.EncodeTest do
 
     assert encode(message) == encoded
 
-    message = Scalars.new!(int32: -42, uint32: -42, sint32: -42, fixed32: -42, sfixed32: -42)
+    message = %Scalars{int32: -42, uint32: -42, sint32: -42, fixed32: -42, sfixed32: -42}
 
     encoded = %{
       "int32" => -42,
@@ -50,7 +46,7 @@ defmodule Protobuf.JSON.EncodeTest do
   end
 
   test "encodes 64-bit integers as strings" do
-    message = Scalars.new!(int64: 42, uint64: 42, sint64: 42, fixed64: 42, sfixed64: 42)
+    message = %Scalars{int64: 42, uint64: 42, sint64: 42, fixed64: 42, sfixed64: 42}
 
     encoded = %{
       "int64" => "42",
@@ -62,7 +58,7 @@ defmodule Protobuf.JSON.EncodeTest do
 
     assert encode(message) == encoded
 
-    message = Scalars.new!(int64: -42, uint64: -42, sint64: -42, fixed64: -42, sfixed64: -42)
+    message = %Scalars{int64: -42, uint64: -42, sint64: -42, fixed64: -42, sfixed64: -42}
 
     encoded = %{
       "int64" => "-42",
@@ -76,79 +72,79 @@ defmodule Protobuf.JSON.EncodeTest do
   end
 
   test "encodes floats and doubles as JSON numbers" do
-    message = Scalars.new!(float: 1.234, double: 1.23456789)
+    message = %Scalars{float: 1.234, double: 1.23456789}
     assert encode(message) == %{"float" => 1.234, "double" => 1.23456789}
 
-    message = Scalars.new!(float: 1.23e3, double: 1.23e-300)
+    message = %Scalars{float: 1.23e3, double: 1.23e-300}
     assert encode(message) == %{"float" => 1230.0, "double" => 1.23e-300}
   end
 
   test "encodes non-numeric floats and doubles" do
-    message = Scalars.new!(float: :nan, double: :nan)
+    message = %Scalars{float: :nan, double: :nan}
     assert encode(message) == %{"float" => "NaN", "double" => "NaN"}
 
-    message = Scalars.new!(float: :infinity, double: :infinity)
+    message = %Scalars{float: :infinity, double: :infinity}
     assert encode(message) == %{"float" => "Infinity", "double" => "Infinity"}
 
-    message = Scalars.new!(float: :negative_infinity, double: :negative_infinity)
+    message = %Scalars{float: :negative_infinity, double: :negative_infinity}
     assert encode(message) == %{"float" => "-Infinity", "double" => "-Infinity"}
   end
 
   test "encodes bytes in Base64 with padding" do
-    message = Scalars.new!(bytes: "abcde")
+    message = %Scalars{bytes: "abcde"}
     assert encode(message) == %{"bytes" => "YWJjZGU="}
 
-    message = Scalars.new!(bytes: <<0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF>>)
+    message = %Scalars{bytes: <<0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF>>}
     assert encode(message) == %{"bytes" => "/////////w=="}
   end
 
   test "encodes enums" do
-    message = Foo.new!(j: 2, m: :C)
+    message = %Foo{j: 2, m: :C}
     assert encode(message) == %{"j" => :B, "m" => :C}
 
-    message = Foo.new!(j: 0, m: :UNKNOWN)
+    message = %Foo{j: 0, m: :UNKNOWN}
     assert encode(message) == %{}
 
     # proto3 accepts numeric unknown values
-    message = Foo.new!(j: -999)
+    message = %Foo{j: -999}
     assert encode(message) == %{"j" => -999}
   end
 
   test "encodes all enums as numbers when use_enum_numbers is on" do
-    message = Foo.new!(j: 2, m: :C)
+    message = %Foo{j: 2, m: :C}
     assert encode(message, use_enum_numbers: true) == %{"j" => 2, "m" => 4}
   end
 
   test "encodes oneof fields" do
-    message = OneofProto3.new!(first: {:a, 1}, second: {:d, "d"}, other: "other")
+    message = %OneofProto3{first: {:a, 1}, second: {:d, "d"}, other: "other"}
     assert encode(message) == %{"a" => 1, "d" => "d", "other" => "other"}
   end
 
   test "skips unset oneof fields" do
-    message = OneofProto3.new!(first: {:a, 1}, other: "other")
+    message = %OneofProto3{first: {:a, 1}, other: "other"}
     assert encode(message) == %{"a" => 1, "other" => "other"}
   end
 
   test "always emits set oneof fields, even if to their default values" do
-    message = OneofProto3.new!(first: {:a, 0}, second: {:d, ""})
+    message = %OneofProto3{first: {:a, 0}, second: {:d, ""}}
 
     assert encode(message) == %{"a" => 0, "d" => ""}
     assert encode(message, emit_unpopulated: true) == %{"a" => 0, "d" => "", "other" => ""}
   end
 
   test "encodes embedded" do
-    message = Foo.new!(e: Bar.new!(a: 12, b: "abc"), f: 2)
+    message = %Foo{e: %Bar{a: 12, b: "abc"}, f: 2}
     assert encode(message) == %{"e" => %{"a" => 12, "b" => "abc"}, "f" => 2}
 
-    message = Parent.new!(child: Child.new!(parent: Parent.new()))
+    message = %Parent{child: %Child{parent: %Parent{}}}
     assert encode(message) == %{"child" => %{"parent" => %{}}}
 
-    message = Parent.new!(child: nil)
+    message = %Parent{child: nil}
     assert encode(message) == %{}
   end
 
   test "encodes repeated" do
-    message = Foo.new!(g: [1, 2], h: [Bar.new(a: 1), Bar.new(b: "b")], o: [:UNKNOWN, 1, :B])
+    message = %Foo{g: [1, 2], h: [%Bar{a: 1}, %Bar{b: "b"}], o: [:UNKNOWN, 1, :B]}
 
     encoded = %{
       "g" => [1, 2],
@@ -160,17 +156,17 @@ defmodule Protobuf.JSON.EncodeTest do
   end
 
   test "encodes maps" do
-    message = Foo.new!(l: %{"foo" => 123, "bar" => 456})
+    message = %Foo{l: %{"foo" => 123, "bar" => 456}}
     assert encode(message) == %{"l" => %{"foo" => 123, "bar" => 456}}
   end
 
   test "skips empty maps" do
-    message = Foo.new!(l: %{})
+    message = %Foo{l: %{}}
     assert encode(message) == %{}
   end
 
   test "map values are always emitted, even when equal to their default" do
-    message = Foo.new!(l: %{"foo" => 123, "bar" => 0})
+    message = %Foo{l: %{"foo" => 123, "bar" => 0}}
     assert encode(message) == %{"l" => %{"foo" => 123, "bar" => 0}}
   end
 
@@ -178,7 +174,7 @@ defmodule Protobuf.JSON.EncodeTest do
     mapii = %{-1 => -1, 0 => 0, 1 => 1, 0b11 => 3, 0xFF => 255}
     mapbi = %{true => 1, false => 0}
     mapsi = %{"" => 0, "ok" => 999_999_999}
-    message = Maps.new!(mapii: mapii, mapbi: mapbi, mapsi: mapsi)
+    message = %Maps{mapii: mapii, mapbi: mapbi, mapsi: mapsi}
 
     encoded = %{
       "mapii" => %{"-1" => -1, "0" => 0, "1" => 1, "3" => 3, "255" => 255},
@@ -190,7 +186,7 @@ defmodule Protobuf.JSON.EncodeTest do
   end
 
   test "nil map values remain nil" do
-    message = Foo.new!(l: %{"foo" => nil})
+    message = %Foo{l: %{"foo" => nil}}
     assert encode(message) == %{"l" => %{"foo" => nil}}
   end
 
@@ -204,12 +200,12 @@ defmodule Protobuf.JSON.EncodeTest do
     end
 
     test "use :json_name or fall back to :name by default" do
-      message = Naming.new!(simple: 1, camel_case: 2, custom: 3)
+      message = %Naming{simple: 1, camel_case: 2, custom: 3}
       assert encode(message) == %{"simple" => 1, "camelCase" => 2, "customName" => 3}
     end
 
     test "are :name when :use_proto_names is on" do
-      message = Naming.new!(simple: 1, camel_case: 2, custom: 3)
+      message = %Naming{simple: 1, camel_case: 2, custom: 3}
       encoded = %{"simple" => 1, "camel_case" => 2, "custom" => 3}
       assert encode(message, use_proto_names: true) == encoded
     end
@@ -238,93 +234,85 @@ defmodule Protobuf.JSON.EncodeTest do
 
     bar = %{"a" => 0, "b" => ""}
 
-    message = Foo.new()
+    message = %Foo{}
     assert encode(message, emit_unpopulated: true) == decoded
 
-    message = Foo.new(e: Bar.new())
+    message = %Foo{e: %Bar{}}
     assert encode(message, emit_unpopulated: true) == %{decoded | "e" => bar}
 
-    message = Foo.new(h: [Bar.new(), Bar.new()])
+    message = %Foo{h: [%Bar{}, %Bar{}]}
     assert encode(message, emit_unpopulated: true) == %{decoded | "h" => [bar, bar]}
   end
 
   test "encodes with transformer module" do
-    assert Protobuf.JSON.encode!(ContainsTransformModule.new(field: 123)) ==
+    assert Protobuf.JSON.encode!(%ContainsTransformModule{field: 123}) ==
              ~S|{"field":{"field":123}}|
 
-    assert Protobuf.JSON.encode!(ContainsTransformModule.new(field: 0)) == ~S|{}|
-    assert Protobuf.JSON.encode!(ContainsTransformModule.new(field: nil)) == ~S|{}|
+    assert Protobuf.JSON.encode!(%ContainsTransformModule{field: 0}) == ~S|{}|
+    assert Protobuf.JSON.encode!(%ContainsTransformModule{field: nil}) == ~S|{}|
   end
 
   describe "Google.Protobuf.* value wrappers" do
     test "Google.Protobuf.BoolValue" do
-      message =
-        TestAllTypesProto3.new!(
-          optional_bool_wrapper: Google.Protobuf.BoolValue.new!(value: true)
-        )
+      message = %TestAllTypesProto3{
+        optional_bool_wrapper: %Google.Protobuf.BoolValue{value: true}
+      }
 
       assert encode(message) == %{"optionalBoolWrapper" => true}
     end
 
     test "Google.Protobuf.StringValue" do
-      message =
-        TestAllTypesProto3.new!(
-          optional_string_wrapper: Google.Protobuf.StringValue.new!(value: "foo")
-        )
+      message = %TestAllTypesProto3{
+        optional_string_wrapper: %Google.Protobuf.StringValue{value: "foo"}
+      }
 
       assert encode(message) == %{"optionalStringWrapper" => "foo"}
     end
 
     test "Google.Protobuf.FloatValue" do
-      message =
-        TestAllTypesProto3.new!(
-          optional_float_wrapper: Google.Protobuf.FloatValue.new!(value: 3.14)
-        )
+      message = %TestAllTypesProto3{
+        optional_float_wrapper: %Google.Protobuf.FloatValue{value: 3.14}
+      }
 
       assert encode(message) == %{"optionalFloatWrapper" => 3.14}
     end
 
     test "Google.Protobuf.DoubleValue" do
-      message =
-        TestAllTypesProto3.new!(
-          optional_double_wrapper: Google.Protobuf.DoubleValue.new!(value: 3.14)
-        )
+      message = %TestAllTypesProto3{
+        optional_double_wrapper: %Google.Protobuf.DoubleValue{value: 3.14}
+      }
 
       assert encode(message) == %{"optionalDoubleWrapper" => 3.14}
     end
 
     test "Google.Protobuf.Int32Value" do
-      message =
-        TestAllTypesProto3.new!(
-          optional_int32_wrapper: Google.Protobuf.Int32Value.new!(value: -3)
-        )
+      message = %TestAllTypesProto3{
+        optional_int32_wrapper: %Google.Protobuf.Int32Value{value: -3}
+      }
 
       assert encode(message) == %{"optionalInt32Wrapper" => -3}
     end
 
     test "Google.Protobuf.UInt32Value" do
-      message =
-        TestAllTypesProto3.new!(
-          optional_uint32_wrapper: Google.Protobuf.UInt32Value.new!(value: 3)
-        )
+      message = %TestAllTypesProto3{
+        optional_uint32_wrapper: %Google.Protobuf.UInt32Value{value: 3}
+      }
 
       assert encode(message) == %{"optionalUint32Wrapper" => 3}
     end
 
     test "Google.Protobuf.Int64Value" do
-      message =
-        TestAllTypesProto3.new!(
-          optional_int64_wrapper: Google.Protobuf.Int64Value.new!(value: -3)
-        )
+      message = %TestAllTypesProto3{
+        optional_int64_wrapper: %Google.Protobuf.Int64Value{value: -3}
+      }
 
       assert encode(message) == %{"optionalInt64Wrapper" => -3}
     end
 
     test "Google.Protobuf.UInt64Value" do
-      message =
-        TestAllTypesProto3.new!(
-          optional_uint64_wrapper: Google.Protobuf.UInt64Value.new!(value: 3)
-        )
+      message = %TestAllTypesProto3{
+        optional_uint64_wrapper: %Google.Protobuf.UInt64Value{value: 3}
+      }
 
       assert encode(message) == %{"optionalUint64Wrapper" => 3}
     end
@@ -332,10 +320,9 @@ defmodule Protobuf.JSON.EncodeTest do
 
   describe "Google.Protobuf.BytesValue" do
     test "encodes with base 64" do
-      message =
-        TestAllTypesProto3.new!(
-          optional_bytes_wrapper: Google.Protobuf.BytesValue.new!(value: <<1, 2, 3>>)
-        )
+      message = %TestAllTypesProto3{
+        optional_bytes_wrapper: %Google.Protobuf.BytesValue{value: <<1, 2, 3>>}
+      }
 
       assert encode(message) == %{"optionalBytesWrapper" => Base.url_encode64(<<1, 2, 3>>)}
     end
@@ -343,10 +330,9 @@ defmodule Protobuf.JSON.EncodeTest do
 
   describe "Google.Protobuf.FieldMask" do
     test "encodes with base 64" do
-      message =
-        TestAllTypesProto3.new!(
-          optional_field_mask: Google.Protobuf.FieldMask.new!(paths: ["foo_bar", "baz_bong"])
-        )
+      message = %TestAllTypesProto3{
+        optional_field_mask: %Google.Protobuf.FieldMask{paths: ["foo_bar", "baz_bong"]}
+      }
 
       assert encode(message) == %{"optionalFieldMask" => "fooBar,bazBong"}
     end
@@ -364,10 +350,9 @@ defmodule Protobuf.JSON.EncodeTest do
       ]
 
       for %{string: expected_string, seconds: seconds, nanos: nanos} <- cases do
-        message =
-          TestAllTypesProto3.new!(
-            optional_duration: Google.Protobuf.Duration.new!(seconds: seconds, nanos: nanos)
-          )
+        message = %TestAllTypesProto3{
+          optional_duration: %Google.Protobuf.Duration{seconds: seconds, nanos: nanos}
+        }
 
         assert encode(message) == %{"optionalDuration" => expected_string}
       end
@@ -376,10 +361,9 @@ defmodule Protobuf.JSON.EncodeTest do
     test "returns an error if the seconds of the duration are too big" do
       max_duration = 315_576_000_000
 
-      message =
-        TestAllTypesProto3.new!(
-          optional_duration: Google.Protobuf.Duration.new!(seconds: max_duration + 1, nanos: 0)
-        )
+      message = %TestAllTypesProto3{
+        optional_duration: %Google.Protobuf.Duration{seconds: max_duration + 1, nanos: 0}
+      }
 
       assert catch_throw(encode(message)) ==
                {:bad_duration, :seconds_outside_of_range, max_duration + 1}
@@ -388,10 +372,9 @@ defmodule Protobuf.JSON.EncodeTest do
     test "returns an error if the seconds of the duration are too small" do
       max_duration = 315_576_000_000
 
-      message =
-        TestAllTypesProto3.new!(
-          optional_duration: Google.Protobuf.Duration.new!(seconds: -max_duration - 1, nanos: 0)
-        )
+      message = %TestAllTypesProto3{
+        optional_duration: %Google.Protobuf.Duration{seconds: -max_duration - 1, nanos: 0}
+      }
 
       assert catch_throw(encode(message)) ==
                {:bad_duration, :seconds_outside_of_range, -max_duration - 1}
@@ -403,8 +386,8 @@ defmodule Protobuf.JSON.EncodeTest do
       {:ok, datetime, _offset = 0} = DateTime.from_iso8601("2000-01-01T00:00:00Z")
       unix_seconds = DateTime.to_unix(datetime, :second)
 
-      timestamp = Google.Protobuf.Timestamp.new!(seconds: unix_seconds, nanos: 0)
-      message = TestAllTypesProto3.new!(optional_timestamp: timestamp)
+      timestamp = %Google.Protobuf.Timestamp{seconds: unix_seconds, nanos: 0}
+      message = %TestAllTypesProto3{optional_timestamp: timestamp}
 
       assert encode(message) == %{"optionalTimestamp" => "2000-01-01T00:00:00Z"}
     end
@@ -413,8 +396,8 @@ defmodule Protobuf.JSON.EncodeTest do
       {:ok, datetime, _offset = 0} = DateTime.from_iso8601("0000-01-01T00:00:00Z")
       unix_seconds = DateTime.to_unix(datetime, :second)
 
-      timestamp = Google.Protobuf.Timestamp.new!(seconds: unix_seconds, nanos: 0)
-      message = TestAllTypesProto3.new!(optional_timestamp: timestamp)
+      timestamp = %Google.Protobuf.Timestamp{seconds: unix_seconds, nanos: 0}
+      message = %TestAllTypesProto3{optional_timestamp: timestamp}
 
       assert catch_throw(encode(message)) ==
                {:invalid_timestamp, timestamp, "timestamp is outside of allowed range"}
@@ -432,8 +415,8 @@ defmodule Protobuf.JSON.EncodeTest do
       ]
 
       for {kind, json} <- cases do
-        value = Google.Protobuf.Value.new!(kind: kind)
-        message = TestAllTypesProto3.new!(optional_value: value)
+        value = %Google.Protobuf.Value{kind: kind}
+        message = %TestAllTypesProto3{optional_value: value}
         assert encode(message) == %{"optionalValue" => json}
       end
     end
@@ -441,16 +424,16 @@ defmodule Protobuf.JSON.EncodeTest do
 
   describe "Google.Protobuf.ListValue" do
     test "encodes correctly" do
-      value = Google.Protobuf.ListValue.new!(values: [])
-      message = TestAllTypesProto3.new!(repeated_list_value: [value])
+      value = %Google.Protobuf.ListValue{values: []}
+      message = %TestAllTypesProto3{repeated_list_value: [value]}
       assert encode(message) == %{"repeatedListValue" => [[]]}
     end
   end
 
   describe "Google.Protobuf.Struct" do
     test "encodes correctly" do
-      value = Google.Protobuf.Struct.new!(fields: %{"foo" => Google.Protobuf.Empty.new!([])})
-      message = TestAllTypesProto3.new!(optional_struct: value)
+      value = %Google.Protobuf.Struct{fields: %{"foo" => %Google.Protobuf.Empty{}}}
+      message = %TestAllTypesProto3{optional_struct: value}
       assert encode(message) == %{"optionalStruct" => %{"foo" => %{}}}
     end
   end
@@ -477,14 +460,14 @@ defmodule Protobuf.JSON.EncodeTest do
       ]
 
       for %{key: key, wrong_value: wrong_value, expected_type: expected_type} <- cases do
-        message = My.Test.MapInput.new!(%{key => %{value: wrong_value}})
+        message = struct!(My.Test.MapInput, %{key => %{value: wrong_value}})
 
         assert {:invalid_type, ^expected_type, ^wrong_value} = catch_throw(encode(message))
       end
     end
 
     test "with enums" do
-      message = My.Test.MapInput.new!(enum_map: %{value: :NOT_VALID})
+      message = %My.Test.MapInput{enum_map: %{value: :NOT_VALID}}
 
       assert {:unknown_enum_value, :NOT_VALID, My.Test.MapEnum} =
                catch_throw(encode(message, use_enum_numbers: false))
@@ -492,5 +475,9 @@ defmodule Protobuf.JSON.EncodeTest do
       assert {:unknown_enum_value, :NOT_VALID, My.Test.MapEnum} =
                catch_throw(encode(message, use_enum_numbers: true))
     end
+  end
+
+  defp encode(struct, opts \\ []) do
+    Protobuf.JSON.Encode.to_encodable(struct, opts)
   end
 end

--- a/test/protobuf/json_test.exs
+++ b/test/protobuf/json_test.exs
@@ -9,7 +9,7 @@ defmodule Protobuf.JSONTest do
   end
 
   test "encoding string field with invalid UTF-8 data" do
-    message = Scalars.new!(string: "   \xff   ")
+    message = %Scalars{string: "   \xff   "}
     assert {:error, %Jason.EncodeError{}} = Protobuf.JSON.encode(message)
   end
 

--- a/test/protobuf/message_merge_test.exs
+++ b/test/protobuf/message_merge_test.exs
@@ -19,8 +19,8 @@ defmodule Protobuf.MessageMergeTest do
                 val2 <- gen,
                 val2 != default,
                 max_runs: @max_runs do
-        msg1 = TestAllTypesProto3.new!([{field, val1}])
-        msg2 = TestAllTypesProto3.new!([{field, val2}])
+        msg1 = struct!(TestAllTypesProto3, [{field, val1}])
+        msg2 = struct!(TestAllTypesProto3, [{field, val2}])
 
         decoded = concat_and_decode([msg1, msg2])
 
@@ -33,8 +33,8 @@ defmodule Protobuf.MessageMergeTest do
     check all list1 <- list_of(integer()),
               list2 <- list_of(integer()),
               max_runs: @max_runs do
-      msg1 = TestAllTypesProto3.new!(repeated_int32: list1)
-      msg2 = TestAllTypesProto3.new!(repeated_int32: list2)
+      msg1 = %TestAllTypesProto3{repeated_int32: list1}
+      msg2 = %TestAllTypesProto3{repeated_int32: list2}
 
       decoded = concat_and_decode([msg1, msg2])
 
@@ -49,8 +49,8 @@ defmodule Protobuf.MessageMergeTest do
   test "oneof fields with the same tag are merged"
 
   test "the latest oneof field takes precedence if the two have different tags" do
-    msg1 = TestAllTypesProto3.new!(oneof_field: {:oneof_nested_message, TestAllTypesProto3.new()})
-    msg2 = TestAllTypesProto3.new!(oneof_field: {:oneof_string, "foo"})
+    msg1 = %TestAllTypesProto3{oneof_field: {:oneof_nested_message, %TestAllTypesProto3{}}}
+    msg2 = %TestAllTypesProto3{oneof_field: {:oneof_string, "foo"}}
 
     decoded = concat_and_decode([msg1, msg2])
 

--- a/test/protobuf/protobuf_test.exs
+++ b/test/protobuf/protobuf_test.exs
@@ -9,19 +9,19 @@ defmodule Protobuf.ProtobufTest do
 
   describe "encode/1" do
     test "encodes a struct" do
-      bin = Protobuf.encode(TestMsg.Foo.new(a: 42))
+      bin = Protobuf.encode(%TestMsg.Foo{a: 42})
       assert bin == <<8, 42>>
     end
 
     test "encodes a struct with proto3 optional field" do
-      bin = Protobuf.encode(TestMsg.Proto3Optional.new(b: "A"))
+      bin = Protobuf.encode(%TestMsg.Proto3Optional{b: "A"})
       assert bin == <<18, 1, 65>>
     end
   end
 
   describe "encode_to_iodata/1" do
     test "encodes a struct as iodata" do
-      iodata = Protobuf.encode_to_iodata(TestMsg.Foo.new(a: 42))
+      iodata = Protobuf.encode_to_iodata(%TestMsg.Foo{a: 42})
       assert IO.iodata_to_binary(iodata) == <<8, 42>>
     end
   end
@@ -29,7 +29,7 @@ defmodule Protobuf.ProtobufTest do
   describe "decode/2" do
     test "decodes a struct" do
       struct = Protobuf.decode(<<8, 42>>, TestMsg.Foo)
-      assert struct == TestMsg.Foo.new(a: 42)
+      assert struct == %TestMsg.Foo{a: 42}
     end
   end
 

--- a/test/protobuf/protoc/cli_test.exs
+++ b/test/protobuf/protoc/cli_test.exs
@@ -90,20 +90,19 @@ defmodule Protobuf.Protoc.CLITest do
   describe "find_types/2" do
     test "returns multiple files" do
       ctx = %Context{}
-      descs = [FileDescriptorProto.new(name: "file1"), FileDescriptorProto.new(name: "file2")]
+      descs = [%FileDescriptorProto{name: "file1"}, %FileDescriptorProto{name: "file2"}]
 
       assert %Context{global_type_mapping: %{"file1" => %{}, "file2" => %{}}} =
                find_types(ctx, descs, [])
     end
 
     test "merge message and enum" do
-      desc =
-        FileDescriptorProto.new(
-          name: "file1",
-          package: "pkg",
-          message_type: [DescriptorProto.new(name: "Msg")],
-          enum_type: [EnumDescriptorProto.new(name: "Enum")]
-        )
+      desc = %FileDescriptorProto{
+        name: "file1",
+        package: "pkg",
+        message_type: [%DescriptorProto{name: "Msg"}],
+        enum_type: [%EnumDescriptorProto{name: "Enum"}]
+      }
 
       assert %{
                "file1" => %{
@@ -114,18 +113,17 @@ defmodule Protobuf.Protoc.CLITest do
     end
 
     test "have nested message types" do
-      desc =
-        FileDescriptorProto.new(
-          name: "file1",
-          package: "pkg",
-          message_type: [
-            DescriptorProto.new(
-              name: "Msg",
-              nested_type: [DescriptorProto.new(name: "NestedMsg")],
-              enum_type: [EnumDescriptorProto.new(name: "NestedEnumMsg")]
-            )
-          ]
-        )
+      desc = %FileDescriptorProto{
+        name: "file1",
+        package: "pkg",
+        message_type: [
+          %DescriptorProto{
+            name: "Msg",
+            nested_type: [%DescriptorProto{name: "NestedMsg"}],
+            enum_type: [%EnumDescriptorProto{name: "NestedEnumMsg"}]
+          }
+        ]
+      }
 
       assert %{
                "file1" => %{
@@ -137,22 +135,21 @@ defmodule Protobuf.Protoc.CLITest do
     end
 
     test "have deeper nested message types" do
-      desc =
-        FileDescriptorProto.new(
-          name: "file1",
-          package: "pkg",
-          message_type: [
-            DescriptorProto.new(
-              name: "Msg",
-              nested_type: [
-                DescriptorProto.new(
-                  name: "NestedMsg",
-                  nested_type: [DescriptorProto.new(name: "NestedMsg2")]
-                )
-              ]
-            )
-          ]
-        )
+      desc = %FileDescriptorProto{
+        name: "file1",
+        package: "pkg",
+        message_type: [
+          %DescriptorProto{
+            name: "Msg",
+            nested_type: [
+              %DescriptorProto{
+                name: "NestedMsg",
+                nested_type: [%DescriptorProto{name: "NestedMsg2"}]
+              }
+            ]
+          }
+        ]
+      }
 
       assert %{
                "file1" => %{
@@ -164,20 +161,19 @@ defmodule Protobuf.Protoc.CLITest do
     end
 
     test "supports elixir_module_prefix" do
-      opts = Google.Protobuf.FileOptions.new()
-      custom_opts = Elixirpb.FileOptions.new(module_prefix: "FooBar.Prefix")
+      opts = %Google.Protobuf.FileOptions{}
+      custom_opts = %Elixirpb.FileOptions{module_prefix: "FooBar.Prefix"}
 
       opts =
         Google.Protobuf.FileOptions.put_extension(opts, Elixirpb.PbExtension, :file, custom_opts)
 
-      desc =
-        FileDescriptorProto.new(
-          name: "file1",
-          package: "pkg",
-          message_type: [DescriptorProto.new(name: "Msg")],
-          enum_type: [EnumDescriptorProto.new(name: "Enum")],
-          options: opts
-        )
+      desc = %FileDescriptorProto{
+        name: "file1",
+        package: "pkg",
+        message_type: [%DescriptorProto{name: "Msg"}],
+        enum_type: [%EnumDescriptorProto{name: "Enum"}],
+        options: opts
+      }
 
       assert %{
                "file1" => %{
@@ -192,11 +188,11 @@ defmodule Protobuf.Protoc.CLITest do
       files_to_generate = ["file1"]
 
       descs = [
-        FileDescriptorProto.new(
+        %FileDescriptorProto{
           name: "file1",
           package: "pkg",
-          message_type: [DescriptorProto.new(name: "Msg")]
-        )
+          message_type: [%DescriptorProto{name: "Msg"}]
+        }
       ]
 
       assert find_types(ctx, descs, files_to_generate).global_type_mapping == %{
@@ -209,16 +205,16 @@ defmodule Protobuf.Protoc.CLITest do
       files_to_generate = ["file_to_generate"]
 
       descs = [
-        FileDescriptorProto.new(
+        %FileDescriptorProto{
           name: "file_to_generate",
           package: "pkg",
-          message_type: [DescriptorProto.new(name: "Msg")]
-        ),
-        FileDescriptorProto.new(
+          message_type: [%DescriptorProto{name: "Msg"}]
+        },
+        %FileDescriptorProto{
           name: "not_in_files_to_generate",
           package: "other_pkg",
-          message_type: [DescriptorProto.new(name: "OtherMsg")]
-        )
+          message_type: [%DescriptorProto{name: "OtherMsg"}]
+        }
       ]
 
       assert find_types(ctx, descs, files_to_generate).global_type_mapping == %{

--- a/test/protobuf/protoc/generator/enum_test.exs
+++ b/test/protobuf/protoc/generator/enum_test.exs
@@ -14,11 +14,11 @@ defmodule Protobuf.Protoc.Generator.EnumTest do
       name: module,
       options: nil,
       value: [
-        Google.Protobuf.EnumValueDescriptorProto.new(name: "A", number: 0),
-        Google.Protobuf.EnumValueDescriptorProto.new(name: "B", number: 1),
-        Google.Protobuf.EnumValueDescriptorProto.new(name: "HAS_UNDERSCORES", number: 2),
-        Google.Protobuf.EnumValueDescriptorProto.new(name: "HAS_UNDERSCORES_X", number: 3),
-        Google.Protobuf.EnumValueDescriptorProto.new(name: "HAS_UNDERSCORES_", number: 4)
+        %Google.Protobuf.EnumValueDescriptorProto{name: "A", number: 0},
+        %Google.Protobuf.EnumValueDescriptorProto{name: "B", number: 1},
+        %Google.Protobuf.EnumValueDescriptorProto{name: "HAS_UNDERSCORES", number: 2},
+        %Google.Protobuf.EnumValueDescriptorProto{name: "HAS_UNDERSCORES_X", number: 3},
+        %Google.Protobuf.EnumValueDescriptorProto{name: "HAS_UNDERSCORES_", number: 4}
       ]
     }
 
@@ -53,11 +53,11 @@ defmodule Protobuf.Protoc.Generator.EnumTest do
       name: module,
       options: nil,
       value: [
-        Google.Protobuf.EnumValueDescriptorProto.new(name: "A", number: 0),
-        Google.Protobuf.EnumValueDescriptorProto.new(name: "B", number: 1),
-        Google.Protobuf.EnumValueDescriptorProto.new(name: "HAS_UNDERSCORES", number: 2),
-        Google.Protobuf.EnumValueDescriptorProto.new(name: "HAS_UNDERSCORES_X", number: 3),
-        Google.Protobuf.EnumValueDescriptorProto.new(name: "HAS_UNDERSCORES_", number: 4)
+        %Google.Protobuf.EnumValueDescriptorProto{name: "A", number: 0},
+        %Google.Protobuf.EnumValueDescriptorProto{name: "B", number: 1},
+        %Google.Protobuf.EnumValueDescriptorProto{name: "HAS_UNDERSCORES", number: 2},
+        %Google.Protobuf.EnumValueDescriptorProto{name: "HAS_UNDERSCORES_X", number: 3},
+        %Google.Protobuf.EnumValueDescriptorProto{name: "HAS_UNDERSCORES_", number: 4}
       ]
     }
 
@@ -99,8 +99,8 @@ defmodule Protobuf.Protoc.Generator.EnumTest do
       name: "valueType",
       options: nil,
       value: [
-        Google.Protobuf.EnumValueDescriptorProto.new(name: "VALUE_TYPE_UNDEFINED", number: 0),
-        Google.Protobuf.EnumValueDescriptorProto.new(name: "VALUE_TYPE_INTEGER", number: 1)
+        %Google.Protobuf.EnumValueDescriptorProto{name: "VALUE_TYPE_UNDEFINED", number: 0},
+        %Google.Protobuf.EnumValueDescriptorProto{name: "VALUE_TYPE_INTEGER", number: 1}
       ]
     }
 
@@ -113,7 +113,7 @@ defmodule Protobuf.Protoc.Generator.EnumTest do
   describe "generate/2 include_docs" do
     test "does not include `@moduledoc false` when flag is true" do
       ctx = %Context{include_docs?: true}
-      desc = Google.Protobuf.EnumDescriptorProto.new(name: "valueType")
+      desc = %Google.Protobuf.EnumDescriptorProto{name: "valueType"}
 
       {_module, msg} = Generator.generate(ctx, desc)
 
@@ -122,7 +122,7 @@ defmodule Protobuf.Protoc.Generator.EnumTest do
 
     test "includes `@moduledoc false` by default" do
       ctx = %Context{}
-      desc = Google.Protobuf.EnumDescriptorProto.new(name: "valueType")
+      desc = %Google.Protobuf.EnumDescriptorProto{name: "valueType"}
 
       {_module, msg} = Generator.generate(ctx, desc)
 

--- a/test/protobuf/protoc/generator/extension_test.exs
+++ b/test/protobuf/protoc/generator/extension_test.exs
@@ -8,7 +8,7 @@ defmodule Protobuf.Protoc.Generator.ExtensionTest do
     test "generates blank" do
       ctx = %Context{namespace: [""]}
 
-      desc = Google.Protobuf.FileDescriptorProto.new(extension: [])
+      desc = %Google.Protobuf.FileDescriptorProto{extension: []}
 
       assert Generator.generate(ctx, desc, []) == nil
     end
@@ -24,36 +24,35 @@ defmodule Protobuf.Protoc.Generator.ExtensionTest do
         syntax: :proto2
       }
 
-      desc =
-        Google.Protobuf.FileDescriptorProto.new(
-          extension: [
-            Google.Protobuf.FieldDescriptorProto.new!(
-              extendee: ".ext.Foo1",
-              name: "foo",
-              json_name: "foo",
-              number: 1047,
-              label: :LABEL_OPTIONAL,
-              type: :TYPE_MESSAGE,
-              type_name: ".ext.Options"
-            ),
-            Google.Protobuf.FieldDescriptorProto.new!(
-              extendee: ".ext.Foo1",
-              name: "foo2",
-              json_name: "foo2",
-              number: 1049,
-              label: :LABEL_REPEATED,
-              type: :TYPE_UINT32
-            ),
-            Google.Protobuf.FieldDescriptorProto.new!(
-              extendee: ".ext.Foo2",
-              name: "bar",
-              json_name: "bar",
-              number: 1047,
-              label: :LABEL_OPTIONAL,
-              type: :TYPE_STRING
-            )
-          ]
-        )
+      desc = %Google.Protobuf.FileDescriptorProto{
+        extension: [
+          %Google.Protobuf.FieldDescriptorProto{
+            extendee: ".ext.Foo1",
+            name: "foo",
+            json_name: "foo",
+            number: 1047,
+            label: :LABEL_OPTIONAL,
+            type: :TYPE_MESSAGE,
+            type_name: ".ext.Options"
+          },
+          %Google.Protobuf.FieldDescriptorProto{
+            extendee: ".ext.Foo1",
+            name: "foo2",
+            json_name: "foo2",
+            number: 1049,
+            label: :LABEL_REPEATED,
+            type: :TYPE_UINT32
+          },
+          %Google.Protobuf.FieldDescriptorProto{
+            extendee: ".ext.Foo2",
+            name: "bar",
+            json_name: "bar",
+            number: 1047,
+            label: :LABEL_OPTIONAL,
+            type: :TYPE_STRING
+          }
+        ]
+      }
 
       assert {_mod_name, msg} = Generator.generate(ctx, desc, _nested_extensions = [])
       assert msg =~ "defmodule Ext.PbExtension do\n"
@@ -72,12 +71,12 @@ defmodule Protobuf.Protoc.Generator.ExtensionTest do
         syntax: :proto2
       }
 
-      desc = Google.Protobuf.FileDescriptorProto.new(extension: [])
+      desc = %Google.Protobuf.FileDescriptorProto{extension: []}
 
       nested = [
         {["Parent"],
          [
-           Google.Protobuf.FieldDescriptorProto.new!(
+           %Google.Protobuf.FieldDescriptorProto{
              extendee: ".ext.Foo1",
              label: :LABEL_OPTIONAL,
              name: "foo",
@@ -85,7 +84,7 @@ defmodule Protobuf.Protoc.Generator.ExtensionTest do
              number: 1048,
              type: :TYPE_ENUM,
              type_name: ".ext.EnumFoo"
-           )
+           }
          ]}
       ]
 
@@ -109,10 +108,10 @@ defmodule Protobuf.Protoc.Generator.ExtensionTest do
       }
 
       descs = [
-        Google.Protobuf.DescriptorProto.new!(
+        %Google.Protobuf.DescriptorProto{
           name: "MyMsg",
           extension: [
-            Google.Protobuf.FieldDescriptorProto.new!(
+            %Google.Protobuf.FieldDescriptorProto{
               extendee: ".ext.Foo1",
               label: :LABEL_OPTIONAL,
               name: "foo1",
@@ -120,13 +119,13 @@ defmodule Protobuf.Protoc.Generator.ExtensionTest do
               number: 1048,
               type: :TYPE_ENUM,
               type_name: ".ext.EnumFoo"
-            )
+            }
           ],
           nested_type: [
-            Google.Protobuf.DescriptorProto.new!(
+            %Google.Protobuf.DescriptorProto{
               name: "MyNestedMsg",
               extension: [
-                Google.Protobuf.FieldDescriptorProto.new!(
+                %Google.Protobuf.FieldDescriptorProto{
                   extendee: ".ext.Foo2",
                   label: :LABEL_OPTIONAL,
                   name: "foo2",
@@ -134,11 +133,11 @@ defmodule Protobuf.Protoc.Generator.ExtensionTest do
                   number: 1048,
                   type: :TYPE_ENUM,
                   type_name: ".ext.EnumFoo"
-                )
+                }
               ]
-            )
+            }
           ]
-        )
+        }
       ]
 
       assert [nested1, nested2] = Generator.get_nested_extensions(ctx, descs)

--- a/test/protobuf/protoc/generator/message_test.exs
+++ b/test/protobuf/protoc/generator/message_test.exs
@@ -8,7 +8,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
 
   test "generate/2 has right name" do
     ctx = %Context{}
-    desc = Google.Protobuf.DescriptorProto.new(name: "Foo")
+    desc = %Google.Protobuf.DescriptorProto{name: "Foo"}
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
     assert msg =~ "defmodule Foo do\n"
     assert msg =~ "use Protobuf, protoc_gen_elixir_version: \"#{Util.version()}\"\n"
@@ -33,7 +33,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
 
   test "generate/2 has right syntax" do
     ctx = %Context{syntax: :proto3}
-    desc = Google.Protobuf.DescriptorProto.new(name: "Foo")
+    desc = %Google.Protobuf.DescriptorProto{name: "Foo"}
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
     assert msg =~ "defmodule Foo do\n"
 
@@ -60,19 +60,19 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
 
   test "generate/2 has right name with package" do
     ctx = %Context{package: "pkg.name", module_prefix: "Pkg.Name"}
-    desc = Google.Protobuf.DescriptorProto.new(name: "Foo")
+    desc = %Google.Protobuf.DescriptorProto{name: "Foo"}
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
     assert msg =~ "defmodule Pkg.Name.Foo do\n"
   end
 
   test "generate/2 adds transform_module/1" do
     ctx = %Context{}
-    desc = Google.Protobuf.DescriptorProto.new(name: "Foo")
+    desc = %Google.Protobuf.DescriptorProto{name: "Foo"}
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
     refute msg =~ "def transform_module()"
 
     ctx = %Context{transform_module: My.Transform.Module}
-    desc = Google.Protobuf.DescriptorProto.new(name: "Foo")
+    desc = %Google.Protobuf.DescriptorProto{name: "Foo"}
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
     assert msg =~ "def transform_module(), do: My.Transform.Module\n"
   end
@@ -80,11 +80,10 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   test "generate/2 has right options" do
     ctx = %Context{package: "pkg.name"}
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        options: Google.Protobuf.MessageOptions.new(map_entry: true)
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      options: %Google.Protobuf.MessageOptions{map_entry: true}
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
     assert msg =~ "use Protobuf, map: true, protoc_gen_elixir_version: \"#{Util.version()}\"\n"
@@ -93,26 +92,25 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   test "generate/2 has right fields" do
     ctx = %Context{}
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_INT32,
-            label: :LABEL_OPTIONAL
-          ),
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "b",
-            json_name: "b",
-            number: 2,
-            type: :TYPE_STRING,
-            label: :LABEL_REQUIRED
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_INT32,
+          label: :LABEL_OPTIONAL
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "b",
+          json_name: "b",
+          number: 2,
+          type: :TYPE_STRING,
+          label: :LABEL_REQUIRED
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
 
@@ -123,19 +121,18 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   test "generate/2 has right fields with right defaults" do
     ctx = %Context{}
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_BOOL,
-            label: :LABEL_REQUIRED
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_BOOL,
+          label: :LABEL_REQUIRED
+        }
+      ]
+    }
 
     {[], [{_mod, _msg}]} = Generator.generate(ctx, desc)
   end
@@ -143,33 +140,32 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   test "generate/2 has right fields for proto3" do
     ctx = %Context{syntax: :proto3}
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_INT32,
-            label: :LABEL_OPTIONAL
-          ),
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "b",
-            json_name: "b",
-            number: 2,
-            type: :TYPE_STRING,
-            label: :LABEL_REQUIRED
-          ),
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "c",
-            json_name: "c",
-            number: 3,
-            type: :TYPE_INT32,
-            label: :LABEL_REPEATED
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_INT32,
+          label: :LABEL_OPTIONAL
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "b",
+          json_name: "b",
+          number: 2,
+          type: :TYPE_STRING,
+          label: :LABEL_REQUIRED
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "c",
+          json_name: "c",
+          number: 3,
+          type: :TYPE_INT32,
+          label: :LABEL_REPEATED
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
 
@@ -201,28 +197,27 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   test "generate/2 supports option :default" do
     ctx = %Context{}
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_INT32,
-            label: :LABEL_OPTIONAL,
-            default_value: "42"
-          ),
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "b",
-            json_name: "b",
-            number: 2,
-            type: :TYPE_BOOL,
-            label: :LABEL_OPTIONAL,
-            default_value: "false"
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_INT32,
+          label: :LABEL_OPTIONAL,
+          default_value: "42"
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "b",
+          json_name: "b",
+          number: 2,
+          type: :TYPE_BOOL,
+          label: :LABEL_OPTIONAL,
+          default_value: "false"
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
     assert msg =~ "field :a, 1, optional: true, type: :int32, default: 42\n"
@@ -232,20 +227,19 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   test "generate/2 supports option :default and uses right default if field is required" do
     ctx = %Context{}
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_INT32,
-            label: :LABEL_REQUIRED,
-            default_value: "42"
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_INT32,
+          label: :LABEL_REQUIRED,
+          default_value: "42"
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
     assert msg =~ "field :a, 1, required: true, type: :int32, default: 42\n"
@@ -254,20 +248,19 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   test "generate/2 supports option :packed" do
     ctx = %Context{}
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_INT32,
-            label: :LABEL_OPTIONAL,
-            options: Google.Protobuf.FieldOptions.new(packed: true)
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_INT32,
+          label: :LABEL_OPTIONAL,
+          options: %Google.Protobuf.FieldOptions{packed: true}
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
     assert msg =~ "field :a, 1, optional: true, type: :int32, packed: true, deprecated: false\n"
@@ -276,20 +269,19 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   test "generated supports explicit option [packed = false] in proto3" do
     ctx = %Context{syntax: :proto3}
 
-    desc =
-      Google.Protobuf.DescriptorProto.new!(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new!(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_BOOL,
-            label: :LABEL_REQUIRED,
-            options: Google.Protobuf.FieldOptions.new!(packed: false)
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_BOOL,
+          label: :LABEL_REQUIRED,
+          options: %Google.Protobuf.FieldOptions{packed: false}
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
 
@@ -299,20 +291,19 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   test "generated supports [proto3_optional = true] in proto3" do
     ctx = %Context{syntax: :proto3}
 
-    desc =
-      Google.Protobuf.DescriptorProto.new!(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new!(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_INT32,
-            label: :LABEL_OPTIONAL,
-            proto3_optional: true
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_INT32,
+          label: :LABEL_OPTIONAL,
+          proto3_optional: true
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
 
@@ -322,20 +313,19 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   test "generate/2 supports option :deprecated" do
     ctx = %Context{}
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_INT32,
-            label: :LABEL_OPTIONAL,
-            options: Google.Protobuf.FieldOptions.new(deprecated: true)
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_INT32,
+          label: :LABEL_OPTIONAL,
+          options: %Google.Protobuf.FieldOptions{deprecated: true}
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
     assert msg =~ "field :a, 1, optional: true, type: :int32, deprecated: true\n"
@@ -349,28 +339,27 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       }
     }
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "bar",
-            json_name: "bar",
-            number: 1,
-            type: :TYPE_MESSAGE,
-            label: :LABEL_OPTIONAL,
-            type_name: ".Bar"
-          ),
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "baz",
-            json_name: "baz",
-            number: 2,
-            type: :TYPE_MESSAGE,
-            label: :LABEL_REPEATED,
-            type_name: ".Baz"
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "bar",
+          json_name: "bar",
+          number: 1,
+          type: :TYPE_MESSAGE,
+          label: :LABEL_OPTIONAL,
+          type_name: ".Bar"
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "baz",
+          json_name: "baz",
+          number: 2,
+          type: :TYPE_MESSAGE,
+          label: :LABEL_REPEATED,
+          type_name: ".Baz"
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
 
@@ -404,43 +393,42 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       module_prefix: "FooBar.AbCd"
     }
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_MESSAGE,
-            label: :LABEL_REPEATED,
-            type_name: ".foo_bar.ab_cd.Foo.ProjectsEntry"
-          )
-        ],
-        nested_type: [
-          Google.Protobuf.DescriptorProto.new(
-            name: "ProjectsEntry",
-            options: Google.Protobuf.MessageOptions.new(map_entry: true),
-            field: [
-              Google.Protobuf.FieldDescriptorProto.new(
-                name: "key",
-                json_name: "key",
-                number: 1,
-                label: :LABEL_OPTIONAL,
-                type: :TYPE_INT32
-              ),
-              Google.Protobuf.FieldDescriptorProto.new(
-                name: "value",
-                json_name: "value",
-                number: 2,
-                label: :LABEL_OPTIONAL,
-                type: :TYPE_MESSAGE,
-                type_name: ".foo_bar.ab_cd.Bar"
-              )
-            ]
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_MESSAGE,
+          label: :LABEL_REPEATED,
+          type_name: ".foo_bar.ab_cd.Foo.ProjectsEntry"
+        }
+      ],
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{
+          name: "ProjectsEntry",
+          options: %Google.Protobuf.MessageOptions{map_entry: true},
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "key",
+              json_name: "key",
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_INT32
+            },
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "value",
+              json_name: "value",
+              number: 2,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_MESSAGE,
+              type_name: ".foo_bar.ab_cd.Bar"
+            }
+          ]
+        }
+      ]
+    }
 
     {[[]], [[{_, nested_msg}], {_mod, msg}]} = Generator.generate(ctx, desc)
     assert msg =~ "field :a, 1, repeated: true, type: FooBar.AbCd.Foo.ProjectsEntry, map: true\n"
@@ -474,20 +462,19 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       }
     }
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_ENUM,
-            label: :LABEL_OPTIONAL,
-            type_name: ".foo_bar.ab_cd.EnumFoo"
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_ENUM,
+          label: :LABEL_OPTIONAL,
+          type_name: ".foo_bar.ab_cd.EnumFoo"
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
     assert msg =~ "field :a, 1, optional: true, type: FooBar.AbCd.EnumFoo, enum: true\n"
@@ -499,20 +486,19 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       dep_type_mapping: %{".other_pkg.EnumFoo" => %{type_name: "OtherPkg.EnumFoo"}}
     }
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_ENUM,
-            label: :LABEL_OPTIONAL,
-            type_name: ".other_pkg.EnumFoo"
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_ENUM,
+          label: :LABEL_OPTIONAL,
+          type_name: ".other_pkg.EnumFoo"
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
     assert msg =~ "field :a, 1, optional: true, type: OtherPkg.EnumFoo, enum: true\n"
@@ -524,20 +510,19 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       dep_type_mapping: %{".other_pkg.MsgFoo" => %{type_name: "OtherPkg.MsgFoo"}}
     }
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_MESSAGE,
-            label: :LABEL_OPTIONAL,
-            type_name: ".other_pkg.MsgFoo"
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_MESSAGE,
+          label: :LABEL_OPTIONAL,
+          type_name: ".other_pkg.MsgFoo"
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
     assert msg =~ "field :a, 1, optional: true, type: OtherPkg.MsgFoo\n"
@@ -564,13 +549,12 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   test "generate/2 supports nested messages" do
     ctx = %Context{}
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        nested_type: [
-          Google.Protobuf.DescriptorProto.new(name: "Nested")
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{name: "Nested"}
+      ]
+    }
 
     {[[]], [[{_mod, msg}], _]} = Generator.generate(ctx, desc)
     assert msg =~ "defmodule Foo.Nested do\n"
@@ -582,23 +566,22 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       dep_type_mapping: %{".my_pkg.Nested" => %{type_name: "MyPkg.Foo.Nested"}}
     }
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_MESSAGE,
-            label: :LABEL_REQUIRED,
-            type_name: ".my_pkg.Nested"
-          )
-        ],
-        nested_type: [
-          Google.Protobuf.DescriptorProto.new(name: "Nested")
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_MESSAGE,
+          label: :LABEL_REQUIRED,
+          type_name: ".my_pkg.Nested"
+        }
+      ],
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{name: "Nested"}
+      ]
+    }
 
     {[[]], [[{_, nested_msg}], {_, main_msg}]} = Generator.generate(ctx, desc)
     assert nested_msg =~ "defmodule MyPkg.Foo.Nested do\n"
@@ -629,24 +612,23 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   test "generate/2 supports nested enum messages" do
     ctx = %Context{}
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        nested_type: [
-          Google.Protobuf.DescriptorProto.new(
-            enum_type: [
-              Google.Protobuf.EnumDescriptorProto.new(
-                name: "EnumFoo",
-                value: [
-                  Google.Protobuf.EnumValueDescriptorProto.new(name: "a", number: 0),
-                  Google.Protobuf.EnumValueDescriptorProto.new(name: "b", number: 1)
-                ]
-              )
-            ],
-            name: "Nested"
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{
+          enum_type: [
+            %Google.Protobuf.EnumDescriptorProto{
+              name: "EnumFoo",
+              value: [
+                %Google.Protobuf.EnumValueDescriptorProto{name: "a", number: 0},
+                %Google.Protobuf.EnumValueDescriptorProto{name: "b", number: 1}
+              ]
+            }
+          ],
+          name: "Nested"
+        }
+      ]
+    }
 
     {[[{_mod, msg}]], _} = Generator.generate(ctx, desc)
     assert msg =~ "defmodule Foo.Nested.EnumFoo do\n"
@@ -661,55 +643,54 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   test "generate/2 supports oneof" do
     ctx = %Context{}
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        oneof_decl: [
-          Google.Protobuf.OneofDescriptorProto.new(name: "first"),
-          Google.Protobuf.OneofDescriptorProto.new(name: "second")
-        ],
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_INT32,
-            label: :LABEL_OPTIONAL,
-            oneof_index: 0
-          ),
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "b",
-            json_name: "b",
-            number: 2,
-            type: :TYPE_INT32,
-            label: :LABEL_OPTIONAL,
-            oneof_index: 0
-          ),
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "c",
-            json_name: "c",
-            number: 3,
-            type: :TYPE_INT32,
-            label: :LABEL_OPTIONAL,
-            oneof_index: 1
-          ),
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "d",
-            json_name: "d",
-            number: 4,
-            type: :TYPE_INT32,
-            label: :LABEL_OPTIONAL,
-            oneof_index: 1
-          ),
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "other",
-            json_name: "other",
-            number: 5,
-            type: :TYPE_INT32,
-            label: :LABEL_OPTIONAL
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      oneof_decl: [
+        %Google.Protobuf.OneofDescriptorProto{name: "first"},
+        %Google.Protobuf.OneofDescriptorProto{name: "second"}
+      ],
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_INT32,
+          label: :LABEL_OPTIONAL,
+          oneof_index: 0
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "b",
+          json_name: "b",
+          number: 2,
+          type: :TYPE_INT32,
+          label: :LABEL_OPTIONAL,
+          oneof_index: 0
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "c",
+          json_name: "c",
+          number: 3,
+          type: :TYPE_INT32,
+          label: :LABEL_OPTIONAL,
+          oneof_index: 1
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "d",
+          json_name: "d",
+          number: 4,
+          type: :TYPE_INT32,
+          label: :LABEL_OPTIONAL,
+          oneof_index: 1
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "other",
+          json_name: "other",
+          number: 5,
+          type: :TYPE_INT32,
+          label: :LABEL_OPTIONAL
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
 
@@ -748,26 +729,25 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     test "is added when it differs from the original field name" do
       ctx = %Context{syntax: :proto3}
 
-      desc =
-        Google.Protobuf.DescriptorProto.new(
-          name: "Foo",
-          field: [
-            Google.Protobuf.FieldDescriptorProto.new(
-              name: "simple",
-              json_name: "simple",
-              number: 1,
-              type: :TYPE_INT32,
-              label: :LABEL_OPTIONAL
-            ),
-            Google.Protobuf.FieldDescriptorProto.new(
-              name: "the_field_name",
-              json_name: "theFieldName",
-              number: 2,
-              type: :TYPE_STRING,
-              label: :LABEL_OPTIONAL
-            )
-          ]
-        )
+      desc = %Google.Protobuf.DescriptorProto{
+        name: "Foo",
+        field: [
+          %Google.Protobuf.FieldDescriptorProto{
+            name: "simple",
+            json_name: "simple",
+            number: 1,
+            type: :TYPE_INT32,
+            label: :LABEL_OPTIONAL
+          },
+          %Google.Protobuf.FieldDescriptorProto{
+            name: "the_field_name",
+            json_name: "theFieldName",
+            number: 2,
+            type: :TYPE_STRING,
+            label: :LABEL_OPTIONAL
+          }
+        ]
+      }
 
       {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
 
@@ -778,19 +758,18 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
     test "is omitted when syntax is not proto3" do
       ctx = %Context{}
 
-      desc =
-        Google.Protobuf.DescriptorProto.new(
-          name: "Foo",
-          field: [
-            Google.Protobuf.FieldDescriptorProto.new(
-              name: "the_field_name",
-              json_name: "theFieldName",
-              number: 1,
-              type: :TYPE_STRING,
-              label: :LABEL_REQUIRED
-            )
-          ]
-        )
+      desc = %Google.Protobuf.DescriptorProto{
+        name: "Foo",
+        field: [
+          %Google.Protobuf.FieldDescriptorProto{
+            name: "the_field_name",
+            json_name: "theFieldName",
+            number: 1,
+            type: :TYPE_STRING,
+            label: :LABEL_REQUIRED
+          }
+        ]
+      }
 
       {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
 
@@ -806,20 +785,19 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
       }
     }
 
-    desc =
-      Google.Protobuf.DescriptorProto.new(
-        name: "Foo",
-        field: [
-          Google.Protobuf.FieldDescriptorProto.new(
-            name: "a",
-            json_name: "a",
-            number: 1,
-            type: :TYPE_ENUM,
-            label: :LABEL_REPEATED,
-            type_name: ".foo_bar.ab_cd.EnumFoo"
-          )
-        ]
-      )
+    desc = %Google.Protobuf.DescriptorProto{
+      name: "Foo",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "a",
+          json_name: "a",
+          number: 1,
+          type: :TYPE_ENUM,
+          label: :LABEL_REPEATED,
+          type_name: ".foo_bar.ab_cd.EnumFoo"
+        }
+      ]
+    }
 
     {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
 
@@ -845,7 +823,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
   describe "generate/2 include_docs" do
     test "does not include `@moduledoc false` when flag is true" do
       ctx = %Context{include_docs?: true}
-      desc = Google.Protobuf.DescriptorProto.new(name: "Foo")
+      desc = %Google.Protobuf.DescriptorProto{name: "Foo"}
 
       {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
 
@@ -854,7 +832,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
 
     test "includes `@moduledoc false` by default" do
       ctx = %Context{}
-      desc = Google.Protobuf.DescriptorProto.new(name: "Foo")
+      desc = %Google.Protobuf.DescriptorProto{name: "Foo"}
 
       {[], [{_mod, msg}]} = Generator.generate(ctx, desc)
 

--- a/test/protobuf/protoc/generator/service_test.exs
+++ b/test/protobuf/protoc/generator/service_test.exs
@@ -24,30 +24,30 @@ defmodule Protobuf.Protoc.Generator.ServiceTest do
     desc = %Google.Protobuf.ServiceDescriptorProto{
       name: "ServiceFoo",
       method: [
-        Google.Protobuf.MethodDescriptorProto.new(
+        %Google.Protobuf.MethodDescriptorProto{
           name: "MethodA",
           input_type: ".foo.Input0",
           output_type: ".foo.Output0"
-        ),
-        Google.Protobuf.MethodDescriptorProto.new(
+        },
+        %Google.Protobuf.MethodDescriptorProto{
           name: "MethodB",
           input_type: ".foo.Input1",
           output_type: ".foo.Output1",
           client_streaming: true
-        ),
-        Google.Protobuf.MethodDescriptorProto.new(
+        },
+        %Google.Protobuf.MethodDescriptorProto{
           name: "MethodC",
           input_type: ".foo.Input2",
           output_type: ".foo.Output2",
           server_streaming: true
-        ),
-        Google.Protobuf.MethodDescriptorProto.new(
+        },
+        %Google.Protobuf.MethodDescriptorProto{
           name: "MethodD",
           input_type: ".foo.Input3",
           output_type: ".foo.Output3",
           client_streaming: true,
           server_streaming: true
-        )
+        }
       ]
     }
 
@@ -66,7 +66,7 @@ defmodule Protobuf.Protoc.Generator.ServiceTest do
   describe "generate/2 include_docs" do
     test "does not include `@moduledoc false` when flag is true" do
       ctx = %Context{include_docs?: true}
-      desc = Google.Protobuf.ServiceDescriptorProto.new(name: "ServiceFoo")
+      desc = %Google.Protobuf.ServiceDescriptorProto{name: "ServiceFoo"}
 
       {_module, msg} = Generator.generate(ctx, desc)
 
@@ -75,7 +75,7 @@ defmodule Protobuf.Protoc.Generator.ServiceTest do
 
     test "includes `@moduledoc false` by default" do
       ctx = %Context{}
-      desc = Google.Protobuf.ServiceDescriptorProto.new(name: "ServiceFoo")
+      desc = %Google.Protobuf.ServiceDescriptorProto{name: "ServiceFoo"}
 
       {_module, msg} = Generator.generate(ctx, desc)
 

--- a/test/protobuf/protoc/generator_integration_test.exs
+++ b/test/protobuf/protoc/generator_integration_test.exs
@@ -9,17 +9,16 @@ defmodule Protobuf.Protoc.GeneratorIntegrationTest do
       _my_field_name_2: 21
     }
 
-    reply = My.Test.Reply.new(found: [entry], compact_keys: [1, 2, 3])
+    reply = %My.Test.Reply{found: [entry], compact_keys: [1, 2, 3]}
 
-    input =
-      My.Test.Request.new(
-        key: [123],
-        hue: :GREEN,
-        hat: :FEZ,
-        deadline: 123.0,
-        name_mapping: %{321 => "name"},
-        msg_mapping: %{1234 => reply}
-      )
+    input = %My.Test.Request{
+      key: [123],
+      hue: :GREEN,
+      hat: :FEZ,
+      deadline: 123.0,
+      name_mapping: %{321 => "name"},
+      msg_mapping: %{1234 => reply}
+    }
 
     output = My.Test.Request.encode(input)
     assert My.Test.Request.__message_props__().field_props[14].map?
@@ -38,7 +37,7 @@ defmodule Protobuf.Protoc.GeneratorIntegrationTest do
       today: :MONDAY,
       maybe: true,
       delta: 123,
-      msg: My.Test.Reply.new()
+      msg: %My.Test.Reply{}
     ]
 
     Enum.each(unions, fn union ->
@@ -53,7 +52,7 @@ defmodule Protobuf.Protoc.GeneratorIntegrationTest do
   end
 
   test "extensions" do
-    assert "hello" == Protobuf.Protoc.ExtTest.Foo.new(a: "hello").a
+    assert "hello" == %Protobuf.Protoc.ExtTest.Foo{a: "hello"}.a
   end
 
   describe "custom options" do
@@ -81,7 +80,7 @@ defmodule Protobuf.Protoc.GeneratorIntegrationTest do
   end
 
   test "maps without packages" do
-    input = NoPackageMessage.new(number_mapping: %{321 => 123, 1337 => 1})
+    input = %NoPackageMessage{number_mapping: %{321 => 123, 1337 => 1}}
 
     output = NoPackageMessage.encode(input)
     assert NoPackageMessage.__message_props__().field_props[1].map?

--- a/test/protobuf/protoc/generator_test.exs
+++ b/test/protobuf/protoc/generator_test.exs
@@ -9,10 +9,10 @@ defmodule Protobuf.Protoc.GeneratorTest do
   describe "generate/2" do
     test "returns a list of Google.Protobuf.Compiler.CodeGeneratorResponse.File structs" do
       ctx = %Context{global_type_mapping: %{"name.proto" => %{}}}
-      desc = Google.Protobuf.FileDescriptorProto.new(name: "name.proto")
+      desc = %Google.Protobuf.FileDescriptorProto{name: "name.proto"}
 
       assert Generator.generate(ctx, desc) ==
-               [CodeGeneratorResponse.File.new(name: "name.pb.ex", content: "")]
+               [%CodeGeneratorResponse.File{name: "name.pb.ex", content: ""}]
     end
 
     test "uses the package prefix" do
@@ -23,11 +23,10 @@ defmodule Protobuf.Protoc.GeneratorTest do
         }
       }
 
-      desc =
-        Google.Protobuf.FileDescriptorProto.new(
-          name: "name.proto",
-          message_type: [Google.Protobuf.DescriptorProto.new(name: "Foo")]
-        )
+      desc = %Google.Protobuf.FileDescriptorProto{
+        name: "name.proto",
+        message_type: [%Google.Protobuf.DescriptorProto{name: "Foo"}]
+      }
 
       assert [%CodeGeneratorResponse.File{} = file] = Generator.generate(ctx, desc)
 
@@ -45,12 +44,11 @@ defmodule Protobuf.Protoc.GeneratorTest do
         }
       }
 
-      desc =
-        Google.Protobuf.FileDescriptorProto.new(
-          name: "name.proto",
-          package: "lib",
-          message_type: [Google.Protobuf.DescriptorProto.new(name: "Foo")]
-        )
+      desc = %Google.Protobuf.FileDescriptorProto{
+        name: "name.proto",
+        package: "lib",
+        message_type: [%Google.Protobuf.DescriptorProto{name: "Foo"}]
+      }
 
       assert [%CodeGeneratorResponse.File{} = file] = Generator.generate(ctx, desc)
 
@@ -66,19 +64,18 @@ defmodule Protobuf.Protoc.GeneratorTest do
         global_type_mapping: %{"name.proto" => %{}}
       }
 
-      desc =
-        Google.Protobuf.FileDescriptorProto.new(
-          name: "name.proto",
-          message_type: [Google.Protobuf.DescriptorProto.new(name: "MyMessage")],
-          enum_type: [
-            Google.Protobuf.EnumDescriptorProto.new(
-              name: "MyEnum",
-              value: [
-                Google.Protobuf.EnumValueDescriptorProto.new(name: :MY_ENUM_NOT_SET, number: 0)
-              ]
-            )
-          ]
-        )
+      desc = %Google.Protobuf.FileDescriptorProto{
+        name: "name.proto",
+        message_type: [%Google.Protobuf.DescriptorProto{name: "MyMessage"}],
+        enum_type: [
+          %Google.Protobuf.EnumDescriptorProto{
+            name: "MyEnum",
+            value: [
+              %Google.Protobuf.EnumValueDescriptorProto{name: :MY_ENUM_NOT_SET, number: 0}
+            ]
+          }
+        ]
+      }
 
       assert [%CodeGeneratorResponse.File{} = file] = Generator.generate(ctx, desc)
 
@@ -97,20 +94,19 @@ defmodule Protobuf.Protoc.GeneratorTest do
         one_file_per_module?: true
       }
 
-      desc =
-        Google.Protobuf.FileDescriptorProto.new(
-          name: "name.proto",
-          package: "foo",
-          message_type: [Google.Protobuf.DescriptorProto.new(name: "MyMessage.Nested")],
-          enum_type: [
-            Google.Protobuf.EnumDescriptorProto.new(
-              name: "MyEnum",
-              value: [
-                Google.Protobuf.EnumValueDescriptorProto.new(name: :MY_ENUM_NOT_SET, number: 0)
-              ]
-            )
-          ]
-        )
+      desc = %Google.Protobuf.FileDescriptorProto{
+        name: "name.proto",
+        package: "foo",
+        message_type: [%Google.Protobuf.DescriptorProto{name: "MyMessage.Nested"}],
+        enum_type: [
+          %Google.Protobuf.EnumDescriptorProto{
+            name: "MyEnum",
+            value: [
+              %Google.Protobuf.EnumValueDescriptorProto{name: :MY_ENUM_NOT_SET, number: 0}
+            ]
+          }
+        ]
+      }
 
       assert [
                %CodeGeneratorResponse.File{} = enum_file,
@@ -128,12 +124,11 @@ defmodule Protobuf.Protoc.GeneratorTest do
         package_prefix: "prfx"
       }
 
-      desc =
-        Google.Protobuf.FileDescriptorProto.new(
-          name: "name.proto",
-          package: "foo",
-          message_type: [Google.Protobuf.DescriptorProto.new(name: "MyMessage.Nested")]
-        )
+      desc = %Google.Protobuf.FileDescriptorProto{
+        name: "name.proto",
+        package: "foo",
+        message_type: [%Google.Protobuf.DescriptorProto{name: "MyMessage.Nested"}]
+      }
 
       assert [%CodeGeneratorResponse.File{} = file] = Generator.generate(ctx, desc)
 
@@ -147,12 +142,11 @@ defmodule Protobuf.Protoc.GeneratorTest do
         module_prefix: "My.Prefix"
       }
 
-      desc =
-        Google.Protobuf.FileDescriptorProto.new(
-          name: "name.proto",
-          package: "foo",
-          message_type: [Google.Protobuf.DescriptorProto.new(name: "MyMessage.Nested")]
-        )
+      desc = %Google.Protobuf.FileDescriptorProto{
+        name: "name.proto",
+        package: "foo",
+        message_type: [%Google.Protobuf.DescriptorProto{name: "MyMessage.Nested"}]
+      }
 
       assert [%CodeGeneratorResponse.File{} = file] = Generator.generate(ctx, desc)
 
@@ -166,12 +160,11 @@ defmodule Protobuf.Protoc.GeneratorTest do
         global_type_mapping: %{"name.proto" => %{}, "my_dep" => %{}}
       }
 
-      desc =
-        Google.Protobuf.FileDescriptorProto.new(
-          name: "name.proto",
-          dependency: ["my_dep"],
-          service: [Google.Protobuf.ServiceDescriptorProto.new(name: "my_service")]
-        )
+      desc = %Google.Protobuf.FileDescriptorProto{
+        name: "name.proto",
+        dependency: ["my_dep"],
+        service: [%Google.Protobuf.ServiceDescriptorProto{name: "my_service"}]
+      }
 
       # We can't compile the generated service module because we haven't loaded GRPC.Service here.
       assert [%CodeGeneratorResponse.File{} = file] = Generator.generate(ctx, desc)


### PR DESCRIPTION
We now fully support struct building with compile-time defaults, so I think it's time to deprecate these and reduce the API surface.

This is already a huge library, and simplifying it is paramount (IMO) to keeping its maintenance sustainable.

The change from `MyMessage.new(attrs)` to `%MyMessage{attrs}` is (tedious but) straightforward.