### PR TITLE
Google_protos with descriptor 

### DIFF
--- a/lib/elixirpb.pb.ex
+++ b/lib/elixirpb.pb.ex
@@ -1,7 +1,7 @@
 defmodule Elixirpb.FileOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :module_prefix, 1, optional: true, type: :string, json_name: "modulePrefix"
 end

--- a/lib/elixirpb/pb_extension.pb.ex
+++ b/lib/elixirpb/pb_extension.pb.ex
@@ -1,7 +1,7 @@
 defmodule Elixirpb.PbExtension do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0"
+  use Protobuf, protoc_gen_elixir_version: "0.14.0"
 
   extend Google.Protobuf.FileOptions, :file, 1047, optional: true, type: Elixirpb.FileOptions
 end

--- a/lib/google/protobuf/any.pb.ex
+++ b/lib/google/protobuf/any.pb.ex
@@ -1,7 +1,53 @@
 defmodule Google.Protobuf.Any do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Any",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "type_url",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "typeUrl",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :type_url, 1, type: :string, json_name: "typeUrl"
   field :value, 2, type: :bytes

--- a/lib/google/protobuf/compiler/plugin.pb.ex
+++ b/lib/google/protobuf/compiler/plugin.pb.ex
@@ -1,7 +1,7 @@
 defmodule Google.Protobuf.Compiler.CodeGeneratorResponse.Feature do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :FEATURE_NONE, 0
   field :FEATURE_PROTO3_OPTIONAL, 1
@@ -11,7 +11,7 @@ end
 defmodule Google.Protobuf.Compiler.Version do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :major, 1, optional: true, type: :int32
   field :minor, 2, optional: true, type: :int32
@@ -22,7 +22,7 @@ end
 defmodule Google.Protobuf.Compiler.CodeGeneratorRequest do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :file_to_generate, 1, repeated: true, type: :string, json_name: "fileToGenerate"
   field :parameter, 2, optional: true, type: :string
@@ -46,7 +46,7 @@ end
 defmodule Google.Protobuf.Compiler.CodeGeneratorResponse.File do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :insertion_point, 2, optional: true, type: :string, json_name: "insertionPoint"
@@ -61,7 +61,7 @@ end
 defmodule Google.Protobuf.Compiler.CodeGeneratorResponse do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :error, 1, optional: true, type: :string
   field :supported_features, 2, optional: true, type: :uint64, json_name: "supportedFeatures"

--- a/lib/google/protobuf/descriptor.pb.ex
+++ b/lib/google/protobuf/descriptor.pb.ex
@@ -1,7 +1,7 @@
 defmodule Google.Protobuf.Edition do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :EDITION_UNKNOWN, 0
   field :EDITION_LEGACY, 900
@@ -20,7 +20,7 @@ end
 defmodule Google.Protobuf.ExtensionRangeOptions.VerificationState do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :DECLARATION, 0
   field :UNVERIFIED, 1
@@ -29,7 +29,7 @@ end
 defmodule Google.Protobuf.FieldDescriptorProto.Type do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :TYPE_DOUBLE, 1
   field :TYPE_FLOAT, 2
@@ -54,7 +54,7 @@ end
 defmodule Google.Protobuf.FieldDescriptorProto.Label do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :LABEL_OPTIONAL, 1
   field :LABEL_REPEATED, 3
@@ -64,7 +64,7 @@ end
 defmodule Google.Protobuf.FileOptions.OptimizeMode do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :SPEED, 1
   field :CODE_SIZE, 2
@@ -74,7 +74,7 @@ end
 defmodule Google.Protobuf.FieldOptions.CType do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :STRING, 0
   field :CORD, 1
@@ -84,7 +84,7 @@ end
 defmodule Google.Protobuf.FieldOptions.JSType do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :JS_NORMAL, 0
   field :JS_STRING, 1
@@ -94,7 +94,7 @@ end
 defmodule Google.Protobuf.FieldOptions.OptionRetention do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :RETENTION_UNKNOWN, 0
   field :RETENTION_RUNTIME, 1
@@ -104,7 +104,7 @@ end
 defmodule Google.Protobuf.FieldOptions.OptionTargetType do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :TARGET_TYPE_UNKNOWN, 0
   field :TARGET_TYPE_FILE, 1
