### PR TITLE
Fix mangled Protobuf.EncodeError 

### DIFF
--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -296,6 +296,17 @@ defmodule Protobuf.EncoderTest do
     end
   end
 
+  test "raises correct error for nested protobufs" do
+    message = """
+    Got error when encoding TestMsg.Foo#e: ** (Protobuf.EncodeError) Got error when \
+    encoding TestMsg.Foo.Bar#a: ** (Protobuf.EncodeError) "not_a_number" is invalid for type :int32\
+    """
+
+    assert_raise Protobuf.EncodeError, message, fn ->
+      Encoder.encode(%TestMsg.Foo{a: 90, e: %TestMsg.Foo.Bar{a: "not_a_number"}})
+    end
+  end
+
   test "encodes with transformer module" do
     msg = %TestMsg.ContainsTransformModule{field: 0}
     assert Encoder.encode(msg) == <<10, 0>>


### PR DESCRIPTION
Because of the recursive implementation of `encode_fields`, unrelated
fields would get mixed up in encode errors.

For example, our struct `%TestMsg.Foo` has fields `:a`, `:b`, `:c`,
`:d`, `e` (and more...). If we had an error at `:e`, we would get the
error popping up for all fields coming before it:


```elixir
iex(1)>  %TestMsg.Foo{a: 90, e: %TestMsg.Foo.Bar{a: "not_a_number"}} |> Protobuf.encode()
** (Protobuf.EncodeError) Got error when encoding TestMsg.Foo#a: ** (Protobuf.EncodeError) Got error when encoding TestMsg.Foo#b: ** (Protobuf.EncodeError) Got error when encoding TestMsg.Foo#c: ** (Protobuf.EncodeError) Got error when encoding TestMsg.Foo#d: ** (Protobuf.EncodeError) Got error when encoding TestMsg.Foo#e: ** (Protobuf.EncodeError) Got error when encoding TestMsg.Foo.Bar#a: ** (Protobuf.EncodeError) "not_a_number" is invalid for type :int32
    (protobuf 0.13.0) lib/protobuf/encoder.ex:71: Protobuf.Encoder.encode_fields/5
    (protobuf 0.13.0) lib/protobuf/encoder.ex:33: Protobuf.Encoder.encode_with_message_props/2
    (protobuf 0.13.0) lib/protobuf/encoder.ex:18: Protobuf.Encoder.encode/1
    iex:1: (file)
```

After the patch, only the relevant fields are mentioned in the error:
```elixir
iex(3)> %TestMsg.Foo{a: 90, e: %TestMsg.Foo.Bar{a: "not_a_number"}} |> Protobuf.encode()
** (Protobuf.EncodeError) Got error when encoding TestMsg.Foo#e: ** (Protobuf.EncodeError) Got error when encoding TestMsg.Foo.Bar#a: ** (Protobuf.EncodeError) "not_a_number" is invalid for type :int32
    (protobuf 0.13.0) lib/protobuf/encoder.ex:75: Protobuf.Encoder.encode_field/4
    (protobuf 0.13.0) lib/protobuf/encoder.ex:63: Protobuf.Encoder.encode_fields/5
    (protobuf 0.13.0) lib/protobuf/encoder.ex:33: Protobuf.Encoder.encode_with_message_props/2
    (protobuf 0.13.0) lib/protobuf/encoder.ex:18: Protobuf.Encoder.encode/1
    iex:3: (file)
```