### PR TITLE
Fix ci: update actions and ubuntu image

### DIFF
--- a/.github/workflows/latest_conformance.yml
+++ b/.github/workflows/latest_conformance.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Cache built Protobuf source
         id: cache-protobuf-source
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: protobuf
           key: ${{ runner.os }}-protobuf-${{ steps.get-protobuf-sha.outputs.sha }}

--- a/.github/workflows/latest_conformance.yml
+++ b/.github/workflows/latest_conformance.yml
@@ -48,7 +48,7 @@ jobs:
 
       - name: Cache built Protobuf source
         id: cache-protobuf-source
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: protobuf
           key: ${{ runner.os }}-protobuf-${{ steps.get-protobuf-sha.outputs.sha }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -9,8 +9,7 @@ on:
 jobs:
   test:
     name: Test (Elixir ${{ matrix.elixir }} | Erlang/OTP ${{ matrix.otp }})
-    # We need Ubuntu 20.04 for now to test old OTP and Elixir versions.
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}-elixir-${{ matrix.elixir }}-erlang-${{ matrix.otp }}
@@ -56,7 +56,7 @@ jobs:
       # Don't cache PLTs based on mix.lock hash, as Dialyzer can incrementally update even old ones
       # Cache key based on Elixir & Erlang version (also useful when running in matrix)
       - name: Cache Dialyzer's PLT
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         id: cache-plt
         with:
           path: priv/plts
@@ -141,7 +141,7 @@ jobs:
 
       - name: Cache Elixir dependencies with compiled protoc
         id: cache-deps-with-built-protoc
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: deps
           key: ${{ runner.os }}-mix-deps-with-protoc-${{ hashFiles('**/mix.lock') }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Cache dependencies
         id: cache-deps
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-${{ hashFiles('**/mix.lock') }}-elixir-${{ matrix.elixir }}-erlang-${{ matrix.otp }}
@@ -55,7 +55,7 @@ jobs:
       # Don't cache PLTs based on mix.lock hash, as Dialyzer can incrementally update even old ones
       # Cache key based on Elixir & Erlang version (also useful when running in matrix)
       - name: Cache Dialyzer's PLT
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-plt
         with:
           path: priv/plts
@@ -140,7 +140,7 @@ jobs:
 
       - name: Cache Elixir dependencies with compiled protoc
         id: cache-deps-with-built-protoc
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: deps
           key: ${{ runner.os }}-mix-deps-with-protoc-${{ hashFiles('**/mix.lock') }}


### PR DESCRIPTION
Extracted from #405 

CI was not running due to deprecated Ubuntu image and cache action.