### PR TITLE
Move wire_type() to Protobuf, create Protobuf.unknown_fields() type

### DIFF
--- a/lib/protobuf/dsl/typespecs.ex
+++ b/lib/protobuf/dsl/typespecs.ex
@@ -40,7 +40,7 @@ defmodule Protobuf.DSL.Typespecs do
       {:__unknown_fields__,
        quote(
          do: [
-           {field_number :: integer(), Protobuf.Wire.Types.wire_type(), value :: term()}
+           Protobuf.unknown_field()
          ]
        )}
     ]

--- a/lib/protobuf/field_props.ex
+++ b/lib/protobuf/field_props.ex
@@ -3,14 +3,12 @@ defmodule Protobuf.FieldProps do
 
   # A struct containing information about a field in a Protobuf message.
 
-  alias Protobuf.Wire.Types
-
   @type t :: %__MODULE__{
           fnum: integer,
           name: String.t(),
           name_atom: atom,
           json_name: String.t(),
-          wire_type: Types.wire_type(),
+          wire_type: Protobuf.wire_type(),
           type: atom | {:enum, atom},
           default: any,
           oneof: non_neg_integer | nil,

--- a/lib/protobuf/wire.ex
+++ b/lib/protobuf/wire.ex
@@ -34,7 +34,7 @@ defmodule Protobuf.Wire do
   @uint32_range 0..0xFFFFFFFF
   @uint64_range 0..0xFFFFFFFFFFFFFFFF
 
-  @spec wire_type(proto_type() | module()) :: Protobuf.Wire.Types.wire_type()
+  @spec wire_type(proto_type() | module()) :: Protobuf.wire_type()
   def wire_type(:int32), do: wire_varint()
   def wire_type(:int64), do: wire_varint()
   def wire_type(:uint32), do: wire_varint()
@@ -53,7 +53,7 @@ defmodule Protobuf.Wire do
   def wire_type(:float), do: wire_32bits()
   def wire_type(mod) when is_atom(mod), do: wire_delimited()
 
-  @spec encode_from_wire_type(Protobuf.Wire.Types.wire_type(), term()) :: iodata()
+  @spec encode_from_wire_type(Protobuf.wire_type(), term()) :: iodata()
   def encode_from_wire_type(wire_type, value)
 
   def encode_from_wire_type(wire_varint(), int) when is_integer(int), do: Varint.encode(int)

--- a/lib/protobuf/wire/types.ex
+++ b/lib/protobuf/wire/types.ex
@@ -1,5 +1,5 @@
 defmodule Protobuf.Wire.Types do
-  @moduledoc false
+  @moduledoc "Internal wire type"
 
   @type wire_type() :: 0..5
 

--- a/lib/protobuf/wire/types.ex
+++ b/lib/protobuf/wire/types.ex
@@ -1,7 +1,5 @@
 defmodule Protobuf.Wire.Types do
-  @moduledoc "Internal wire type"
-
-  @type wire_type() :: 0..5
+  @moduledoc false
 
   # From: https://developers.google.com/protocol-buffers/docs/encoding
   defmacro wire_varint, do: 0

--- a/test/protobuf/dsl/typespecs_test.exs
+++ b/test/protobuf/dsl/typespecs_test.exs
@@ -7,10 +7,7 @@ defmodule Protobuf.DSL.TypespecsTest do
 
   @unknown_fields_spec quote(
                          do: [
-                           __unknown_fields__: [
-                             {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
-                              value :: term()}
-                           ]
+                           __unknown_fields__: [Protobuf.unknown_field()]
                          ]
                        )
 

--- a/test/protobuf/protoc/generator/message_test.exs
+++ b/test/protobuf/protoc/generator/message_test.exs
@@ -20,10 +20,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %Foo{
-                     __unknown_fields__: [
-                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
-                        value :: term()}
-                     ]
+                     __unknown_fields__: [Protobuf.unknown_field()]
                    }
                )
              )
@@ -48,10 +45,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %Foo{
-                     __unknown_fields__: [
-                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
-                        value :: term()}
-                     ]
+                     __unknown_fields__: [Protobuf.unknown_field()]
                    }
                )
              )
@@ -177,10 +171,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %Foo{
-                     __unknown_fields__: [
-                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
-                        value :: term()}
-                     ],
+                     __unknown_fields__: [Protobuf.unknown_field()],
                      a: integer(),
                      b: String.t(),
                      c: [integer()]
@@ -371,10 +362,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %Foo{
-                     __unknown_fields__: [
-                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
-                        value :: term()}
-                     ],
+                     __unknown_fields__: [Protobuf.unknown_field()],
                      bar: Bar.t() | nil,
                      baz: [Baz.t()]
                    }
@@ -443,10 +431,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %FooBar.AbCd.Foo{
-                     __unknown_fields__: [
-                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
-                        value :: term()}
-                     ],
+                     __unknown_fields__: [Protobuf.unknown_field()],
                      a: %{optional(integer()) => FooBar.AbCd.Bar.t() | nil}
                    }
                )
@@ -535,10 +520,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %FooBar.AbCd.Foo{
-                     __unknown_fields__: [
-                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
-                        value :: term()}
-                     ],
+                     __unknown_fields__: [Protobuf.unknown_field()],
                      a: OtherPkg.MsgFoo.t() | nil
                    }
                )
@@ -598,10 +580,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %MyPkg.Foo{
-                     __unknown_fields__: [
-                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
-                        value :: term()}
-                     ],
+                     __unknown_fields__: [Protobuf.unknown_field()],
                      a: MyPkg.Foo.Nested.t() | nil
                    }
                )
@@ -702,10 +681,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %Foo{
-                     __unknown_fields__: [
-                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
-                        value :: term()}
-                     ],
+                     __unknown_fields__: [Protobuf.unknown_field()],
                      first: {:a, integer()} | {:b, integer()} | nil,
                      other: integer() | nil,
                      second: {:c, integer()} | {:d, integer()} | nil
@@ -809,10 +785,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %FooBar.AbCd.Foo{
-                     __unknown_fields__: [
-                       {field_number :: integer(), Protobuf.Wire.Types.wire_type(),
-                        value :: term()}
-                     ],
+                     __unknown_fields__: [Protobuf.unknown_field()],
                      a: [FooBar.AbCd.EnumFoo.t()]
                    }
                )


### PR DESCRIPTION
This type is referenced from the typespecs generated by the protoc extension. When building documentation for the protobufs (that is, using include_docs=true), it can't be resolved and ex_doc will print the following warning for every struct:

warning: documentation references type "Protobuf.Wire.Types.wire_type()" but it is hidden or private.

By making it public, the warning is resolved, and it becomes clickable on hexdocs.

Another alternative to solve the issue (while keeping the internal type private) would be to change the typespec of `:__unknown_fields__` to avoid referring to it, instead referring to a public type.