### PR TITLE
Add native Elixir `JSON` support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,7 +16,9 @@ jobs:
       matrix:
         include:
           - otp: 27.0
-            elixir: 1.17.0
+            elixir: 1.18.1
+          - otp: 27.0
+            elixir: 1.17.3
           - otp: 24.3
             elixir: 1.12.3
 

--- a/lib/protobuf/json.ex
+++ b/lib/protobuf/json.ex
@@ -314,11 +314,8 @@ defmodule Protobuf.JSON do
       {:ok, json_data} ->
         from_decoded(json_data, module)
 
-      {:error, exception} when is_exception(exception) ->
+      {:error, exception} ->
         {:error, exception}
-
-      {:error, other} ->
-        {:error, DecodeError.new(other)}
     end
   end
 

--- a/lib/protobuf/json.ex
+++ b/lib/protobuf/json.ex
@@ -269,11 +269,8 @@ defmodule Protobuf.JSON do
   @spec decode!(iodata, module) :: struct | no_return
   def decode!(iodata, module) do
     case decode(iodata, module) do
-      {:ok, json} ->
-        json
-
-      {:error, error} ->
-        raise error
+      {:ok, json} -> json
+      {:error, error} -> raise error
     end
   end
 

--- a/lib/protobuf/json/decode_error.ex
+++ b/lib/protobuf/json/decode_error.ex
@@ -80,7 +80,8 @@ defmodule Protobuf.JSON.DecodeError do
 
   def new({:unexpected_sequence, position, sequence}) do
     %__MODULE__{
-      message: "Invalid byte at position #{inspect(position)}, sequence: #{inspect(sequence)}"
+      message:
+        "Unexpected sequence at position #{inspect(position)}, sequence: #{inspect(sequence)}"
     }
   end
 end

--- a/lib/protobuf/json/decode_error.ex
+++ b/lib/protobuf/json/decode_error.ex
@@ -69,4 +69,18 @@ defmodule Protobuf.JSON.DecodeError do
   def new({:bad_repeated, field, value}) do
     %__MODULE__{message: "Repeated field '#{field}' expected a list, got #{inspect(value)}"}
   end
+
+  def new({:unexpected_end, position}) do
+    %__MODULE__{message: "Unexpected end at position #{inspect(position)}"}
+  end
+
+  def new({:invalid_byte, position, byte}) do
+    %__MODULE__{message: "Invalid byte at position #{inspect(position)}, byte: #{inspect(byte)}"}
+  end
+
+  def new({:unexpected_sequence, position, sequence}) do
+    %__MODULE__{
+      message: "Invalid byte at position #{inspect(position)}, sequence: #{inspect(sequence)}"
+    }
+  end
 end

--- a/lib/protobuf/json/json_library.ex
+++ b/lib/protobuf/json/json_library.ex
@@ -1,0 +1,29 @@
+defmodule Protobuf.JSON.JSONLibrary do
+  @moduledoc false
+  # Uses `JSON` for Elixir >= 1.18, Jason if Elixir < 1.18 and Jason available,
+  # or returns error otherwise
+
+  cond do
+    Code.ensure_loaded?(JSON) ->
+      def encode_to_iodata(encodable) do
+        try do
+          {:ok, JSON.encode_to_iodata!(encodable)}
+        rescue
+          exception ->
+            {:error, exception}
+        end
+      end
+
+      def decode(data) do
+        JSON.decode(data)
+      end
+
+    Code.ensure_loaded?(Jason) ->
+      def encode_to_iodata(encodable), do: Jason.encode_to_iodata(encodable)
+      def decode(data), do: Jason.decode(data)
+
+    true ->
+      def encode_to_iodata(_), do: {:error, EncodeError.new(:no_json_lib)}
+      def decode(_), do: {:error, EncodeError.new(:no_json_lib)}
+  end
+end

--- a/lib/protobuf/json/json_library.ex
+++ b/lib/protobuf/json/json_library.ex
@@ -15,7 +15,10 @@ defmodule Protobuf.JSON.JSONLibrary do
       end
 
       def decode(data) do
-        JSON.decode(data)
+        case JSON.decode(data) do
+          {:ok, decoded} -> {:ok, decoded}
+          {:error, error} -> {:error, Protobuf.JSON.DecodeError.new(error)}
+        end
       end
 
     Code.ensure_loaded?(Jason) ->

