### PR TITLE
Create Protobuf.Presence module

### DIFF
--- a/lib/protobuf/presence.ex
+++ b/lib/protobuf/presence.ex
@@ -111,11 +111,12 @@ defmodule Protobuf.Presence do
     end
   end
 
-  # Defaults for different field types: implicit presence means they are maybe set
+  # Messages have explicit presence tracking in proto3
   def get_field_presence(:proto3, nil, _prop) do
-    :maybe
+    :not_present
   end
 
+  # Defaults for different field types: implicit presence means they are maybe set
   def get_field_presence(:proto3, 0, _prop) do
     :maybe
   end

--- a/lib/protobuf/presence.ex
+++ b/lib/protobuf/presence.ex
@@ -1,0 +1,151 @@
+defmodule Protobuf.Presence do
+  @moduledoc """
+  Helpers for determining Protobuf field presence.
+  """
+
+  alias Protobuf.FieldProps
+
+  @doc """
+  Returns whether a field or oneof is present, not present, or maybe present
+
+  `:present` and `:not present` mean that a field is **explicitly** present or not,
+  respectively.
+
+  Some values may be implicitly present. For example, lists in `repeated` fields
+  always have implicit presence. In these cases, if the presence is ambiguous,
+  returns `:maybe`.
+  """
+  @spec field_presence(message :: struct(), field :: atom()) :: :present | :not_present | :maybe
+  def field_presence(%mod{} = message, field) do
+    message_props = mod.__message_props__()
+    transformed_message = transform_module(message, mod)
+    fnum = Map.fetch!(message_props.field_tags, field)
+    field_prop = Map.fetch!(message_props.field_props, fnum)
+    value = get_oneof_value(transformed_message, message_props, field, field_prop)
+
+    transformed_value =
+      case field_prop do
+        %{embedded: true, type: mod} -> transform_module(value, mod)
+        _ -> value
+      end
+
+    get_field_presence(message_props.syntax, transformed_value, field_prop)
+  end
+
+  defp get_oneof_value(message, message_props, field, field_prop) do
+    case field_prop.oneof do
+      nil ->
+        Map.fetch!(message, field)
+
+      oneof_num ->
+        {oneof_field, _} = Enum.find(message_props.oneof, fn {_name, tag} -> tag == oneof_num end)
+
+        case Map.fetch!(message, oneof_field) do
+          {^field, value} -> value
+          _ -> nil
+        end
+    end
+  end
+
+  defp transform_module(message, module) do
+    if transform_module = module.transform_module() do
+      transform_module.encode(message, module)
+    else
+      message
+    end
+  end
+
+  # We probably want to make this public eventually, but it makes sense to hold
+  # it until we add editions support, since we definitely don't want to add
+  # `syntax` in a public API
+  @doc false
+  @spec get_field_presence(:proto2 | :proto3, term(), FieldProps.t()) :: :present | :not_present | :maybe
+  def get_field_presence(syntax, value, field_prop)
+
+  # Repeated and maps are always implicit.
+  def get_field_presence(_syntax, [], _prop) do
+    :maybe
+  end
+
+  def get_field_presence(_syntax, val, _prop) when is_map(val) do
+    if map_size(val) == 0 do
+      :maybe
+    else
+      :present
+    end
+  end
+
+  # For proto2 singular cardinality fields:
+  #
+  # - Non-one_of fields with default values have implicit presence
+  # - Others have explicit presence
+  def get_field_presence(:proto2, nil, _prop) do
+    :not_present
+  end
+
+  def get_field_presence(:proto2, value, %FieldProps{default: value, oneof: nil}) do
+    :maybe
+  end
+
+  def get_field_presence(:proto2, _value, _props) do
+    :present
+  end
+
+  # For proto3 singular cardinality fields:
+  #
+  # - Optional and Oneof fields have explicit presence tracking
+  # - Other fields have implicit presence tracking
+  def get_field_presence(:proto3, nil, %FieldProps{proto3_optional?: true}) do
+    :not_present
+  end
+
+  def get_field_presence(:proto3, _, %FieldProps{proto3_optional?: true}) do
+    :present
+  end
+
+  def get_field_presence(_syntax, value, %FieldProps{oneof: oneof}) when not is_nil(oneof) do
+    if is_nil(value) do
+      :not_present
+    else
+      :present
+    end
+  end
+
+  # Defaults for different field types: implicit presence means they are maybe set
+  def get_field_presence(:proto3, nil, _prop) do
+    :maybe
+  end
+
+  def get_field_presence(:proto3, 0, _prop) do
+    :maybe
+  end
+
+  def get_field_presence(:proto3, +0.0, _prop) do
+    :maybe
+  end
+
+  def get_field_presence(:proto3, "", _prop) do
+    :maybe
+  end
+
+  def get_field_presence(:proto3, false, _prop) do
+    :maybe
+  end
+
+  def get_field_presence(_syntax, value, %FieldProps{type: {:enum, enum_mod}}) do
+    if enum_default?(enum_mod, value) do
+      :maybe
+    else
+      :present
+    end
+  end
+
+  # Finally, everything else.
+  def get_field_presence(_syntax, _val, _prop) do
+    :present
+  end
+
+  defp enum_default?(enum_mod, val) when is_atom(val), do: enum_mod.value(val) == 0
+  defp enum_default?(_enum_mod, val) when is_integer(val), do: val == 0
+  defp enum_default?(_enum_mod, list) when is_list(list), do: false
+end

