### PR TITLE
Add `typespec/1` macro to transform module behaviour

### DIFF
--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -87,13 +87,14 @@ defmodule Protobuf do
         nil
       end
 
-      defoverridable transform_module: 0
-
       @impl unquote(__MODULE__)
       def decode(data), do: Protobuf.Decoder.decode(data, __MODULE__)
 
       @impl unquote(__MODULE__)
       def encode(struct), do: Protobuf.Encoder.encode(struct)
+
+      @on_definition {Protobuf.DSL, :on_def}
+      defoverridable transform_module: 0
     end
   end
 

--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -254,11 +254,11 @@ defmodule Protobuf.DSL do
         _ ->
           raise CompileError, """
           Transform module #{inspect(unquote(transform_module_ast))} not available
-          during protobuf definition compilation.
+          during Protobuf definition compilation.
 
-          Since protobuf v0.14, protobuf definitions depend in compile time on
+          Since Protobuf v0.14, Protobuf definitions depend in compile time on
           their transform modules. This means that transform modules can't depend
-          on protobuf structs, and must be available for compilation when protobuf
+          on Protobuf structs, and must be available for compilation when Protobuf
           definitions are compiled.
           """
       end

--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -242,7 +242,7 @@ defmodule Protobuf.DSL do
     end
   end
 
-  defp def_t_typespec(props, _extension_props, transform_module_ast) when not is_nil(transform_module_ast) do
+  defp def_t_typespec(_props, _extension_props, transform_module_ast) when not is_nil(transform_module_ast) do
     quote do
       @type t() :: unquote(transform_module_ast).t(__MODULE__)
     end

--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -136,6 +136,21 @@ defmodule Protobuf.DSL do
   alias Protobuf.MessageProps
   alias Protobuf.Wire
 
+  # Registered as the @on_definition compile callback for modules that call "use Protobuf"
+  # Allow us to detect when `transform_module` is re-defined
+  def on_def(_env, :def, :transform_module, [], [], [do: nil]) do
+    :ok
+  end
+
+  def on_def(env, :def, :transform_module, [], [], [do: module_alias_ast]) do
+    Module.put_attribute(env.module, :transform_module, module_alias_ast)
+    :ok
+  end
+
+  def on_def(_, _, _, _, _, _) do
+    :ok
+  end
+
   # Registered as the @before_compile callback for modules that call "use Protobuf".
   defmacro __before_compile__(env) do
     fields = Module.get_attribute(env.module, :fields)
@@ -151,6 +166,7 @@ defmodule Protobuf.DSL do
 
     defines_t_type? = Module.defines_type?(env.module, {:t, 0})
     defines_defstruct? = Module.defines?(env.module, {:__struct__, 1})
+    transform_module_ast = Module.get_attribute(env.module, :transform_module)
 
     quote do
       @spec __message_props__() :: Protobuf.MessageProps.t()
@@ -208,7 +224,7 @@ defmodule Protobuf.DSL do
 
         # Newest version of this library generate both the t/0 type as well as the struct.
         true ->
-          unquote(def_t_typespec(msg_props, extension_props))
+          unquote(def_t_typespec(msg_props, extension_props, transform_module_ast))
           unquote(gen_defstruct(msg_props))
       end
 
@@ -226,19 +242,25 @@ defmodule Protobuf.DSL do
     end
   end
 
-  defp def_t_typespec(%MessageProps{enum?: true} = props, _extension_props) do
+  defp def_t_typespec(props, _extension_props, transform_module_ast) when not is_nil(transform_module_ast) do
+    quote do
+      @type t() :: unquote(transform_module_ast).t(__MODULE__)
+    end
+  end
+
+  defp def_t_typespec(%MessageProps{enum?: true} = props, _extension_props, _) do
     quote do
       @type t() :: unquote(Protobuf.DSL.Typespecs.quoted_enum_typespec(props))
     end
   end
 
-  defp def_t_typespec(%MessageProps{} = props, _extension_props = nil) do
+  defp def_t_typespec(%MessageProps{} = props, _extension_props = nil, _) do
     quote do
       @type t() :: unquote(Protobuf.DSL.Typespecs.quoted_message_typespec(props))
     end
   end
 
-  defp def_t_typespec(_props, _extension_props) do
+  defp def_t_typespec(_props, _extension_props, _) do
     nil
   end
 

--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -247,25 +247,9 @@ defmodule Protobuf.DSL do
     default_typespec = def_t_typespec(props, extension_props, nil)
 
     quote do
-      case Code.ensure_compiled(unquote(transform_module_ast)) do
-        {:module, _} ->
-          :ok
-
-        _ ->
-          raise CompileError, """
-          Transform module #{inspect(unquote(transform_module_ast))} not available
-          during Protobuf definition compilation.
-
-          Since Protobuf v0.14, Protobuf definitions depend in compile time on
-          their transform modules. This means that transform modules can't depend
-          on Protobuf structs, and must be available for compilation when Protobuf
-          definitions are compiled.
-          """
-      end
-
       require unquote(transform_module_ast)
 
-      if macro_exported?(unquote(transform_module_ast), :typespec, 2) do
+      if macro_exported?(unquote(transform_module_ast), :typespec, 1) do
         unquote(transform_module_ast).typespec(unquote(default_typespec))
       else
         unquote(default_typespec)

--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -266,7 +266,7 @@ defmodule Protobuf.DSL do
       require unquote(transform_module_ast)
 
       if macro_exported?(unquote(transform_module_ast), :typespec, 2) do
