### PR TITLE
Don't encode a struct as another struct

### DIFF
--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -143,9 +143,15 @@ defmodule Protobuf.Encoder do
 
   defp encode_from_type(mod, msg) do
     case msg do
-      %{__struct__: ^mod} -> encode_to_iodata(msg)
-      %_{} -> encode_to_iodata(struct(mod, Map.from_struct(msg)))
-      _ -> encode_to_iodata(struct(mod, msg))
+      %{__struct__: ^mod} ->
+        encode_to_iodata(msg)
+
+      %other_mod{} ->
+        raise Protobuf.EncodeError,
+          message: "struct #{inspect(other_mod)} can't be encoded as #{inspect(mod)}"
+
+      _ ->
+        encode_to_iodata(struct(mod, msg))
     end
   end
 

--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -146,9 +146,10 @@ defmodule Protobuf.Encoder do
       %{__struct__: ^mod} ->
         encode_to_iodata(msg)
 
-      %other_mod{} ->
+      %other_mod{} = struct ->
         raise Protobuf.EncodeError,
-          message: "struct #{inspect(other_mod)} can't be encoded as #{inspect(mod)}"
+          message:
+            "struct #{inspect(other_mod)} can't be encoded as #{inspect(mod)}: #{inspect(struct)}"
 
       _ ->
         encode_to_iodata(struct(mod, msg))

--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -264,6 +264,26 @@ defmodule Protobuf.EncoderTest do
     end
   end
 
+  test "raises for invalid types" do
+    message = ~r/123 is invalid for type :string/
+
+    assert_raise Protobuf.EncodeError, message, fn ->
+      Encoder.encode(%TestMsg.Foo{c: 123})
+    end
+
+    message = ~r/protocol Enumerable not implemented for 123/
+
+    assert_raise Protobuf.EncodeError, message, fn ->
+      Encoder.encode(%TestMsg.Foo{e: 123})
+    end
+
+    message = ~r/struct TestMsg.Foo.Baz can't be encoded as TestMsg.Foo.Bar/
+
+    assert_raise Protobuf.EncodeError, message, fn ->
+      Encoder.encode(%TestMsg.Foo{e: %TestMsg.Foo.Baz{a: 123}})
+    end
+  end
+
   test "encodes with transformer module" do
     msg = %TestMsg.ContainsTransformModule{field: 0}
     assert Encoder.encode(msg) == <<10, 0>>

--- a/test/protobuf/message_merge_test.exs
+++ b/test/protobuf/message_merge_test.exs
@@ -49,7 +49,10 @@ defmodule Protobuf.MessageMergeTest do
   test "oneof fields with the same tag are merged"
 
   test "the latest oneof field takes precedence if the two have different tags" do
-    msg1 = %TestAllTypesProto3{oneof_field: {:oneof_nested_message, %TestAllTypesProto3{}}}
+    msg1 = %TestAllTypesProto3{
+      oneof_field: {:oneof_nested_message, %TestAllTypesProto3.NestedMessage{}}
+    }
+
     msg2 = %TestAllTypesProto3{oneof_field: {:oneof_string, "foo"}}
 
     decoded = concat_and_decode([msg1, msg2])

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -14,6 +14,15 @@ defmodule TestMsg do
     field :b, 2, type: :string
   end
 
+  defmodule Foo.Baz do
+    @moduledoc false
+    use Protobuf, syntax: :proto3
+
+    field :a, 1, type: :int32
+    field :b, 2, type: :string
+    field :c, 3, type: :string
+  end
+
   defmodule EnumFoo do
     @moduledoc false
     use Protobuf, enum: true, syntax: :proto3


### PR DESCRIPTION
Closes https://github.com/elixir-protobuf/protobuf/issues/365

This is a breaking change, as you could rely on the automatic transformation between structs. I don't think that should be done, though.