### PR TITLE
Ensure there's a newline in the end of generated files

### DIFF
--- a/lib/protobuf/protoc/generator/util.ex
+++ b/lib/protobuf/protoc/generator/util.ex
@@ -81,11 +81,14 @@ defmodule Protobuf.Protoc.Generator.Util do
 
   @spec format(String.t()) :: String.t()
   def format(code) when is_binary(code) do
-    formatted_code = Code.format_string!(code, locals_without_parens: @locals_without_parens)
+    formatted_code =
+      code
+      |> Code.format_string!(locals_without_parens: @locals_without_parens)
+      |> IO.iodata_to_binary()
 
     # As neither Code.format_string!/2 nor protoc automatically adds a newline
-    # at end of files, we must add ourselves
-    IO.iodata_to_binary([formatted_code, "\n"])
+    # at end of files, we must add ourselves if not present.
+    if String.ends_with?(formatted_code, "\n"), do: formatted_code, else: formatted_code <> "\n"
   end
 
   @spec pad_comment(String.t(), non_neg_integer()) :: String.t()

--- a/lib/protobuf/protoc/generator/util.ex
+++ b/lib/protobuf/protoc/generator/util.ex
@@ -81,9 +81,11 @@ defmodule Protobuf.Protoc.Generator.Util do
 
   @spec format(String.t()) :: String.t()
   def format(code) when is_binary(code) do
-    code
-    |> Code.format_string!(locals_without_parens: @locals_without_parens)
-    |> IO.iodata_to_binary()
+    formatted_code = Code.format_string!(code, locals_without_parens: @locals_without_parens)
+
+    # As neither Code.format_string!/2 nor protoc automatically adds a newline
+    # at end of files, we must add ourselves
+    IO.iodata_to_binary([formatted_code, "\n"])
   end
 
   @spec pad_comment(String.t(), non_neg_integer()) :: String.t()

--- a/test/protobuf/protoc/generator_test.exs
+++ b/test/protobuf/protoc/generator_test.exs
@@ -12,7 +12,7 @@ defmodule Protobuf.Protoc.GeneratorTest do
       desc = %Google.Protobuf.FileDescriptorProto{name: "name.proto"}
 
       assert Generator.generate(ctx, desc) ==
-               {nil, [%CodeGeneratorResponse.File{name: "name.pb.ex", content: ""}]}
+               {nil, [%CodeGeneratorResponse.File{name: "name.pb.ex", content: "\n"}]}
     end
 
     test "uses the package prefix" do


### PR DESCRIPTION
We must manually add it, as `Code.format_string!` doesn't add a newline to end of file, nor does protoc.

Closes #380 