@@ -121,7 +121,7 @@ end
 defmodule Google.Protobuf.MethodOptions.IdempotencyLevel do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :IDEMPOTENCY_UNKNOWN, 0
   field :NO_SIDE_EFFECTS, 1
@@ -131,7 +131,7 @@ end
 defmodule Google.Protobuf.FeatureSet.FieldPresence do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :FIELD_PRESENCE_UNKNOWN, 0
   field :EXPLICIT, 1
@@ -142,7 +142,7 @@ end
 defmodule Google.Protobuf.FeatureSet.EnumType do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :ENUM_TYPE_UNKNOWN, 0
   field :OPEN, 1
@@ -152,7 +152,7 @@ end
 defmodule Google.Protobuf.FeatureSet.RepeatedFieldEncoding do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :REPEATED_FIELD_ENCODING_UNKNOWN, 0
   field :PACKED, 1
@@ -162,7 +162,7 @@ end
 defmodule Google.Protobuf.FeatureSet.Utf8Validation do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :UTF8_VALIDATION_UNKNOWN, 0
   field :VERIFY, 2
@@ -172,7 +172,7 @@ end
 defmodule Google.Protobuf.FeatureSet.MessageEncoding do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :MESSAGE_ENCODING_UNKNOWN, 0
   field :LENGTH_PREFIXED, 1
@@ -182,7 +182,7 @@ end
 defmodule Google.Protobuf.FeatureSet.JsonFormat do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :JSON_FORMAT_UNKNOWN, 0
   field :ALLOW, 1
@@ -192,7 +192,7 @@ end
 defmodule Google.Protobuf.GeneratedCodeInfo.Annotation.Semantic do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :NONE, 0
   field :SET, 1
@@ -202,7 +202,7 @@ end
 defmodule Google.Protobuf.FileDescriptorSet do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :file, 1, repeated: true, type: Google.Protobuf.FileDescriptorProto
 
@@ -212,7 +212,7 @@ end
 defmodule Google.Protobuf.FileDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :package, 2, optional: true, type: :string
@@ -246,7 +246,7 @@ end
 defmodule Google.Protobuf.DescriptorProto.ExtensionRange do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :start, 1, optional: true, type: :int32
   field :end, 2, optional: true, type: :int32
@@ -256,7 +256,7 @@ end
 defmodule Google.Protobuf.DescriptorProto.ReservedRange do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :start, 1, optional: true, type: :int32
   field :end, 2, optional: true, type: :int32
@@ -265,7 +265,7 @@ end
 defmodule Google.Protobuf.DescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :field, 2, repeated: true, type: Google.Protobuf.FieldDescriptorProto
@@ -304,7 +304,7 @@ end
 defmodule Google.Protobuf.ExtensionRangeOptions.Declaration do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :number, 1, optional: true, type: :int32
   field :full_name, 2, optional: true, type: :string, json_name: "fullName"
@@ -316,7 +316,7 @@ end
 defmodule Google.Protobuf.ExtensionRangeOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :uninterpreted_option, 999,
     repeated: true,
@@ -343,7 +343,7 @@ end
 defmodule Google.Protobuf.FieldDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :number, 3, optional: true, type: :int32
@@ -361,7 +361,7 @@ end
 defmodule Google.Protobuf.OneofDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :options, 2, optional: true, type: Google.Protobuf.OneofOptions
@@ -370,7 +370,7 @@ end
 defmodule Google.Protobuf.EnumDescriptorProto.EnumReservedRange do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :start, 1, optional: true, type: :int32
   field :end, 2, optional: true, type: :int32
@@ -379,7 +379,7 @@ end
 defmodule Google.Protobuf.EnumDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :value, 2, repeated: true, type: Google.Protobuf.EnumValueDescriptorProto
@@ -396,7 +396,7 @@ end
 defmodule Google.Protobuf.EnumValueDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :number, 2, optional: true, type: :int32
@@ -406,7 +406,7 @@ end
 defmodule Google.Protobuf.ServiceDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :method, 2, repeated: true, type: Google.Protobuf.MethodDescriptorProto
@@ -416,7 +416,7 @@ end
 defmodule Google.Protobuf.MethodDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :input_type, 2, optional: true, type: :string, json_name: "inputType"
