### PR TITLE
Fix multiple conflicting PbExtension modules

### DIFF
--- a/lib/elixirpb.pb.ex
+++ b/lib/elixirpb.pb.ex
@@ -5,10 +5,3 @@ defmodule Elixirpb.FileOptions do
 
   field :module_prefix, 1, optional: true, type: :string
 end
-
-defmodule Elixirpb.Extensions112641087.PbExtension do
-  @moduledoc false
-  use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
-
-  extend Google.Protobuf.FileOptions, :file, 1047, optional: true, type: Elixirpb.FileOptions
-end

--- a/lib/elixirpb.pb.ex
+++ b/lib/elixirpb.pb.ex
@@ -6,7 +6,7 @@ defmodule Elixirpb.FileOptions do
   field :module_prefix, 1, optional: true, type: :string
 end
 
-defmodule Elixirpb.PbExtension do
+defmodule Elixirpb.Extensions112641087.PbExtension do
   @moduledoc false
   use Protobuf, protoc_gen_elixir_version: "0.11.0", syntax: :proto2
 

--- a/lib/elixirpb/pb_extension.pb.ex
+++ b/lib/elixirpb/pb_extension.pb.ex
@@ -1,0 +1,6 @@
+defmodule Elixirpb.PbExtension do
+  @moduledoc false
+  use Protobuf, protoc_gen_elixir_version: "0.11.0"
+
+  extend Google.Protobuf.FileOptions, :file, 1047, optional: true, type: Elixirpb.FileOptions
+end

--- a/lib/google/protobuf/descriptor.pb.ex
+++ b/lib/google/protobuf/descriptor.pb.ex
@@ -154,7 +154,7 @@ defmodule Google.Protobuf.ExtensionRangeOptions do
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  extensions [{1000, 536_870_912}]
+  extensions [{1000, Protobuf.Extension.max()}]
 end
 
 defmodule Google.Protobuf.FieldDescriptorProto do
@@ -275,7 +275,7 @@ defmodule Google.Protobuf.FileOptions do
   field :ruby_package, 45, optional: true, type: :string
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  extensions [{1000, 536_870_912}]
+  extensions [{1000, Protobuf.Extension.max()}]
 end
 
 defmodule Google.Protobuf.MessageOptions do
@@ -289,7 +289,7 @@ defmodule Google.Protobuf.MessageOptions do
   field :map_entry, 7, optional: true, type: :bool
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  extensions [{1000, 536_870_912}]
+  extensions [{1000, Protobuf.Extension.max()}]
 end
 
 defmodule Google.Protobuf.FieldOptions do
@@ -317,7 +317,7 @@ defmodule Google.Protobuf.FieldOptions do
   field :weak, 10, optional: true, type: :bool, default: false
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  extensions [{1000, 536_870_912}]
+  extensions [{1000, Protobuf.Extension.max()}]
 end
 
 defmodule Google.Protobuf.OneofOptions do
@@ -327,7 +327,7 @@ defmodule Google.Protobuf.OneofOptions do
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  extensions [{1000, 536_870_912}]
+  extensions [{1000, Protobuf.Extension.max()}]
 end
 
 defmodule Google.Protobuf.EnumOptions do
@@ -339,7 +339,7 @@ defmodule Google.Protobuf.EnumOptions do
   field :deprecated, 3, optional: true, type: :bool, default: false
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  extensions [{1000, 536_870_912}]
+  extensions [{1000, Protobuf.Extension.max()}]
 end
 
 defmodule Google.Protobuf.EnumValueOptions do
@@ -350,7 +350,7 @@ defmodule Google.Protobuf.EnumValueOptions do
   field :deprecated, 1, optional: true, type: :bool, default: false
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  extensions [{1000, 536_870_912}]
+  extensions [{1000, Protobuf.Extension.max()}]
 end
 
 defmodule Google.Protobuf.ServiceOptions do
@@ -361,7 +361,7 @@ defmodule Google.Protobuf.ServiceOptions do
   field :deprecated, 33, optional: true, type: :bool, default: false
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  extensions [{1000, 536_870_912}]
+  extensions [{1000, Protobuf.Extension.max()}]
 end
 
 defmodule Google.Protobuf.MethodOptions do
@@ -379,7 +379,7 @@ defmodule Google.Protobuf.MethodOptions do
 
   field :uninterpreted_option, 999, repeated: true, type: Google.Protobuf.UninterpretedOption
 
-  extensions [{1000, 536_870_912}]
+  extensions [{1000, Protobuf.Extension.max()}]
 end
 
 defmodule Google.Protobuf.UninterpretedOption.NamePart do

