### PR TITLE
Keep same alphabetical order in `Util.options_to_str/1`

### DIFF
--- a/lib/protobuf/protoc/generator/util.ex
+++ b/lib/protobuf/protoc/generator/util.ex
@@ -47,6 +47,7 @@ defmodule Protobuf.Protoc.Generator.Util do
   def options_to_str(opts) when is_map(opts) do
     opts
     |> Enum.reject(fn {_key, val} -> val in [nil, false] end)
+    |> Enum.sort()
     |> Enum.map_join(", ", fn {key, val} -> "#{key}: #{print(val)}" end)
   end
 

--- a/test/protobuf/protoc/generator/util_test.exs
+++ b/test/protobuf/protoc/generator/util_test.exs
@@ -50,6 +50,20 @@ defmodule Protobuf.Protoc.Generator.UtilTest do
       assert options_to_str(%{default: "42", enum: false}) == "default: 42"
       assert options_to_str(%{json_name: "\"theFieldName\""}) == "json_name: \"theFieldName\""
     end
+
+    test "keep options string in alphabetical order" do
+      opts = %{
+        syntax: :proto3,
+        map: true,
+        deprecated: true,
+        protoc_gen_elixir_version: "1.2.3"
+      }
+
+      sorted_str =
+        "deprecated: true, map: true, protoc_gen_elixir_version: 1.2.3, syntax: :proto3"
+
+      assert options_to_str(opts) == sorted_str
+    end
   end
 
   describe "type_from_type_name/2" do


### PR DESCRIPTION
Fixes #361.

---

Solves the issue where the module options keep changing on OTP-26+.