### PR TITLE
Add optional keys to `Protobuf.decode/2` typespecs

### DIFF
--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -175,7 +175,11 @@ defmodule Protobuf do
       #=> ** (Protobuf.DecodeError) ...
 
   """
-  @spec decode(binary(), message) :: %{required(:__struct__) => message} when message: module()
+  @spec decode(binary(), message) :: %{
+          required(:__struct__) => message,
+          optional(atom()) => any()
+        }
+        when message: module()
   defdelegate decode(data, module), to: Protobuf.Decoder
 
   @doc """


### PR DESCRIPTION
Same issue as in https://github.com/elixir-protobuf/protobuf/issues/287, the typespec was over constrained and not really accepting the structs as it should
