### PR TITLE
Fix decoding of maps to match conformance tests

### DIFF
--- a/lib/protobuf/decoder.ex
+++ b/lib/protobuf/decoder.ex
@@ -234,7 +234,15 @@ defmodule Protobuf.Decoder do
       prop
 
     embedded_msg = decode(bin, type)
-    val = if map?, do: %{embedded_msg.key => embedded_msg.value}, else: embedded_msg
+
+    val =
+      if map?,
+        do: %{
+          (embedded_msg.key || map_default(prop, :key)) =>
+            embedded_msg.value || map_default(prop, :value)
+        },
+        else: embedded_msg
+
     val = if oneof, do: {name_atom, val}, else: val
 
     cond do
@@ -253,6 +261,15 @@ defmodule Protobuf.Decoder do
       true ->
         val
     end
+  end
+
+  defp map_default(prop, key_or_value) do
+    prop.type.__message_props__().field_props
+    |> Enum.find(fn {_key, field_props} -> field_props.name_atom == key_or_value end)
+    |> then(fn {_key, field_props} ->
+      # Conformance only works when we use proto3 defaults here, even for proto2...
+      Protobuf.DSL.field_default(:proto3, field_props)
+    end)
   end
 
   defp deep_merge(_oneof1 = {tag1, val1}, oneof2 = {tag2, val2}, props) do

--- a/lib/protobuf/decoder.ex
+++ b/lib/protobuf/decoder.ex
@@ -233,15 +233,16 @@ defmodule Protobuf.Decoder do
     %FieldProps{type: type, map?: map?, oneof: oneof, name_atom: name_atom, repeated?: repeated?} =
       prop
 
-    embedded_msg = decode(bin, type)
+    embed_msg = decode(bin, type)
 
     val =
-      if map?,
-        do: %{
-          (embedded_msg.key || map_default(prop, :key)) =>
-            embedded_msg.value || map_default(prop, :value)
-        },
-        else: embedded_msg
+      if map? do
+        key = if is_nil(embed_msg.key), do: map_default(prop, :key), else: embed_msg.key
+        value = if is_nil(embed_msg.value), do: map_default(prop, :value), else: embed_msg.value
+        %{key => value}
+      else
+        embed_msg
+      end
 
     val = if oneof, do: {name_atom, val}, else: val
 

--- a/lib/protobuf/json.ex
+++ b/lib/protobuf/json.ex
@@ -171,7 +171,9 @@ defmodule Protobuf.JSON do
           {:ok, String.t()} | {:error, EncodeError.t() | Exception.t()}
   def encode(%_{} = struct, opts \\ []) when is_list(opts) do
     if jason = load_jason() do
-      with {:ok, map} <- to_encodable(struct, opts), do: jason.encode(map)
+      with {:ok, map} <- to_encodable(struct, opts) do
+        jason.encode(map)
+      end
     else
       {:error, EncodeError.new(:no_json_lib)}
     end

--- a/test/protobuf/conformance_regressions_test.exs
+++ b/test/protobuf/conformance_regressions_test.exs
@@ -83,6 +83,12 @@ defmodule Protobuf.ConformanceRegressionsTest do
 
     @describetag message_type: "protobuf_test_messages.proto3.TestAllTypesProto3"
 
+    test "map i32 i32" do
+      mod = ProtobufTestMessages.Proto2.TestAllTypesProto2
+      problematic_payload = <<194, 3, 0>>
+      assert m = %{map_int32_int32: %{0 => 0}} = mod.decode(problematic_payload)
+    end
+
     test "Recommended.Proto3.JsonInput.NullValueInOtherOneofNewFormat.Validator",
          %{message_mod: message_mod} do
       json = "{\"oneofNullValue\": null}"

--- a/test/protobuf/conformance_regressions_test.exs
+++ b/test/protobuf/conformance_regressions_test.exs
@@ -83,7 +83,7 @@ defmodule Protobuf.ConformanceRegressionsTest do
 
     @describetag message_type: "protobuf_test_messages.proto3.TestAllTypesProto3"
 
-    test "map i32 i32" do
+    test "Required.Proto2.ProtobufInput.ValidDataMap.INT32.INT32.MissingDefault.JsonOutput" do
       mod = ProtobufTestMessages.Proto2.TestAllTypesProto2
       problematic_payload = <<194, 3, 0>>
       assert %{map_int32_int32: %{0 => 0}} = mod.decode(problematic_payload)

--- a/test/protobuf/conformance_regressions_test.exs
+++ b/test/protobuf/conformance_regressions_test.exs
@@ -86,7 +86,7 @@ defmodule Protobuf.ConformanceRegressionsTest do
     test "map i32 i32" do
       mod = ProtobufTestMessages.Proto2.TestAllTypesProto2
       problematic_payload = <<194, 3, 0>>
-      assert m = %{map_int32_int32: %{0 => 0}} = mod.decode(problematic_payload)
+      assert %{map_int32_int32: %{0 => 0}} = mod.decode(problematic_payload)
     end
 
     test "Recommended.Proto3.JsonInput.NullValueInOtherOneofNewFormat.Validator",


### PR DESCRIPTION
Different from the previous fixes in #390, I'm not 100% sure about this one. Feels like it could/should be solved in a different layer, but I didn't find a better way to do it without breaking anything else.