### PR TITLE
Add lib/elixirpb to package files

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -73,17 +73,6 @@ defmodule Protobuf.Mixfile do
     [
       maintainers: ["Bing Han", "Andrea Leopardi"],
       licenses: ["MIT"],
-      files: ~w(
-        mix.exs
-        README.md
-        lib/google
-        lib/protobuf
-        lib/*.ex
-        src
-        LICENSE
-        priv/templates
-        .formatter.exs
-      ),
       links: %{"GitHub" => @source_url}
     ]
   end


### PR DESCRIPTION
This fixes the issue that `option (elixirpb.file).module_prefix` is not loaded correctly if the protobuf package is installed from Hex, due to missing lib/elixirpb/pb_extension.pb.ex in the 0.11.0 or 0.12.0 packages.

Closes #367 
