### PR TITLE
Update docs to work with v0.10.0

### DIFF
--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -8,8 +8,6 @@ defmodule Protobuf do
       defmodule Foo do
         use Protobuf, syntax: :proto3
 
-        defstruct [:a, :b]
-
         field :a, 1, type: :int32
         field :b, 2, type: :string
       end


### PR DESCRIPTION
Old docs in `Protobuf` module (and hex docs) don't work with a 0.10.0 change not requiring `defstruct` when making a new protobuf module.

Before change:

![image](https://user-images.githubusercontent.com/25253248/210443183-a0cf5754-f878-4c34-b5e0-1387307c96c5.png)

After change:

![image](https://user-images.githubusercontent.com/25253248/210443217-bb9b7694-51c0-4740-a88c-c763a2a47b90.png)

Because of this change, the example from the Protobuf behaviour hex docs can be used without edits.