### PR TITLE
Decode integer-formatted JSON numbers as float (#364)

### DIFF
--- a/lib/protobuf/json/decode.ex
+++ b/lib/protobuf/json/decode.ex
@@ -392,6 +392,7 @@ defmodule Protobuf.JSON.Decode do
   end
 
   defp decode_float(float) when is_float(float), do: {:ok, float}
+  defp decode_float(integer) when is_integer(integer), do: {:ok, integer / 1}
   defp decode_float(string) when is_binary(string), do: parse_float(string)
   defp decode_float(_bad), do: :error
 

--- a/test/protobuf/json/decode_test.exs
+++ b/test/protobuf/json/decode_test.exs
@@ -238,6 +238,10 @@ defmodule Protobuf.JSON.DecodeTest do
       data = %{"float" => 1.23e3, "double" => 1.23e-2}
       decoded = %Scalars{float: 1230.0, double: 0.0123}
       assert decode(data, Scalars) == {:ok, decoded}
+
+      data = %{"float" => 5, "double" => 9}
+      decoded = %Scalars{float: 5.0, double: 9.0}
+      assert decode(data, Scalars) == {:ok, decoded}
     end
 
     test "constants are valid" do
@@ -279,8 +283,8 @@ defmodule Protobuf.JSON.DecodeTest do
     end
 
     test "other types are invalid" do
-      data = %{"float" => 5}
-      msg = "Field 'float' has an invalid floating point (5)"
+      data = %{"float" => <<1::15>>}
+      msg = "Field 'float' has an invalid floating point (<<0, 1::size(7)>>)"
       assert decode(data, Scalars) == error(msg)
 
       data = %{"double" => true}


### PR DESCRIPTION
JSON has a single type for numbers. The same number can be written as `42` or `42.0`. Without additional context, this number should be valid in any of the Protobuf numeric types. For reference, the `protobuf` Python library is totally fine decoding `{ "foo": 42 }` with either a `float` or an `int32` Protobuf field.