### PR TITLE
Accept integers in scientific notation in JSON decoder

### DIFF
--- a/lib/protobuf/json/decode.ex
+++ b/lib/protobuf/json/decode.ex
@@ -376,8 +376,24 @@ defmodule Protobuf.JSON.Decode do
 
   defp parse_int(string) do
     case Integer.parse(string) do
-      {int, ""} -> {:ok, int}
-      _ -> :error
+      {int, ""} ->
+        {:ok, int}
+
+      _ ->
+        # We accept integers in scientific notation as well:
+        case Float.parse(string) do
+          {float, ""} ->
+            truncated = trunc(float)
+
+            if truncated == float do
+              {:ok, truncated}
+            else
+              :error
+            end
+
+          _ ->
+            :error
+        end
     end
   end
 

--- a/test/protobuf/conformance_regressions_test.exs
+++ b/test/protobuf/conformance_regressions_test.exs
@@ -83,6 +83,12 @@ defmodule Protobuf.ConformanceRegressionsTest do
 
     @describetag message_type: "protobuf_test_messages.proto3.TestAllTypesProto3"
 
+    test "Required.Proto3.JsonInput.Int32FieldQuotedExponentialValue.JsonOutput" do
+      mod = ProtobufTestMessages.Proto3.TestAllTypesProto3
+      problematic_payload = ~S({"optionalInt32": "1e5"})
+      assert %{optional_int32: 100_000} = Protobuf.JSON.decode!(problematic_payload, mod)
+    end
+
     test "Recommended.Proto3.JsonInput.NullValueInOtherOneofNewFormat.Validator",
          %{message_mod: message_mod} do
       json = "{\"oneofNullValue\": null}"


### PR DESCRIPTION
Required for compliance tests