### PR TITLE
Correctly indent code block in docs

### DIFF
--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -243,9 +243,9 @@ defmodule Protobuf do
 
   In this case, this function will return the decoded unknown field:
 
-    message = User.decode(<<...>>)
-    Protobuf.get_unknown_fields(message)
-    #=> [{_field_number = 1, _wire_type = 3, "user@example.com}]
+      message = User.decode(<<...>>)
+      Protobuf.get_unknown_fields(message)
+      #=> [{_field_number = 1, _wire_type = 3, "user@example.com}]
 
   """
   @doc since: "0.10.0"


### PR DESCRIPTION
Should update the a hex docs section to show a code snippet as code instead of just text.

Old text:

![image](https://user-images.githubusercontent.com/25253248/213262599-e5282b90-7cf4-4373-afad-fd58b47d6c01.png)
