### PR TITLE
Fix broken code example in Protobuf.TransformModule docs

### DIFF
--- a/lib/protobuf/transform_module.ex
+++ b/lib/protobuf/transform_module.ex
@@ -13,8 +13,6 @@ defmodule Protobuf.TransformModule do
       defmodule StringMessage do
         use Protobuf, syntax: :proto3
 
-        defstruct [:value]
-
         field :value, 1, type: :string
 
         def transform_module(), do: MyTransformModule


### PR DESCRIPTION
Noticed while opening #382.

Per 0.13.0, calling `defstruct` (without `@type`) raises a compile error (see https://github.com/elixir-protobuf/protobuf/blob/0f5e070961bd06f53572bcc0fd55fe8d0d478f03/test/protobuf/dsl_test.exs#L280)