--- a/lib/protobuf/message_props.ex
+++ b/lib/protobuf/message_props.ex
@@ -22,6 +22,8 @@ defmodule Protobuf.MessageProps do
           enum?: boolean(),
           extendable?: boolean(),
           map?: boolean(),
+
+          # See Protobuf.DSL.extensions/1.
           extension_range: [{non_neg_integer(), non_neg_integer()}] | nil
         }
 

--- a/lib/protobuf/protoc/context.ex
+++ b/lib/protobuf/protoc/context.ex
@@ -60,7 +60,7 @@ defmodule Protobuf.Protoc.Context do
       ) do
     custom_file_opts =
       Google.Protobuf.FileOptions.get_extension(options, Elixirpb.PbExtension, :file) ||
-        %Elixirpb.PbExtension{}
+        %Elixirpb.FileOptions{}
 
     %__MODULE__{
       ctx

--- a/lib/protobuf/protoc/generator.ex
+++ b/lib/protobuf/protoc/generator.ex
@@ -41,14 +41,12 @@ defmodule Protobuf.Protoc.Generator do
       }
       |> Protobuf.Protoc.Context.custom_file_options_from_file_desc(desc)
 
-    nested_extensions = Generator.Extension.get_nested_extensions(ctx, desc.message_type)
-
     enum_defmodules = Enum.map(desc.enum_type, &Generator.Enum.generate(ctx, &1))
 
     {nested_enum_defmodules, message_defmodules} =
       Generator.Message.generate_list(ctx, desc.message_type)
 
-    extension_defmodules = Generator.Extension.generate(ctx, desc, nested_extensions)
+    extension_defmodules = Generator.Extension.generate(ctx, desc)
 
     service_defmodules =
       if "grpc" in ctx.plugins do

--- a/lib/protobuf/protoc/generator/extension.ex
+++ b/lib/protobuf/protoc/generator/extension.ex
@@ -74,10 +74,12 @@ defmodule Protobuf.Protoc.Generator.Extension do
       |> Enum.sort()
       |> :erlang.phash2()
       |> Integer.to_string()
-      |> then(&"Extensions#{&1}")
 
     module_name =
