### PR TITLE
Preserve original indentation in generated documentation

### DIFF
--- a/lib/protobuf/protoc/generator/comment.ex
+++ b/lib/protobuf/protoc/generator/comment.ex
@@ -33,10 +33,29 @@ defmodule Protobuf.Protoc.Generator.Comment do
   defp format_comment(location) do
     [location.leading_comments, location.trailing_comments | location.leading_detached_comments]
     |> Enum.reject(&is_nil/1)
-    |> Enum.map(&String.replace(&1, ~r/^\s*\*/, "", global: true))
     |> Enum.join("\n\n")
     |> String.replace(~r/\n{3,}/, "\n")
+    |> normalize_indentation()
     |> String.trim()
+  end
+
+  defp normalize_indentation(comments) do
+    indentation =
+      String.split(comments, "\n")
+      |> Enum.reject(&String.match?(&1, ~r/^\s*$/))
+      |> Enum.map(fn line ->
+        Regex.run(~r/^\s*/, line, capture: :first)
+        |> List.first()
+        |> String.length()
+      end)
+      |> Enum.min(fn -> 0 end)
+
+    comments
+    |> String.split("\n")
+    |> Enum.map(fn line ->
+      String.replace_prefix(line, String.duplicate(" ", indentation), "")
+    end)
+    |> Enum.join("\n")
   end
 
   @doc """

--- a/lib/protobuf/protoc/generator/util.ex
+++ b/lib/protobuf/protoc/generator/util.ex
@@ -94,14 +94,7 @@ defmodule Protobuf.Protoc.Generator.Util do
   @spec pad_comment(String.t(), non_neg_integer()) :: String.t()
   def pad_comment(comment, size) do
     padding = String.duplicate(" ", size)
-
-    comment
-    |> String.split("\n")
-    |> Enum.map(fn line ->
-      trimmed = String.trim_leading(line, " ")
-      padding <> trimmed
-    end)
-    |> Enum.join("\n")
+    String.replace(comment, "\n", "\n" <> padding)
   end
 
   @spec version() :: String.t()


### PR DESCRIPTION
Hello 👋🏼 

This PR modifies the processing of comments to preserve the original indentation. Here's the methodology:

Most comment sets have a single space at the beginning of each line, ex. `// Test`. However, there are some situations where all lines may have multiple spaces or no spaces at the beginning. To handle this without disrupting further indents, we look at the minimum number of spaces used for any line that has non-whitespace characters.

Once we trim the minimum number of spaces determined above, all other indentation is preserved. It is no longer necessary to trim while padding the final comments.

Would love your feedback ❤️ 