### PR TITLE
Update readme to warn against using different escript and deps versions.

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ Since `:protobuf` version `0.14.0` we include all of the well known Google Proto
    that `protoc-gen-elixir` works:
 
     ```bash
-    $ mix escript.install hex protobuf
+    $ mix escript.install hex protobuf 0.14.0
     ```
+    Note: make sure to use the same version of the escript and dependency in your application.
 
 3. Generate Elixir code for [helloworld.proto](https://raw.githubusercontent.com/grpc/grpc/master/examples/protos/helloworld.proto) using `protoc`:
 


### PR DESCRIPTION
Ive spent a good amount of time figuring out why our protobufs didnt compile anymore. 

It turned out that the version being installed in the CI was `0.14` and not `0.11` as in the application. 

I added a warning for this to the readme, because I feel it could save other people a lot of time.

Perhaps for the Google machine, the error I got was the following:

```== Compilation error in file  lib/protobuf/indexer_service.pb.ex ==
** (KeyError) key :features not found
    (protobuf 0.11.0) expanding struct: Google.Protobuf.MethodOptions.__struct__/1
    lib/protobuf/indexer_service.pb.ex:13: IndexerService.Service.descriptor/0```