@@ -439,7 +439,7 @@ end
 defmodule Google.Protobuf.FileOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :java_package, 1, optional: true, type: :string, json_name: "javaPackage"
   field :java_outer_classname, 8, optional: true, type: :string, json_name: "javaOuterClassname"
@@ -522,7 +522,7 @@ end
 defmodule Google.Protobuf.MessageOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :message_set_wire_format, 1,
     optional: true,
@@ -558,7 +558,7 @@ end
 defmodule Google.Protobuf.FieldOptions.EditionDefault do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :edition, 3, optional: true, type: Google.Protobuf.Edition, enum: true
   field :value, 2, optional: true, type: :string
@@ -567,7 +567,7 @@ end
 defmodule Google.Protobuf.FieldOptions.FeatureSupport do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :edition_introduced, 1,
     optional: true,
@@ -593,7 +593,7 @@ end
 defmodule Google.Protobuf.FieldOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :ctype, 1,
     optional: true,
@@ -654,7 +654,7 @@ end
 defmodule Google.Protobuf.OneofOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :features, 1, optional: true, type: Google.Protobuf.FeatureSet
 
@@ -669,7 +669,7 @@ end
 defmodule Google.Protobuf.EnumOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :allow_alias, 2, optional: true, type: :bool, json_name: "allowAlias"
   field :deprecated, 3, optional: true, type: :bool, default: false
@@ -693,7 +693,7 @@ end
 defmodule Google.Protobuf.EnumValueOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :deprecated, 1, optional: true, type: :bool, default: false
   field :features, 2, optional: true, type: Google.Protobuf.FeatureSet
@@ -715,7 +715,7 @@ end
 defmodule Google.Protobuf.ServiceOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :features, 34, optional: true, type: Google.Protobuf.FeatureSet
   field :deprecated, 33, optional: true, type: :bool, default: false
@@ -731,7 +731,7 @@ end
 defmodule Google.Protobuf.MethodOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :deprecated, 33, optional: true, type: :bool, default: false
 
@@ -755,7 +755,7 @@ end
 defmodule Google.Protobuf.UninterpretedOption.NamePart do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :name_part, 1, required: true, type: :string, json_name: "namePart"
   field :is_extension, 2, required: true, type: :bool, json_name: "isExtension"
@@ -764,7 +764,7 @@ end
 defmodule Google.Protobuf.UninterpretedOption do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :name, 2, repeated: true, type: Google.Protobuf.UninterpretedOption.NamePart
   field :identifier_value, 3, optional: true, type: :string, json_name: "identifierValue"
@@ -778,7 +778,7 @@ end
 defmodule Google.Protobuf.FeatureSet do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :field_presence, 1,
     optional: true,
@@ -828,7 +828,7 @@ end
 defmodule Google.Protobuf.FeatureSetDefaults.FeatureSetEditionDefault do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :edition, 3, optional: true, type: Google.Protobuf.Edition, enum: true
 
@@ -846,7 +846,7 @@ end
 defmodule Google.Protobuf.FeatureSetDefaults do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :defaults, 1,
     repeated: true,
@@ -868,7 +868,7 @@ end
 defmodule Google.Protobuf.SourceCodeInfo.Location do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :path, 1, repeated: true, type: :int32, packed: true, deprecated: false
   field :span, 2, repeated: true, type: :int32, packed: true, deprecated: false
@@ -884,7 +884,7 @@ end
 defmodule Google.Protobuf.SourceCodeInfo do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :location, 1, repeated: true, type: Google.Protobuf.SourceCodeInfo.Location
 
@@ -894,7 +894,7 @@ end
 defmodule Google.Protobuf.GeneratedCodeInfo.Annotation do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :path, 1, repeated: true, type: :int32, packed: true, deprecated: false
   field :source_file, 2, optional: true, type: :string, json_name: "sourceFile"
@@ -910,7 +910,7 @@ end
 defmodule Google.Protobuf.GeneratedCodeInfo do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
 
   field :annotation, 1, repeated: true, type: Google.Protobuf.GeneratedCodeInfo.Annotation
 end

--- a/lib/google/protobuf/duration.pb.ex
+++ b/lib/google/protobuf/duration.pb.ex
@@ -1,7 +1,53 @@
 defmodule Google.Protobuf.Duration do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Duration",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "seconds",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT64,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "seconds",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "nanos",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT32,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "nanos",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :seconds, 1, type: :int64
   field :nanos, 2, type: :int32

