### PR TITLE
 Add warning when implicitly casting maps/keywords to struct encode-time

### DIFF
--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -161,7 +161,18 @@ defmodule Protobuf.Encoder do
           message:
             "struct #{inspect(other_mod)} can't be encoded as #{inspect(mod)}: #{inspect(struct)}"
 
-      _ ->
+      enumerable ->
+        IO.warn("""
+        Implicit casting from #{inspect(enumerable)} to #{inspect(mod)} struct.
+        This automatic coercion is deprecated in Protobuf 0.15 and will raise an error in future versions.
+
+        Instead of:
+          %Parent{child: %{name: ""}}
+
+        Build child structs explicitly:
+          %Parent{child: %Child{name: ""}}
+        """)
+
         do_encode_to_iodata(struct(mod, msg))
     end
   end

--- a/test/protobuf/encoder_test.exs
+++ b/test/protobuf/encoder_test.exs
@@ -184,7 +184,10 @@ defmodule Protobuf.EncoderTest do
   end
 
   test "encodes map with oneof" do
-    msg = %Google.Protobuf.Struct{fields: %{"valid" => %{kind: {:bool_value, true}}}}
+    msg = %Google.Protobuf.Struct{
+      fields: %{"valid" => %Google.Protobuf.Value{kind: {:bool_value, true}}}
+    }
+
     bin = Google.Protobuf.Struct.encode(msg)
 
     assert Google.Protobuf.Struct.decode(bin) ==
@@ -307,6 +310,15 @@ defmodule Protobuf.EncoderTest do
     assert_raise Protobuf.EncodeError, message, fn ->
       Encoder.encode(%TestMsg.Foo{a: 90, e: %TestMsg.Foo.Bar{a: "not_a_number"}})
     end
+  end
+
+  test "gives a warning for implicitly cast structs" do
+    warning =
+      ExUnit.CaptureIO.capture_io(:stderr, fn ->
+        assert <<50, 2, 8, 1>> = Encoder.encode(%TestMsg.Foo{e: %{a: 1}})
+      end)
+
+    assert warning =~ "Implicit casting from %{a: 1} to TestMsg.Foo.Bar"
   end
 
   test "encodes with transformer module" do


### PR DESCRIPTION
Addresses discussion on #362. 