--- a/lib/protobuf/presence.ex
+++ b/lib/protobuf/presence.ex
@@ -14,6 +14,33 @@ defmodule Protobuf.Presence do
   Some values may be implicitly present. For example, lists in `repeated` fields
   always have implicit presence. In these cases, if the presence is ambiguous,
   returns `:maybe`.
+
+  For more information about field presence tracking rules, refer to the official
+  [Field Presence docs](https://protobuf.dev/programming-guides/field_presence/).
+
+
+  ## Examples
+
+      # Non-optional proto3 field:
+      Protobuf.Presence(%MyMessage{foo: 42}, :foo)
+      #=> :present
+
+      Protobuf.Presence(%MyMessage{foo: 0}, :foo)
+      #=> :maybe
+
+      Protobuf.Presence(%MyMessage{}, :foo)
+      #=> :maybe
+
+      # Optional proto3 field:
+      Protobuf.Presence(%MyMessage{bar: 42}, :bar)
+      #=> :present
+
+      Protobuf.Presence(%MyMessage{bar: 0}, :bar)
+      #=> :present
+
+      Protobuf.Presence(%MyMessage{}, :bar)
+      #=> :not_present
+
   """
   @spec field_presence(message :: struct(), field :: atom()) :: :present | :not_present | :maybe
   def field_presence(%mod{} = message, field) do

--- a/test/protobuf/presence_test.exs
+++ b/test/protobuf/presence_test.exs
@@ -1,0 +1,130 @@
+defmodule Protobuf.PresenceTest do
+  use ExUnit.Case, async: true
+
+  alias Protobuf.Presence
+  alias TestMsg.{Foo, Foo2, Proto3Optional, Oneof, OneofProto3, ContainsTransformModule}
+
+  describe "field_presence/2 for proto3" do
+    test "singular non-optional fields have implicit presence" do
+      msg = %Foo{}
+      assert Presence.field_presence(msg, :a) == :maybe
+      assert Presence.field_presence(msg, :c) == :maybe
+      assert Presence.field_presence(msg, :k) == :maybe
+
+      msg = %Foo{a: 42, c: "hello", k: true, j: :A}
+      assert Presence.field_presence(msg, :a) == :present
+      assert Presence.field_presence(msg, :c) == :present
+      assert Presence.field_presence(msg, :k) == :present
+      assert Presence.field_presence(msg, :j) == :present
+
+      msg = %Foo{a: 0, c: "", k: false, j: :UNKNOWN}
+      assert Presence.field_presence(msg, :a) == :maybe
+      assert Presence.field_presence(msg, :c) == :maybe
+      assert Presence.field_presence(msg, :k) == :maybe
+      assert Presence.field_presence(msg, :j) == :maybe
+    end
+
+    test "optional fields have explicit presence" do
+      msg = %Proto3Optional{}
+      assert Presence.field_presence(msg, :a) == :not_present
+      assert Presence.field_presence(msg, :c) == :not_present
+
+      msg = %Proto3Optional{a: 50, c: "hello"}
+      assert Presence.field_presence(msg, :a) == :present
+      assert Presence.field_presence(msg, :c) == :present
+
+      msg = %Proto3Optional{a: 0, c: ""}
+      assert Presence.field_presence(msg, :a) == :present
+      assert Presence.field_presence(msg, :c) == :present
+    end
+
+    test "oneof fields have explicit presence" do
+      msg = %OneofProto3{}
+      assert Presence.field_presence(msg, :a) == :not_present
+      assert Presence.field_presence(msg, :b) == :not_present
+
+      msg = %OneofProto3{first: {:a, 42}}
+      assert Presence.field_presence(msg, :a) == :present
+      assert Presence.field_presence(msg, :b) == :not_present
+
+      msg = %OneofProto3{first: {:a, 0}}
+      assert Presence.field_presence(msg, :a) == :present
+
+      msg = %OneofProto3{first: {:e, :UNKNOWN}}
+      assert Presence.field_presence(msg, :e) == :present
+    end
+  end
+
+  describe "field_presence/2 for proto2" do
+    test "singular fields have explicit presence" do
+      msg = %Foo2{}
+      assert Presence.field_presence(msg, :a) == :not_present
+      assert Presence.field_presence(msg, :c) == :not_present
+      assert Presence.field_presence(msg, :k) == :not_present
+
+      msg = %Foo2{a: 42, c: "hello", k: true, j: :A}
+      assert Presence.field_presence(msg, :a) == :present
+      assert Presence.field_presence(msg, :c) == :present
+      assert Presence.field_presence(msg, :k) == :present
+      assert Presence.field_presence(msg, :j) == :present
+
+      msg = %Foo2{a: 0, c: "", k: false, j: :UNKNOWN}
+      assert Presence.field_presence(msg, :a) == :present
+      assert Presence.field_presence(msg, :c) == :present
+      assert Presence.field_presence(msg, :k) == :present
+      assert Presence.field_presence(msg, :j) == :present
+    end
+
+    test "singular fields with default have implicit presence" do
+      msg = %Foo2{}
+      assert Presence.field_presence(msg, :b) == :maybe
+
+      msg = %Foo2{b: 5} # 5 is the default value for :b
+      assert Presence.field_presence(msg, :b) == :maybe
+
+      msg = %Foo2{b: 6}
+      assert Presence.field_presence(msg, :b) == :present
+    end
+
+    test "oneof fields have explicit presence" do
+      msg = %Oneof{}
+      assert Presence.field_presence(msg, :a) == :not_present
+      assert Presence.field_presence(msg, :b) == :not_present
+
+      msg = %Oneof{first: {:a, 42}}
+      assert Presence.field_presence(msg, :a) == :present
+      assert Presence.field_presence(msg, :b) == :not_present
+
+      # Even if the value is default, it is present
+      msg = %Oneof{first: {:a, 0}}
+      assert Presence.field_presence(msg, :a) == :present
+
+      msg = %Oneof{first: {:e, :UNKNOWN}}
+      assert Presence.field_presence(msg, :e) == :present
+    end
+  end
+
+  describe "field_presence/2" do
+    test "repeated fields have implicit presence" do
+      msg = %Foo{g: []}
+      assert Presence.field_presence(msg, :g) == :maybe
+
+      msg = %Foo{g: [1, 2, 3]}
+      assert Presence.field_presence(msg, :g) == :present
+    end
+
+    test "maps have implicit presence" do
+      msg = %Foo{l: %{}}
+      assert Presence.field_presence(msg, :l) == :maybe
+
+      msg = %Foo{l: %{"key" => 123}}
+      assert Presence.field_presence(msg, :l) == :present
+    end
+
+    # Transform module tests
+    test "field_presence works with transform modules" do
+      msg = %ContainsTransformModule{field: 42}
+      assert Presence.field_presence(msg, :field) == :present
+    end
+  end
+end

--- a/test/protobuf/presence_test.exs
+++ b/test/protobuf/presence_test.exs
@@ -53,6 +53,14 @@ defmodule Protobuf.PresenceTest do
       msg = %OneofProto3{first: {:e, :UNKNOWN}}
       assert Presence.field_presence(msg, :e) == :present
     end
+
+    test "message fields have explicit presence" do
+      msg = %Foo{}
+      assert Presence.field_presence(msg, :e) == :not_present
+
+      msg = %Foo{e: %Foo.Bar{}}
+      assert Presence.field_presence(msg, :e) == :present
+    end
   end
 
   describe "field_presence/2 for proto2" do
@@ -100,6 +108,14 @@ defmodule Protobuf.PresenceTest do
       assert Presence.field_presence(msg, :a) == :present
 
       msg = %Oneof{first: {:e, :UNKNOWN}}
+      assert Presence.field_presence(msg, :e) == :present
+    end
+
+    test "message fields have explicit presence" do
+      msg = %Foo2{}
+      assert Presence.field_presence(msg, :e) == :not_present
+
+      msg = %Foo2{e: %Foo.Bar{}}
       assert Presence.field_presence(msg, :e) == :present
     end
   end

--- a/test/protobuf/text_test.exs
+++ b/test/protobuf/text_test.exs
@@ -143,7 +143,7 @@ defmodule Protobuf.TextTest do
   end
 
   test "raises on absent proto2 required" do
-    assert_raise RuntimeError, "field :a is required", fn ->
+    assert_raise Protobuf.EncodeError, "field :a is required", fn ->
       Text.encode(%TestMsg.Foo2{})
     end
   end

--- a/test/support/test_msg.ex
+++ b/test/support/test_msg.ex
@@ -82,8 +82,8 @@ defmodule TestMsg do
     field :g, 8, repeated: true, type: :int32
     # field :h, 9, repeated: true, type: Foo.Bar
     field :i, 10, repeated: true, type: :int32, packed: true
-    # field :j, 11, optional: true, type: EnumFoo, enum: true
-    # field :k, 12, optional: true, type: :bool
+    field :j, 11, optional: true, type: EnumFoo, enum: true
+    field :k, 12, optional: true, type: :bool
     field :l, 13, repeated: true, type: MapFoo, map: true
     field :non_matched, 101, type: :int32, optional: true
   end


### PR DESCRIPTION
This PR is on-top of #398.

Adds a unified presence tracking module. Makes the different encoders use it when deciding whether to skip a field or not.

Adds a public API for checking field presence on `Protobuf.Presence.field_presence/2`. This is similar to the feature present on the official protobuf libraries, but with a different API.

In Ruby, for example, fields that have **explicit presence tracking** generate a `has_{field_name}?` method:
```ruby
message = MyMessage.new()
message.has_foo? #=> false
message.foo = 0
message.has_foo? # => true
```

If another field, say `bar`, doesn't have explicit presence tracking (e.g.: it is a non-optional, non-one_of proto3), it simply doesn't generate the `has_bar?` method, so you can't "presence-check" these fields.

My proposed API is a bit different, and allows presence-checking `:bar`, but sometimes giving
a `:maybe` as a response:
```elixir
message = %Message{}
Protobuf.Presence.field_presence(message, :foo)
#=> :not_present
Protobuf.Presence.field_presence(%Message{foo: 0}, :foo)
#=> :present

Protobuf.Presence.field_presence(%Message{}, :bar)
#=> :maybe
Protobuf.Presence.field_presence(%Message{bar: 0}, :bar)
#=> :maybe
Protobuf.Presence.field_presence(%Message{bar: 1}, :bar)
#=> :present
```

## Motivation

I think it makes sense to centralize presence checking for a few reasons:
1. Presence rules become even more complex with protobuf editions and I'd like to add support for them soon, so this refactoring seems opportune
2. Existing logic is a bit ad-hoc and duplicated. Seemed like a good opportunity to improve the code I noticed when adding `Protobuf.Text`.
3. Official protobuf libraries provide APIs for presence checking and I don't see why this one shouldn't