--- a/lib/google/protobuf/empty.pb.ex
+++ b/lib/google/protobuf/empty.pb.ex
@@ -1,5 +1,22 @@
 defmodule Google.Protobuf.Empty do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Empty",
+      field: [],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 end

--- a/lib/google/protobuf/field_mask.pb.ex
+++ b/lib/google/protobuf/field_mask.pb.ex
@@ -1,7 +1,39 @@
 defmodule Google.Protobuf.FieldMask do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "FieldMask",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "paths",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_REPEATED,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "paths",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :paths, 1, repeated: true, type: :string
 end

--- a/lib/google/protobuf/struct.pb.ex
+++ b/lib/google/protobuf/struct.pb.ex
@@ -1,7 +1,26 @@
 defmodule Google.Protobuf.NullValue do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.EnumDescriptorProto{
+      name: "NullValue",
+      value: [
+        %Google.Protobuf.EnumValueDescriptorProto{
+          name: "NULL_VALUE",
+          number: 0,
+          options: nil,
+          __unknown_fields__: []
+        }
+      ],
+      options: nil,
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :NULL_VALUE, 0
 end
@@ -9,7 +28,63 @@ end
 defmodule Google.Protobuf.Struct.FieldsEntry do
   @moduledoc false
 
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "FieldsEntry",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "key",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "key",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".google.protobuf.Value",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: %Google.Protobuf.MessageOptions{
+        message_set_wire_format: false,
+        no_standard_descriptor_accessor: false,
+        deprecated: false,
+        map_entry: true,
+        deprecated_legacy_json_field_conflicts: nil,
+        features: nil,
+        uninterpreted_option: [],
+        __pb_extensions__: %{},
+        __unknown_fields__: []
+      },
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :key, 1, type: :string
   field :value, 2, type: Google.Protobuf.Value
@@ -18,7 +93,92 @@ end
 defmodule Google.Protobuf.Struct do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Struct",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "fields",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_REPEATED,
+          type: :TYPE_MESSAGE,
+          type_name: ".google.protobuf.Struct.FieldsEntry",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "fields",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [
+        %Google.Protobuf.DescriptorProto{
+          name: "FieldsEntry",
+          field: [
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "key",
+              extendee: nil,
+              number: 1,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_STRING,
+              type_name: nil,
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "key",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            },
+            %Google.Protobuf.FieldDescriptorProto{
+              name: "value",
+              extendee: nil,
+              number: 2,
+              label: :LABEL_OPTIONAL,
+              type: :TYPE_MESSAGE,
+              type_name: ".google.protobuf.Value",
+              default_value: nil,
+              options: nil,
+              oneof_index: nil,
+              json_name: "value",
+              proto3_optional: nil,
+              __unknown_fields__: []
+            }
+          ],
+          nested_type: [],
+          enum_type: [],
+          extension_range: [],
+          extension: [],
+          options: %Google.Protobuf.MessageOptions{
+            message_set_wire_format: false,
+            no_standard_descriptor_accessor: false,
+            deprecated: false,
+            map_entry: true,
+            deprecated_legacy_json_field_conflicts: nil,
+            features: nil,
+            uninterpreted_option: [],
+            __pb_extensions__: %{},
+            __unknown_fields__: []
+          },
+          oneof_decl: [],
+          reserved_range: [],
+          reserved_name: [],
+          __unknown_fields__: []
+        }
+      ],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :fields, 1, repeated: true, type: Google.Protobuf.Struct.FieldsEntry, map: true
 end
@@ -26,7 +186,111 @@ end
 defmodule Google.Protobuf.Value do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Value",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "null_value",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_ENUM,
+          type_name: ".google.protobuf.NullValue",
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "nullValue",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "number_value",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_DOUBLE,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "numberValue",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "string_value",
+          extendee: nil,
+          number: 3,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "stringValue",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "bool_value",
+          extendee: nil,
+          number: 4,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BOOL,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "boolValue",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "struct_value",
+          extendee: nil,
+          number: 5,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".google.protobuf.Struct",
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "structValue",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "list_value",
+          extendee: nil,
+          number: 6,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_MESSAGE,
+          type_name: ".google.protobuf.ListValue",
+          default_value: nil,
+          options: nil,
+          oneof_index: 0,
+          json_name: "listValue",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [
+        %Google.Protobuf.OneofDescriptorProto{name: "kind", options: nil, __unknown_fields__: []}
+      ],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   oneof :kind, 0
 