-        unquote(transform_module_ast).typespec(__MODULE__, unquote(default_typespec))
+        unquote(transform_module_ast).typespec(unquote(default_typespec))
       else
         unquote(default_typespec)
       end

--- a/lib/protobuf/transform_module.ex
+++ b/lib/protobuf/transform_module.ex
@@ -23,7 +23,7 @@ defmodule Protobuf.TransformModule do
       defmodule MyTransformModule do
         @behaviour Protobuf.TransformModule
 
-        defmacro typespec(_module, _default_ast) do
+        defmacro typespec(_default_ast) do
           quote do
             @type t() :: String.t()
           end
@@ -36,7 +36,7 @@ defmodule Protobuf.TransformModule do
         def decode(%{value: string}, StringMessage), do: string
       end
 
-  Notice that since the `c:typespec/2` macro was introduced, transform modules can't
+  Notice that since the `c:typespec/1` macro was introduced, transform modules can't
   depend on the types that they transform anymore in compile time, meaning struct
   syntax can't be used.
   """
@@ -64,9 +64,9 @@ defmodule Protobuf.TransformModule do
   @doc """
   Transforms the typespec for modules using this transformer
 
-  Optional. If this callback is not present, the default typespec will be used.
+  If this callback is not present, the default typespec will be used.
   """
-  @macrocallback typespec(module :: module(), default_typespec :: Macro.t()) :: Macro.t()
+  @macrocallback typespec(default_typespec :: Macro.t()) :: Macro.t()
 
-  @optional_callbacks [typespec: 2]
+  @optional_callbacks [typespec: 1]
 end

--- a/lib/protobuf/transform_module.ex
+++ b/lib/protobuf/transform_module.ex
@@ -62,7 +62,7 @@ defmodule Protobuf.TransformModule do
   @callback decode(message(), type()) :: value()
 
   @doc """
-  Transforms the typespec for modules using this transformer
+  Transforms the typespec for modules using this transformer.
 
   If this callback is not present, the default typespec will be used.
   """

--- a/lib/protobuf/transform_module/infer_fields_from_enum.ex
+++ b/lib/protobuf/transform_module/infer_fields_from_enum.ex
@@ -5,8 +5,6 @@ defmodule Protobuf.TransformModule.InferFieldsFromEnum do
   `c:Protobuf.new/1` before the value is encoded.
   """
 
-  @type t(_module) :: term()
-
   @behaviour Protobuf.TransformModule
 
   @impl true

--- a/lib/protobuf/transform_module/infer_fields_from_enum.ex
+++ b/lib/protobuf/transform_module/infer_fields_from_enum.ex
@@ -5,6 +5,8 @@ defmodule Protobuf.TransformModule.InferFieldsFromEnum do
   `c:Protobuf.new/1` before the value is encoded.
   """
 
+  @type t(_module) :: term()
+
   @behaviour Protobuf.TransformModule
 
   @impl true

--- a/test/protobuf/protoc/cli_integration_test.exs
+++ b/test/protobuf/protoc/cli_integration_test.exs
@@ -45,7 +45,7 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
       protoc!([
         "--proto_path=#{tmp_dir}",
         "--elixir_out=#{tmp_dir}",
-        "--elixir_opt=transform_module=MyTransformer",
+        "--elixir_opt=transform_module=Protobuf.TransformModule.InferFieldsFromEnum",
         "--plugin=./protoc-gen-elixir",
         proto_path
       ])
@@ -53,7 +53,7 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
       assert [mod] = compile_file_and_clean_modules_on_exit("#{tmp_dir}/user.pb.ex")
       assert mod == Foo.User
 
-      assert mod.transform_module() == MyTransformer
+      assert mod.transform_module() == Protobuf.TransformModule.InferFieldsFromEnum
     end
 
     test "gen_descriptors option", %{tmp_dir: tmp_dir, proto_path: proto_path} do

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -256,7 +256,7 @@ defmodule TestMsg do
 
     @impl true
     defmacro typespec(default_typespec) do
-      case module do
+      case __CALLER__.module do
         WithTransformModule ->
           quote do
             @type t() :: integer()

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -255,7 +255,7 @@ defmodule TestMsg do
     alias TestMsg.WithTransformModule
 
     @impl true
-    defmacro typespec(module, default_typespec) do
+    defmacro typespec(default_typespec) do
       case module do
         WithTransformModule ->
           quote do

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -280,6 +280,8 @@ defmodule TestMsg do
   defmodule TransformModule do
     @behaviour Protobuf.TransformModule
 
+    @type t(_module) :: term()
+
     @impl true
     def encode(integer, WithTransformModule) when is_integer(integer) do
       %WithTransformModule{field: integer}
@@ -301,6 +303,8 @@ defmodule TestMsg do
 
   defmodule TransformIntegerStrings do
     @behaviour Protobuf.TransformModule
+
+    @type t(_module) :: term()
 
     @impl true
     def encode(


### PR DESCRIPTION
Adds a `typespec/1` macrocallback to transform module behaviour.

This macro can modify the typespec for modules using it. This way, we can provide correct typespecs for modules using transformers. A "breaking" change is that transform modules can't depend on Protobuf definitions anymore. This is quite easily solvable, though.

Closes #382 

--------------------------------------------------
**Previous description, from previous implementation:**

We detect that `transform_module/0` was defined through a on_definition hook. We then store the module in an attribute. This attribute is later used by the `before_compile` callback to set the typespec, which is set in the form of:

```elixir
@type t() :: transform_module.t(__MODULE__)
```

Then, transform modules can implement proper typespecs.

No changes if `transform_module` is not overriden.

Closes #382 