--- a/test/protobuf/builder_test.exs
+++ b/test/protobuf/builder_test.exs
@@ -45,11 +45,17 @@ defmodule Protobuf.BuilderTest do
     end
 
     test "raises an error for non-list repeated embedded msgs" do
-      assert_raise Protocol.UndefinedError,
-                   ~r/protocol Enumerable not implemented for %TestMsg.Foo.Bar/,
-                   fn ->
-                     Foo.new(h: Foo.Bar.new())
-                   end
+      # TODO: remove conditional once we support only Elixir 1.18+
+      message =
+        if System.version() >= "1.18.0" do
+          ~r/protocol Enumerable not implemented for type TestMsg.Foo.Ba/
+        else
+          ~r/protocol Enumerable not implemented for %TestMsg.Foo.Bar/
+        end
+
+      assert_raise Protocol.UndefinedError, message, fn ->
+        Foo.new(h: Foo.Bar.new())
+      end
     end
 
     test "builds correct message for non matched struct" do

--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -283,7 +283,9 @@ defmodule Protobuf.EncoderTest do
       Encoder.encode(%TestMsg.Foo{c: 123})
     end
 
-    message = ~r/protocol Enumerable not implemented for 123/
+    # For Elixir 1.18+ it's `type Integer`, before, it was just `123`
+    # TODO: fix once we require Elixir 1.18+
+    message = ~r/protocol Enumerable not implemented for (123|type Integer)/
 
     assert_raise Protobuf.EncodeError, message, fn ->
       Encoder.encode(%TestMsg.Foo{e: 123})

--- a/test/protobuf/json_test.exs
+++ b/test/protobuf/json_test.exs
@@ -16,20 +16,32 @@ defmodule Protobuf.JSONTest do
 
   test "encoding string field with invalid UTF-8 data" do
     message = %Scalars{string: "   \xff   "}
-    assert {:error, %Jason.EncodeError{}} = Protobuf.JSON.encode(message)
+    assert {:error, exception} = Protobuf.JSON.encode(message)
+    assert is_exception(exception)
   end
 
   test "decoding string field with invalid UTF-8 data" do
     json = ~S|{"string":"   \xff   "}|
-    assert {:error, %Jason.DecodeError{}} = Protobuf.JSON.decode(json, Scalars)
+    assert {:error, exception} = Protobuf.JSON.decode(json, Scalars)
+    assert is_exception(exception)
   end
 
   describe "bang variants of encode and decode" do
-    test "decode!/2" do
-      json = ~S|{"string":"   \xff   "}|
+    if Code.ensure_loaded?(JSON) do
+      test "decode!/2" do
+        json = ~S|{"string":"   \xff   "}|
 
-      assert_raise Jason.DecodeError, fn ->
-        Protobuf.JSON.decode!(json, Scalars)
+        assert_raise Protobuf.JSON.DecodeError, fn ->
+          Protobuf.JSON.decode!(json, Scalars)
+        end
+      end
+    else
+      test "decode!/2" do
+        json = ~S|{"string":"   \xff   "}|
+
+        assert_raise Jason.DecodeError, fn ->
+          Protobuf.JSON.decode!(json, Scalars)
+        end
       end
     end
   end

--- a/test/protobuf/json_test.exs
+++ b/test/protobuf/json_test.exs
@@ -27,6 +27,7 @@ defmodule Protobuf.JSONTest do
   end
 
   describe "bang variants of encode and decode" do
+    # TODO: remove Jason when we require Elixir 1.18
     if Code.ensure_loaded?(JSON) do
       test "decode!/2" do
         json = ~S|{"string":"   \xff   "}|


### PR DESCRIPTION
This implementation defaults to `JSON` if it's available. If it's not,
it tries to use `Jason` as it did before.

Some exceptions are changed (only for `JSON`, `Jason` is unaffected). For
example, instead of `Jason.DecodeError`, when using `JSON` we raise
`Protobuf.JSON.DecodeError`, and encode errors have a more varied shape
(since they can be mostly anything coming from Elixir side).

Additionally, it adds 1.18.1 in CI. Once it's working in both versions, I'll 
remove 1.17.x.