### PR TITLE
Fix JSON encoding of proto3 optional non-nil defaults

### DIFF
--- a/lib/protobuf/json/encode.ex
+++ b/lib/protobuf/json/encode.ex
@@ -162,8 +162,22 @@ defmodule Protobuf.JSON.Encode do
   defp encode_regular_fields(struct, %{field_props: field_props}, opts) do
     for {_field_num, %{name_atom: name, oneof: nil} = prop} <- field_props,
         %{^name => value} = struct,
-        opts[:emit_unpopulated] || !default?(prop, value) do
+        emit?(prop, value) || opts[:emit_unpopulated] do
       encode_field(prop, value, opts)
+    end
+  end
+
+  defp emit?(_prop, nil) do
+    false
+  end
+
+  defp emit?(prop, value) do
+    case default?(prop, value) do
+      true ->
+        prop.proto3_optional?
+
+      false ->
+        true
     end
   end
 

--- a/lib/protobuf/json/encode.ex
+++ b/lib/protobuf/json/encode.ex
@@ -172,13 +172,7 @@ defmodule Protobuf.JSON.Encode do
   end
 
   defp emit?(prop, value) do
-    case default?(prop, value) do
-      true ->
-        prop.proto3_optional?
-
-      false ->
-        true
-    end
+    if default?(prop, value), do: prop.proto3_optional?, else: true
   end
 
   defp encode_oneof_fields(struct, message_props, opts) do

--- a/test/protobuf/json/decode_test.exs
+++ b/test/protobuf/json/decode_test.exs
@@ -653,6 +653,26 @@ defmodule Protobuf.JSON.DecodeTest do
              %ContainsTransformModule{field: nil}
   end
 
+  test "decodes nil for proto3" do
+    data = %{
+      "b" => "A"
+    }
+
+    assert decode(data, TestMsg.Proto3Optional) ==
+             {:ok, %TestMsg.Proto3Optional{a: nil, b: "A", c: nil}}
+  end
+
+  test "decodes default values for proto3 optional" do
+    data = %{
+      "a" => 0,
+      "b" => "A",
+      "c" => "UNKNOWN"
+    }
+
+    assert decode(data, TestMsg.Proto3Optional) ==
+             {:ok, %TestMsg.Proto3Optional{a: 0, b: "A", c: :UNKNOWN}}
+  end
+
   describe "Google types" do
     test "Google.Protobuf.Empty" do
       data = %{}

--- a/test/protobuf/json/encode_test.exs
+++ b/test/protobuf/json/encode_test.exs
@@ -14,6 +14,16 @@ defmodule Protobuf.JSON.EncodeTest do
     Scalars
   }
 
+  test "encodes proto3 optional fields zero values" do
+    message = %TestMsg.Proto3Optional{a: 0, c: :UNKNOWN}
+    assert encode(message) == %{"a" => 0, "c" => :UNKNOWN}
+  end
+
+  test "skips a proto3 optional field with a nil value" do
+    message = %TestMsg.Proto3Optional{a: nil, c: nil}
+    assert encode(message) == %{}
+  end
+
   test "encodes strings and booleans as they are" do
     message = %Scalars{string: "エリクサー", bool: true}
     assert encode(message) == %{"string" => "エリクサー", "bool" => true}


### PR DESCRIPTION
It fixes the same issue but now for the JSON encoder like https://github.com/elixir-protobuf/protobuf/pull/302

Currently with proto3 optional values, a zero/default value is skipped. This means that the JSON `decode(encode(msg))` is not the same for all messages with proto3 optional fields.

This PR ensures that attributes containing the default values are not skipped for proto3_optional fields.