### PR TITLE
Add support for handling "." in FieldMask paths when JSON decoding

### DIFF
--- a/lib/protobuf/json/decode.ex
+++ b/lib/protobuf/json/decode.ex
@@ -204,8 +204,10 @@ defmodule Protobuf.JSON.Decode do
   def from_json_data(data, module) when is_atom(module), do: throw({:bad_message, data, module})
 
   defp convert_field_mask_to_underscore(mask) do
-    if mask =~ ~r/^[a-zA-Z0-9]+$/ do
-      Macro.underscore(mask)
+    if mask =~ ~r/^[a-zA-Z0-9\.]+$/ do
+      String.split(mask, ".")
+      |> Enum.map(&Macro.underscore/1)
+      |> Enum.join(".")
     else
       throw({:bad_field_mask, mask})
     end

--- a/test/protobuf/json/decode_test.exs
+++ b/test/protobuf/json/decode_test.exs
@@ -773,6 +773,7 @@ defmodule Protobuf.JSON.DecodeTest do
       cases = [
         {"", []},
         {"helloWorld1", ["hello_world1"]},
+        {"foo.bar,foo.baz2Bong,fooBar.bazBong", ["foo.bar", "foo.baz2_bong", "foo_bar.baz_bong"]},
         {"fooBar,baz2Bong", ["foo_bar", "baz2_bong"]}
       ]
 

--- a/test/protobuf/json/encode_test.exs
+++ b/test/protobuf/json/encode_test.exs
@@ -336,6 +336,14 @@ defmodule Protobuf.JSON.EncodeTest do
 
       assert encode(message) == %{"optionalFieldMask" => "fooBar,bazBong"}
     end
+
+    test "encodes with a period in the path" do
+      message = %TestAllTypesProto3{
+        optional_field_mask: %Google.Protobuf.FieldMask{paths: ["foo.bar", "foo_bar.baz_bong"]}
+      }
+
+      assert encode(message) == %{"optionalFieldMask" => "foo.bar,fooBar.bazBong"}
+    end
   end
 
   describe "Google.Protobuf.Duration" do


### PR DESCRIPTION
Fixes #335 