-      Util.mod_name(ctx, ctx.namespace ++ [unique_module_name_part, Macro.camelize(@ext_postfix)])
+      Util.mod_name(
+        ctx,
+        ctx.namespace ++ ["Extensions#{unique_module_name_part}", Macro.camelize(@ext_postfix)]
+      )
 
     module_contents =
       Util.format(

--- a/lib/protobuf/protoc/generator/message.ex
+++ b/lib/protobuf/protoc/generator/message.ex
@@ -1,7 +1,7 @@
 defmodule Protobuf.Protoc.Generator.Message do
   @moduledoc false
 
-  alias Google.Protobuf.FieldDescriptorProto
+  alias Google.Protobuf.{DescriptorProto, FieldDescriptorProto}
 
   alias Protobuf.Protoc.Context
   alias Protobuf.Protoc.Generator.Util
@@ -177,8 +177,14 @@ defmodule Protobuf.Protoc.Generator.Message do
   end
 
   defp get_extensions(desc) do
-    Enum.map(desc.extension_range, fn range ->
-      {range.start, range.end}
+    max = Protobuf.Extension.max()
+
+    Enum.map(desc.extension_range, fn %DescriptorProto.ExtensionRange{start: start, end: end_} ->
+      if end_ == max do
+        {Integer.to_string(start), "Protobuf.Extension.max()"}
+      else
+        {Integer.to_string(start), Integer.to_string(end_)}
+      end
     end)
   end
 

--- a/priv/templates/extension.ex.eex
+++ b/priv/templates/extension.ex.eex
@@ -2,6 +2,8 @@ defmodule <%= @module %> do
   @moduledoc false
   use Protobuf, <%= @use_options %>
 
+  <% if @extends == [], do: raise("Fuck! #{@module}") %>
+
   <%= for ext <- @extends do %>
   extend <%= ext %>
   <% end %>

--- a/priv/templates/message.ex.eex
+++ b/priv/templates/message.ex.eex
@@ -24,6 +24,6 @@ defmodule <%= @module %> do
   <% end %>
 
   <%= if @extensions != [] do %>
-  extensions <%= inspect(@extensions, limit: :infinity) %>
+  extensions [<%= Enum.map_join(@extensions, ", ", fn {start, end_} -> "{#{start}, #{end_}}" end) %>]
   <% end %>
 end

--- a/test/protobuf/extension_test.exs
+++ b/test/protobuf/extension_test.exs
@@ -3,6 +3,8 @@ defmodule Protobuf.ExtensionTest do
 
   alias TestMsg.Ext
 
+  doctest Protobuf.Extension
+
   test "extension persistent works" do
     assert Ext.PbExtension == :persistent_term.get({Protobuf.Extension, Ext.Foo1, 1047})
     assert Ext.PbExtension == :persistent_term.get({Protobuf.Extension, Ext.Foo1, 1048})

--- a/test/protobuf/protobuf_test.exs
+++ b/test/protobuf/protobuf_test.exs
@@ -3,8 +3,8 @@ defmodule Protobuf.ProtobufTest do
 
   test "load_extensions/0 is a noop" do
     Protobuf.load_extensions()
-    assert loaded_extensions() == 13
-    assert loaded_extensions() == 13
+    assert loaded_extensions() == 15
+    assert loaded_extensions() == 15
   end
 
   describe "encode/1" do

--- a/test/protobuf/protoc/cli_integration_test.exs
+++ b/test/protobuf/protoc/cli_integration_test.exs
@@ -175,7 +175,7 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
     assert Map.fetch!(mod.__message_props__().field_props, 1).type == Google.Protobuf.Timestamp
   end
 
-  test "TODO", %{tmp_dir: tmp_dir} do
+  test "multiple extensions defined in different scopes", %{tmp_dir: tmp_dir} do
     proto_path_base = Path.join(tmp_dir, "base.proto")
     proto_path_ext1 = Path.join(tmp_dir, "ext1.proto")
     proto_path_ext2 = Path.join(tmp_dir, "ext2.proto")
@@ -220,7 +220,7 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
 
     message Ext2 {
       extend Base {
-        optional string last_name = 102;
+        optional string first_name = 102;
       }
     }
     """)
@@ -234,17 +234,31 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
       proto_path_ext2
     ])
 
-    assert [Bugs.Base] = compile_file_and_clean_modules_on_exit("#{tmp_dir}/base.pb.ex")
+    assert [Bugs.Base = base_mod] =
+             compile_file_and_clean_modules_on_exit("#{tmp_dir}/base.pb.ex")
 
-    assert [Bugs.Ext1, file_exts_mod1, Bugs.Ext1.PbExtension] =
+    assert [Bugs.Ext1, Bugs.Ext1.PbExtension] =
              compile_file_and_clean_modules_on_exit("#{tmp_dir}/ext1.pb.ex")
 
-    assert [Bugs.Ext2, file_exts_mod2, Bugs.Ext2.PbExtension] =
+    assert [Bugs.Ext2, Bugs.Ext2.PbExtension] =
              compile_file_and_clean_modules_on_exit("#{tmp_dir}/ext2.pb.ex")
 
-    assert ["Bugs", unique_part1, "PbExtension"] = Module.split(file_exts_mod1)
-    assert ["Bugs", unique_part2, "PbExtension"] = Module.split(file_exts_mod2)
-    assert unique_part1 != unique_part2
+    assert [Bugs.PbExtension] =
+             compile_file_and_clean_modules_on_exit("#{tmp_dir}/bugs/pb_extension.pb.ex")
+
+    message = struct!(Bugs.Base, name: "Richard")
+
+    message = base_mod.put_extension(message, Bugs.PbExtension, :top_first_name, "TFN")
+    assert base_mod.get_extension(message, Bugs.PbExtension, :top_first_name) == "TFN"
+
+    message = base_mod.put_extension(message, Bugs.PbExtension, :top_last_name, "TLN")
+    assert base_mod.get_extension(message, Bugs.PbExtension, :top_last_name) == "TLN"
+
+    message = base_mod.put_extension(message, Bugs.Ext1.PbExtension, :first_name, "Ext1 FN")
+    assert base_mod.get_extension(message, Bugs.Ext1.PbExtension, :first_name) == "Ext1 FN"
+
+    message = base_mod.put_extension(message, Bugs.Ext2.PbExtension, :first_name, "Ext2 FN")
+    assert base_mod.get_extension(message, Bugs.Ext2.PbExtension, :first_name) == "Ext2 FN"
   end
 
   @tag :skip

--- a/test/protobuf/protoc/generator_test.exs
+++ b/test/protobuf/protoc/generator_test.exs
@@ -12,7 +12,7 @@ defmodule Protobuf.Protoc.GeneratorTest do
       desc = %Google.Protobuf.FileDescriptorProto{name: "name.proto"}
 
       assert Generator.generate(ctx, desc) ==
-               [%CodeGeneratorResponse.File{name: "name.pb.ex", content: ""}]
+               {nil, [%CodeGeneratorResponse.File{name: "name.pb.ex", content: ""}]}
     end
 
     test "uses the package prefix" do
@@ -28,7 +28,7 @@ defmodule Protobuf.Protoc.GeneratorTest do
         message_type: [%Google.Protobuf.DescriptorProto{name: "Foo"}]
       }
 
-      assert [%CodeGeneratorResponse.File{} = file] = Generator.generate(ctx, desc)
+      assert {nil, [%CodeGeneratorResponse.File{} = file]} = Generator.generate(ctx, desc)
 
       assert [{mod, _bytecode}] = Code.compile_string(file.content)
       assert mod == Myapp.Foo
@@ -50,7 +50,7 @@ defmodule Protobuf.Protoc.GeneratorTest do
         message_type: [%Google.Protobuf.DescriptorProto{name: "Foo"}]
       }
 
-      assert [%CodeGeneratorResponse.File{} = file] = Generator.generate(ctx, desc)
+      assert {nil, [%CodeGeneratorResponse.File{} = file]} = Generator.generate(ctx, desc)
 
       assert [{mod, _bytecode}] = Code.compile_string(file.content)
       assert mod == Myapp.Proto.Lib.Foo
@@ -77,7 +77,7 @@ defmodule Protobuf.Protoc.GeneratorTest do
         ]
       }
 
-      assert [%CodeGeneratorResponse.File{} = file] = Generator.generate(ctx, desc)
+      assert {nil, [%CodeGeneratorResponse.File{} = file]} = Generator.generate(ctx, desc)
 
       assert [{enum_mod, _bytecode1}, {message_mod, _bytecode2}] =
                Code.compile_string(file.content)
@@ -108,10 +108,11 @@ defmodule Protobuf.Protoc.GeneratorTest do
         ]
       }
 
-      assert [
-               %CodeGeneratorResponse.File{} = enum_file,
-               %CodeGeneratorResponse.File{} = message_file
-             ] = Generator.generate(ctx, desc)
+      assert {nil = _extensions,
+              [
+                %CodeGeneratorResponse.File{} = enum_file,
+                %CodeGeneratorResponse.File{} = message_file
+              ]} = Generator.generate(ctx, desc)
 
       assert message_file.name == "foo/my_message/nested.pb.ex"
       assert enum_file.name == "foo/my_enum.pb.ex"
@@ -130,7 +131,7 @@ defmodule Protobuf.Protoc.GeneratorTest do
         message_type: [%Google.Protobuf.DescriptorProto{name: "MyMessage.Nested"}]
       }
 
-      assert [%CodeGeneratorResponse.File{} = file] = Generator.generate(ctx, desc)
+      assert {nil, [%CodeGeneratorResponse.File{} = file]} = Generator.generate(ctx, desc)
 
       assert file.name == "prfx/foo/my_message/nested.pb.ex"
     end
@@ -148,7 +149,7 @@ defmodule Protobuf.Protoc.GeneratorTest do
         message_type: [%Google.Protobuf.DescriptorProto{name: "MyMessage.Nested"}]
       }
 
-      assert [%CodeGeneratorResponse.File{} = file] = Generator.generate(ctx, desc)
+      assert {nil, [%CodeGeneratorResponse.File{} = file]} = Generator.generate(ctx, desc)
 
       assert file.name == "my/prefix/my_message/nested.pb.ex"
     end
@@ -167,7 +168,7 @@ defmodule Protobuf.Protoc.GeneratorTest do
       }
 
       # We can't compile the generated service module because we haven't loaded GRPC.Service here.
-      assert [%CodeGeneratorResponse.File{} = file] = Generator.generate(ctx, desc)
+      assert {nil, [%CodeGeneratorResponse.File{} = file]} = Generator.generate(ctx, desc)
       assert file.content =~ "defmodule MyService.Service do"
     end
   end

--- a/test/protobuf/protoc/proto/test.proto
+++ b/test/protobuf/protoc/proto/test.proto
@@ -67,7 +67,7 @@ message Reply {
 
 message OtherBase {
   optional string name = 1;
-  extensions 100 to max;
+  extensions 100 to 110, 199;
 }
 
 message ReplyExtensions {


### PR DESCRIPTION
Closes #88.

The idea here is:

  * Generate one extension module per message, as suggested by @ericmj (https://github.com/elixir-protobuf/protobuf/issues/88#issuecomment-961293983)
  * For extensions defined at the `.proto` file level, we generate a unique module name like `<package>.Extensions<unique_int>.PbExtension`. The `<unique_int>` part is calculated by using `erlang:phash2/1` on the sorted list of extensions definitions in the file. That way it stays mostly the same when regenerating, module reordering them too.