@@ -46,7 +310,39 @@ end
 defmodule Google.Protobuf.ListValue do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "ListValue",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "values",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_REPEATED,
+          type: :TYPE_MESSAGE,
+          type_name: ".google.protobuf.Value",
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "values",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :values, 1, repeated: true, type: Google.Protobuf.Value
 end

--- a/lib/google/protobuf/timestamp.pb.ex
+++ b/lib/google/protobuf/timestamp.pb.ex
@@ -1,7 +1,53 @@
 defmodule Google.Protobuf.Timestamp do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Timestamp",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "seconds",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT64,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "seconds",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        },
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "nanos",
+          extendee: nil,
+          number: 2,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT32,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "nanos",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :seconds, 1, type: :int64
   field :nanos, 2, type: :int32

--- a/lib/google/protobuf/wrappers.pb.ex
+++ b/lib/google/protobuf/wrappers.pb.ex
@@ -1,7 +1,39 @@
 defmodule Google.Protobuf.DoubleValue do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "DoubleValue",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_DOUBLE,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :value, 1, type: :double
 end
@@ -9,7 +41,39 @@ end
 defmodule Google.Protobuf.FloatValue do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "FloatValue",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_FLOAT,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :value, 1, type: :float
 end
@@ -17,7 +81,39 @@ end
 defmodule Google.Protobuf.Int64Value do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Int64Value",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT64,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :value, 1, type: :int64
 end
@@ -25,7 +121,39 @@ end
 defmodule Google.Protobuf.UInt64Value do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "UInt64Value",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_UINT64,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :value, 1, type: :uint64
 end
@@ -33,7 +161,39 @@ end
 defmodule Google.Protobuf.Int32Value do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "Int32Value",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_INT32,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :value, 1, type: :int32
 end
@@ -41,7 +201,39 @@ end
 defmodule Google.Protobuf.UInt32Value do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "UInt32Value",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_UINT32,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :value, 1, type: :uint32
 end
@@ -49,7 +241,39 @@ end
 defmodule Google.Protobuf.BoolValue do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "BoolValue",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BOOL,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :value, 1, type: :bool
 end
@@ -57,7 +281,39 @@ end
 defmodule Google.Protobuf.StringValue do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "StringValue",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_STRING,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :value, 1, type: :string
 end
@@ -65,7 +321,39 @@ end
 defmodule Google.Protobuf.BytesValue do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.13.0", syntax: :proto3
+  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+
+  def descriptor do
+    # credo:disable-for-next-line
+    %Google.Protobuf.DescriptorProto{
+      name: "BytesValue",
+      field: [
+        %Google.Protobuf.FieldDescriptorProto{
+          name: "value",
+          extendee: nil,
+          number: 1,
+          label: :LABEL_OPTIONAL,
+          type: :TYPE_BYTES,
+          type_name: nil,
+          default_value: nil,
+          options: nil,
+          oneof_index: nil,
+          json_name: "value",
+          proto3_optional: nil,
+          __unknown_fields__: []
+        }
+      ],
+      nested_type: [],
+      enum_type: [],
+      extension_range: [],
+      extension: [],
+      options: nil,
+      oneof_decl: [],
+      reserved_range: [],
+      reserved_name: [],
+      __unknown_fields__: []
+    }
+  end
 
   field :value, 1, type: :bytes
 end

--- a/mix.exs
+++ b/mix.exs
@@ -192,7 +192,7 @@ defmodule Protobuf.Mixfile do
       google/protobuf/wrappers.proto
     )
 
-    protoc!("-I \"#{proto_src}\"", "./lib", files)
+    protoc!("-I \"#{proto_src}\" --elixir_opt=gen_descriptors=true", "./lib", files)
   end
 
   defp gen_google_test_protos(_args) do


### PR DESCRIPTION
This is done to avoid breaking apps that depended on google_protos descriptor functionality that needs to update to the latest `protobuf` version.

solves: https://github.com/elixir-protobuf/protobuf/issues/401 