### PR TITLE
Regenerate Google protos with documentation

### DIFF
--- a/lib/elixirpb.pb.ex
+++ b/lib/elixirpb.pb.ex
@@ -1,7 +1,7 @@
 defmodule Elixirpb.FileOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :module_prefix, 1, optional: true, type: :string, json_name: "modulePrefix"
 end

--- a/lib/elixirpb/pb_extension.pb.ex
+++ b/lib/elixirpb/pb_extension.pb.ex
@@ -1,7 +1,7 @@
 defmodule Elixirpb.PbExtension do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0"
+  use Protobuf, protoc_gen_elixir_version: "0.14.1"
 
   extend Google.Protobuf.FileOptions, :file, 1047, optional: true, type: Elixirpb.FileOptions
 end

--- a/lib/google/protobuf/any.pb.ex
+++ b/lib/google/protobuf/any.pb.ex
@@ -1,7 +1,93 @@
 defmodule Google.Protobuf.Any do
-  @moduledoc false
+  @moduledoc """
+  `Any` contains an arbitrary serialized protocol buffer message along with a
+  URL that describes the type of the serialized message.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  Protobuf library provides support to pack/unpack Any values in the form
+  of utility functions or additional generated methods of the Any type.
+
+  Example 1: Pack and unpack a message in C++.
+
+      Foo foo = ...;
+      Any any;
+      any.PackFrom(foo);
+      ...
+      if (any.UnpackTo(&foo)) {
+        ...
+      }
+
+  Example 2: Pack and unpack a message in Java.
+
+      Foo foo = ...;
+      Any any = Any.pack(foo);
+      ...
+      if (any.is(Foo.class)) {
+        foo = any.unpack(Foo.class);
+      }
+      // or ...
+      if (any.isSameTypeAs(Foo.getDefaultInstance())) {
+        foo = any.unpack(Foo.getDefaultInstance());
+      }
+
+   Example 3: Pack and unpack a message in Python.
+
+      foo = Foo(...)
+      any = Any()
+      any.Pack(foo)
+      ...
+      if any.Is(Foo.DESCRIPTOR):
+        any.Unpack(foo)
+        ...
+
+   Example 4: Pack and unpack a message in Go
+
+       foo := &pb.Foo{...}
+       any, err := anypb.New(foo)
+       if err != nil {
+         ...
+       }
+       ...
+       foo := &pb.Foo{}
+       if err := any.UnmarshalTo(foo); err != nil {
+         ...
+       }
+
+  The pack methods provided by protobuf library will by default use
+  'type.googleapis.com/full.type.name' as the type URL and the unpack
+  methods only use the fully qualified type name after the last '/'
+  in the type URL, for example "foo.bar.com/x/y.z" will yield type
+  name "y.z".
+
+  JSON
+  ====
+  The JSON representation of an `Any` value uses the regular
+  representation of the deserialized, embedded message, with an
+  additional field `@type` which contains the type URL. Example:
+
+      package google.profile;
+      message Person {
+        string first_name = 1;
+        string last_name = 2;
+      }
+
+      {
+        "@type": "type.googleapis.com/google.profile.Person",
+        "firstName": <string>,
+        "lastName": <string>
+      }
+
+  If the embedded message type is well-known and has a custom JSON
+  representation, that representation will be embedded adding a field
+  `value` which holds the custom JSON in addition to the `@type`
+  field. Example (for message [google.protobuf.Duration][]):
+
+      {
+        "@type": "type.googleapis.com/google.protobuf.Duration",
+        "value": "1.212s"
+      }
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line

--- a/lib/google/protobuf/compiler/plugin.pb.ex
+++ b/lib/google/protobuf/compiler/plugin.pb.ex
@@ -1,7 +1,7 @@
 defmodule Google.Protobuf.Compiler.CodeGeneratorResponse.Feature do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :FEATURE_NONE, 0
   field :FEATURE_PROTO3_OPTIONAL, 1
@@ -11,7 +11,7 @@ end
 defmodule Google.Protobuf.Compiler.Version do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :major, 1, optional: true, type: :int32
   field :minor, 2, optional: true, type: :int32
@@ -22,7 +22,7 @@ end
 defmodule Google.Protobuf.Compiler.CodeGeneratorRequest do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :file_to_generate, 1, repeated: true, type: :string, json_name: "fileToGenerate"
   field :parameter, 2, optional: true, type: :string
@@ -46,7 +46,7 @@ end
 defmodule Google.Protobuf.Compiler.CodeGeneratorResponse.File do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :insertion_point, 2, optional: true, type: :string, json_name: "insertionPoint"
@@ -61,7 +61,7 @@ end
 defmodule Google.Protobuf.Compiler.CodeGeneratorResponse do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :error, 1, optional: true, type: :string
   field :supported_features, 2, optional: true, type: :uint64, json_name: "supportedFeatures"

--- a/lib/google/protobuf/descriptor.pb.ex
+++ b/lib/google/protobuf/descriptor.pb.ex
@@ -1,7 +1,7 @@
 defmodule Google.Protobuf.Edition do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :EDITION_UNKNOWN, 0
   field :EDITION_LEGACY, 900
@@ -20,7 +20,7 @@ end
 defmodule Google.Protobuf.ExtensionRangeOptions.VerificationState do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :DECLARATION, 0
   field :UNVERIFIED, 1
@@ -29,7 +29,7 @@ end
 defmodule Google.Protobuf.FieldDescriptorProto.Type do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :TYPE_DOUBLE, 1
   field :TYPE_FLOAT, 2
@@ -54,7 +54,7 @@ end
 defmodule Google.Protobuf.FieldDescriptorProto.Label do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :LABEL_OPTIONAL, 1
   field :LABEL_REPEATED, 3
@@ -64,7 +64,7 @@ end
 defmodule Google.Protobuf.FileOptions.OptimizeMode do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :SPEED, 1
   field :CODE_SIZE, 2
@@ -74,7 +74,7 @@ end
 defmodule Google.Protobuf.FieldOptions.CType do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :STRING, 0
   field :CORD, 1
@@ -84,7 +84,7 @@ end
 defmodule Google.Protobuf.FieldOptions.JSType do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :JS_NORMAL, 0
   field :JS_STRING, 1
@@ -94,7 +94,7 @@ end
 defmodule Google.Protobuf.FieldOptions.OptionRetention do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :RETENTION_UNKNOWN, 0
   field :RETENTION_RUNTIME, 1
@@ -104,7 +104,7 @@ end
 defmodule Google.Protobuf.FieldOptions.OptionTargetType do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :TARGET_TYPE_UNKNOWN, 0
   field :TARGET_TYPE_FILE, 1
@@ -121,7 +121,7 @@ end
 defmodule Google.Protobuf.MethodOptions.IdempotencyLevel do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :IDEMPOTENCY_UNKNOWN, 0
   field :NO_SIDE_EFFECTS, 1
@@ -131,7 +131,7 @@ end
 defmodule Google.Protobuf.FeatureSet.FieldPresence do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :FIELD_PRESENCE_UNKNOWN, 0
   field :EXPLICIT, 1
@@ -142,7 +142,7 @@ end
 defmodule Google.Protobuf.FeatureSet.EnumType do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :ENUM_TYPE_UNKNOWN, 0
   field :OPEN, 1
@@ -152,7 +152,7 @@ end
 defmodule Google.Protobuf.FeatureSet.RepeatedFieldEncoding do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :REPEATED_FIELD_ENCODING_UNKNOWN, 0
   field :PACKED, 1
@@ -162,7 +162,7 @@ end
 defmodule Google.Protobuf.FeatureSet.Utf8Validation do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :UTF8_VALIDATION_UNKNOWN, 0
   field :VERIFY, 2
@@ -172,7 +172,7 @@ end
 defmodule Google.Protobuf.FeatureSet.MessageEncoding do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :MESSAGE_ENCODING_UNKNOWN, 0
   field :LENGTH_PREFIXED, 1
@@ -182,7 +182,7 @@ end
 defmodule Google.Protobuf.FeatureSet.JsonFormat do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :JSON_FORMAT_UNKNOWN, 0
   field :ALLOW, 1
@@ -192,7 +192,7 @@ end
 defmodule Google.Protobuf.GeneratedCodeInfo.Annotation.Semantic do
   @moduledoc false
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :NONE, 0
   field :SET, 1
@@ -202,7 +202,7 @@ end
 defmodule Google.Protobuf.FileDescriptorSet do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :file, 1, repeated: true, type: Google.Protobuf.FileDescriptorProto
 
@@ -212,7 +212,7 @@ end
 defmodule Google.Protobuf.FileDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :package, 2, optional: true, type: :string
@@ -246,7 +246,7 @@ end
 defmodule Google.Protobuf.DescriptorProto.ExtensionRange do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :start, 1, optional: true, type: :int32
   field :end, 2, optional: true, type: :int32
@@ -256,7 +256,7 @@ end
 defmodule Google.Protobuf.DescriptorProto.ReservedRange do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :start, 1, optional: true, type: :int32
   field :end, 2, optional: true, type: :int32
@@ -265,7 +265,7 @@ end
 defmodule Google.Protobuf.DescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :field, 2, repeated: true, type: Google.Protobuf.FieldDescriptorProto
@@ -304,7 +304,7 @@ end
 defmodule Google.Protobuf.ExtensionRangeOptions.Declaration do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :number, 1, optional: true, type: :int32
   field :full_name, 2, optional: true, type: :string, json_name: "fullName"
@@ -316,7 +316,7 @@ end
 defmodule Google.Protobuf.ExtensionRangeOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :uninterpreted_option, 999,
     repeated: true,
@@ -343,7 +343,7 @@ end
 defmodule Google.Protobuf.FieldDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :number, 3, optional: true, type: :int32
@@ -361,7 +361,7 @@ end
 defmodule Google.Protobuf.OneofDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :options, 2, optional: true, type: Google.Protobuf.OneofOptions
@@ -370,7 +370,7 @@ end
 defmodule Google.Protobuf.EnumDescriptorProto.EnumReservedRange do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :start, 1, optional: true, type: :int32
   field :end, 2, optional: true, type: :int32
@@ -379,7 +379,7 @@ end
 defmodule Google.Protobuf.EnumDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :value, 2, repeated: true, type: Google.Protobuf.EnumValueDescriptorProto
@@ -396,7 +396,7 @@ end
 defmodule Google.Protobuf.EnumValueDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :number, 2, optional: true, type: :int32
@@ -406,7 +406,7 @@ end
 defmodule Google.Protobuf.ServiceDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :method, 2, repeated: true, type: Google.Protobuf.MethodDescriptorProto
@@ -416,7 +416,7 @@ end
 defmodule Google.Protobuf.MethodDescriptorProto do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :name, 1, optional: true, type: :string
   field :input_type, 2, optional: true, type: :string, json_name: "inputType"
@@ -439,7 +439,7 @@ end
 defmodule Google.Protobuf.FileOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :java_package, 1, optional: true, type: :string, json_name: "javaPackage"
   field :java_outer_classname, 8, optional: true, type: :string, json_name: "javaOuterClassname"
@@ -522,7 +522,7 @@ end
 defmodule Google.Protobuf.MessageOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :message_set_wire_format, 1,
     optional: true,
@@ -558,7 +558,7 @@ end
 defmodule Google.Protobuf.FieldOptions.EditionDefault do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :edition, 3, optional: true, type: Google.Protobuf.Edition, enum: true
   field :value, 2, optional: true, type: :string
@@ -567,7 +567,7 @@ end
 defmodule Google.Protobuf.FieldOptions.FeatureSupport do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :edition_introduced, 1,
     optional: true,
@@ -593,7 +593,7 @@ end
 defmodule Google.Protobuf.FieldOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :ctype, 1,
     optional: true,
@@ -654,7 +654,7 @@ end
 defmodule Google.Protobuf.OneofOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :features, 1, optional: true, type: Google.Protobuf.FeatureSet
 
@@ -669,7 +669,7 @@ end
 defmodule Google.Protobuf.EnumOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :allow_alias, 2, optional: true, type: :bool, json_name: "allowAlias"
   field :deprecated, 3, optional: true, type: :bool, default: false
@@ -693,7 +693,7 @@ end
 defmodule Google.Protobuf.EnumValueOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :deprecated, 1, optional: true, type: :bool, default: false
   field :features, 2, optional: true, type: Google.Protobuf.FeatureSet
@@ -715,7 +715,7 @@ end
 defmodule Google.Protobuf.ServiceOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :features, 34, optional: true, type: Google.Protobuf.FeatureSet
   field :deprecated, 33, optional: true, type: :bool, default: false
@@ -731,7 +731,7 @@ end
 defmodule Google.Protobuf.MethodOptions do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :deprecated, 33, optional: true, type: :bool, default: false
 
@@ -755,7 +755,7 @@ end
 defmodule Google.Protobuf.UninterpretedOption.NamePart do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :name_part, 1, required: true, type: :string, json_name: "namePart"
   field :is_extension, 2, required: true, type: :bool, json_name: "isExtension"
@@ -764,7 +764,7 @@ end
 defmodule Google.Protobuf.UninterpretedOption do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :name, 2, repeated: true, type: Google.Protobuf.UninterpretedOption.NamePart
   field :identifier_value, 3, optional: true, type: :string, json_name: "identifierValue"
@@ -778,7 +778,7 @@ end
 defmodule Google.Protobuf.FeatureSet do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :field_presence, 1,
     optional: true,
@@ -828,7 +828,7 @@ end
 defmodule Google.Protobuf.FeatureSetDefaults.FeatureSetEditionDefault do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :edition, 3, optional: true, type: Google.Protobuf.Edition, enum: true
 
@@ -846,7 +846,7 @@ end
 defmodule Google.Protobuf.FeatureSetDefaults do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :defaults, 1,
     repeated: true,
@@ -868,7 +868,7 @@ end
 defmodule Google.Protobuf.SourceCodeInfo.Location do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :path, 1, repeated: true, type: :int32, packed: true, deprecated: false
   field :span, 2, repeated: true, type: :int32, packed: true, deprecated: false
@@ -884,7 +884,7 @@ end
 defmodule Google.Protobuf.SourceCodeInfo do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :location, 1, repeated: true, type: Google.Protobuf.SourceCodeInfo.Location
 
@@ -894,7 +894,7 @@ end
 defmodule Google.Protobuf.GeneratedCodeInfo.Annotation do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :path, 1, repeated: true, type: :int32, packed: true, deprecated: false
   field :source_file, 2, optional: true, type: :string, json_name: "sourceFile"
@@ -910,7 +910,7 @@ end
 defmodule Google.Protobuf.GeneratedCodeInfo do
   @moduledoc false
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto2
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto2
 
   field :annotation, 1, repeated: true, type: Google.Protobuf.GeneratedCodeInfo.Annotation
 end

--- a/lib/google/protobuf/duration.pb.ex
+++ b/lib/google/protobuf/duration.pb.ex
@@ -1,7 +1,66 @@
 defmodule Google.Protobuf.Duration do
-  @moduledoc false
+  @moduledoc """
+  A Duration represents a signed, fixed-length span of time represented
+  as a count of seconds and fractions of seconds at nanosecond
+  resolution. It is independent of any calendar and concepts like "day"
+  or "month". It is related to Timestamp in that the difference between
+  two Timestamp values is a Duration and it can be added or subtracted
+  from a Timestamp. Range is approximately +-10,000 years.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  # Examples
+
+  Example 1: Compute Duration from two Timestamps in pseudo code.
+
+      Timestamp start = ...;
+      Timestamp end = ...;
+      Duration duration = ...;
+
+      duration.seconds = end.seconds - start.seconds;
+      duration.nanos = end.nanos - start.nanos;
+
+      if (duration.seconds < 0 && duration.nanos > 0) {
+        duration.seconds += 1;
+        duration.nanos -= 1000000000;
+      } else if (duration.seconds > 0 && duration.nanos < 0) {
+        duration.seconds -= 1;
+        duration.nanos += 1000000000;
+      }
+
+  Example 2: Compute Timestamp from Timestamp + Duration in pseudo code.
+
+      Timestamp start = ...;
+      Duration duration = ...;
+      Timestamp end = ...;
+
+      end.seconds = start.seconds + duration.seconds;
+      end.nanos = start.nanos + duration.nanos;
+
+      if (end.nanos < 0) {
+        end.seconds -= 1;
+        end.nanos += 1000000000;
+      } else if (end.nanos >= 1000000000) {
+        end.seconds += 1;
+        end.nanos -= 1000000000;
+      }
+
+  Example 3: Compute Duration from datetime.timedelta in Python.
+
+      td = datetime.timedelta(days=3, minutes=10)
+      duration = Duration()
+      duration.FromTimedelta(td)
+
+  # JSON Mapping
+
+  In JSON format, the Duration type is encoded as a string rather than an
+  object, where the string ends in the suffix "s" (indicating seconds) and
+  is preceded by the number of seconds, with nanoseconds expressed as
+  fractional seconds. For example, 3 seconds with 0 nanoseconds should be
+  encoded in JSON format as "3s", while 3 seconds and 1 nanosecond should
+  be expressed in JSON format as "3.000000001s", and 3 seconds and 1
+  microsecond should be expressed in JSON format as "3.000001s".
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line

--- a/lib/google/protobuf/empty.pb.ex
+++ b/lib/google/protobuf/empty.pb.ex
@@ -1,7 +1,15 @@
 defmodule Google.Protobuf.Empty do
-  @moduledoc false
+  @moduledoc """
+  A generic empty message that you can re-use to avoid defining duplicated
+  empty messages in your APIs. A typical example is to use it as the request
+  or the response type of an API method. For instance:
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+      service Foo {
+        rpc Bar(google.protobuf.Empty) returns (google.protobuf.Empty);
+      }
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line

--- a/lib/google/protobuf/field_mask.pb.ex
+++ b/lib/google/protobuf/field_mask.pb.ex
@@ -1,7 +1,205 @@
 defmodule Google.Protobuf.FieldMask do
-  @moduledoc false
+  @moduledoc """
+  `FieldMask` represents a set of symbolic field paths, for example:
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+      paths: "f.a"
+      paths: "f.b.d"
+
+  Here `f` represents a field in some root message, `a` and `b`
+  fields in the message found in `f`, and `d` a field found in the
+  message in `f.b`.
+
+  Field masks are used to specify a subset of fields that should be
+  returned by a get operation or modified by an update operation.
+  Field masks also have a custom JSON encoding (see below).
+
+  # Field Masks in Projections
+
+  When used in the context of a projection, a response message or
+  sub-message is filtered by the API to only contain those fields as
+  specified in the mask. For example, if the mask in the previous
+  example is applied to a response message as follows:
+
+      f {
+        a : 22
+        b {
+          d : 1
+          x : 2
+        }
+        y : 13
+      }
+      z: 8
+
+  The result will not contain specific values for fields x,y and z
+  (their value will be set to the default, and omitted in proto text
+  output):
+      f {
+        a : 22
+        b {
+          d : 1
+        }
+      }
+
+  A repeated field is not allowed except at the last position of a
+  paths string.
+
+  If a FieldMask object is not present in a get operation, the
+  operation applies to all fields (as if a FieldMask of all fields
+  had been specified).
+
+  Note that a field mask does not necessarily apply to the
+  top-level response message. In case of a REST get operation, the
+  field mask applies directly to the response, but in case of a REST
+  list operation, the mask instead applies to each individual message
+  in the returned resource list. In case of a REST custom method,
+  other definitions may be used. Where the mask applies will be
+  clearly documented together with its declaration in the API.  In
+  any case, the effect on the returned resource/resources is required
+  behavior for APIs.
+
+  # Field Masks in Update Operations
+
+  A field mask in update operations specifies which fields of the
+  targeted resource are going to be updated. The API is required
+  to only change the values of the fields as specified in the mask
+  and leave the others untouched. If a resource is passed in to
+  describe the updated values, the API ignores the values of all
+  fields not covered by the mask.
+
+  If a repeated field is specified for an update operation, new values will
+  be appended to the existing repeated field in the target resource. Note that
+  a repeated field is only allowed in the last position of a `paths` string.
+
+  If a sub-message is specified in the last position of the field mask for an
+  update operation, then new value will be merged into the existing sub-message
+  in the target resource.
+
+  For example, given the target message:
+
+      f {
+        b {
+          d: 1
+          x: 2
+        }
+        c: [1]
+      }
+
+  And an update message:
+
+      f {
+        b {
+          d: 10
+        }
+        c: [2]
+      }
+
+  then if the field mask is:
+
+   paths: ["f.b", "f.c"]
+
+  then the result will be:
+
+      f {
+        b {
+          d: 10
+          x: 2
+        }
+        c: [1, 2]
+      }
+
+  An implementation may provide options to override this default behavior for
+  repeated and message fields.
+
+  In order to reset a field's value to the default, the field must
+  be in the mask and set to the default value in the provided resource.
+  Hence, in order to reset all fields of a resource, provide a default
+  instance of the resource and set all fields in the mask, or do
+  not provide a mask as described below.
+
+  If a field mask is not present on update, the operation applies to
+  all fields (as if a field mask of all fields has been specified).
+  Note that in the presence of schema evolution, this may mean that
+  fields the client does not know and has therefore not filled into
+  the request will be reset to their default. If this is unwanted
+  behavior, a specific service may require a client to always specify
+  a field mask, producing an error if not.
+
+  As with get operations, the location of the resource which
+  describes the updated values in the request message depends on the
+  operation kind. In any case, the effect of the field mask is
+  required to be honored by the API.
+
+  ## Considerations for HTTP REST
+
+  The HTTP kind of an update operation which uses a field mask must
+  be set to PATCH instead of PUT in order to satisfy HTTP semantics
+  (PUT must only be used for full updates).
+
+  # JSON Encoding of Field Masks
+
+  In JSON, a field mask is encoded as a single string where paths are
+  separated by a comma. Fields name in each path are converted
+  to/from lower-camel naming conventions.
+
+  As an example, consider the following message declarations:
+
+      message Profile {
+        User user = 1;
+        Photo photo = 2;
+      }
+      message User {
+        string display_name = 1;
+        string address = 2;
+      }
+
+  In proto a field mask for `Profile` may look as such:
+
+      mask {
+        paths: "user.display_name"
+        paths: "photo"
+      }
+
+  In JSON, the same mask is represented as below:
+
+      {
+        mask: "user.displayName,photo"
+      }
+
+  # Field Masks and Oneof Fields
+
+  Field masks treat fields in oneofs just as regular fields. Consider the
+  following message:
+
+      message SampleMessage {
+        oneof test_oneof {
+          string name = 4;
+          SubMessage sub_message = 9;
+        }
+      }
+
+  The field mask can be:
+
+      mask {
+        paths: "name"
+      }
+
+  Or:
+
+      mask {
+        paths: "sub_message"
+      }
+
+  Note that oneof type names ("test_oneof" in this case) cannot be used in
+  paths.
+
+  ## Field Mask Verification
+
+  The implementation of any API method which has a FieldMask type field in the
+  request should verify the included field paths, and return an
+  `INVALID_ARGUMENT` error if any path is unmappable.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line

--- a/lib/google/protobuf/struct.pb.ex
+++ b/lib/google/protobuf/struct.pb.ex
@@ -1,7 +1,12 @@
 defmodule Google.Protobuf.NullValue do
-  @moduledoc false
+  @moduledoc """
+  `NullValue` is a singleton enumeration to represent the null value for the
+  `Value` type union.
 
-  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  The JSON representation for `NullValue` is JSON `null`.
+  """
+
+  use Protobuf, enum: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line
@@ -26,9 +31,7 @@ defmodule Google.Protobuf.NullValue do
 end
 
 defmodule Google.Protobuf.Struct.FieldsEntry do
-  @moduledoc false
-
-  use Protobuf, map: true, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  use Protobuf, map: true, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line
@@ -91,9 +94,18 @@ defmodule Google.Protobuf.Struct.FieldsEntry do
 end
 
 defmodule Google.Protobuf.Struct do
-  @moduledoc false
+  @moduledoc """
+  `Struct` represents a structured data value, consisting of fields
+  which map to dynamically typed values. In some languages, `Struct`
+  might be supported by a native representation. For example, in
+  scripting languages like JS a struct is represented as an
+  object. The details of that representation are described together
+  with the proto support for the language.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  The JSON representation for `Struct` is JSON object.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line
@@ -184,9 +196,16 @@ defmodule Google.Protobuf.Struct do
 end
 
 defmodule Google.Protobuf.Value do
-  @moduledoc false
+  @moduledoc """
+  `Value` represents a dynamically typed value which can be either
+  null, a number, a string, a boolean, a recursive struct value, or a
+  list of values. A producer of value is expected to set one of these
+  variants. Absence of any variant indicates an error.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  The JSON representation for `Value` is JSON value.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line
@@ -308,9 +327,13 @@ defmodule Google.Protobuf.Value do
 end
 
 defmodule Google.Protobuf.ListValue do
-  @moduledoc false
+  @moduledoc """
+  `ListValue` is a wrapper around a repeated field of values.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  The JSON representation for `ListValue` is JSON array.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line

--- a/lib/google/protobuf/timestamp.pb.ex
+++ b/lib/google/protobuf/timestamp.pb.ex
@@ -1,7 +1,97 @@
 defmodule Google.Protobuf.Timestamp do
-  @moduledoc false
+  @moduledoc """
+  A Timestamp represents a point in time independent of any time zone or local
+  calendar, encoded as a count of seconds and fractions of seconds at
+  nanosecond resolution. The count is relative to an epoch at UTC midnight on
+  January 1, 1970, in the proleptic Gregorian calendar which extends the
+  Gregorian calendar backwards to year one.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  All minutes are 60 seconds long. Leap seconds are "smeared" so that no leap
+  second table is needed for interpretation, using a [24-hour linear
+  smear](https://developers.google.com/time/smear).
+
+  The range is from 0001-01-01T00:00:00Z to 9999-12-31T23:59:59.999999999Z. By
+  restricting to that range, we ensure that we can convert to and from [RFC
+  3339](https://www.ietf.org/rfc/rfc3339.txt) date strings.
+
+  # Examples
+
+  Example 1: Compute Timestamp from POSIX `time()`.
+
+      Timestamp timestamp;
+      timestamp.set_seconds(time(NULL));
+      timestamp.set_nanos(0);
+
+  Example 2: Compute Timestamp from POSIX `gettimeofday()`.
+
+      struct timeval tv;
+      gettimeofday(&tv, NULL);
+
+      Timestamp timestamp;
+      timestamp.set_seconds(tv.tv_sec);
+      timestamp.set_nanos(tv.tv_usec * 1000);
+
+  Example 3: Compute Timestamp from Win32 `GetSystemTimeAsFileTime()`.
+
+      FILETIME ft;
+      GetSystemTimeAsFileTime(&ft);
+      UINT64 ticks = (((UINT64)ft.dwHighDateTime) << 32) | ft.dwLowDateTime;
+
+      // A Windows tick is 100 nanoseconds. Windows epoch 1601-01-01T00:00:00Z
+      // is 11644473600 seconds before Unix epoch 1970-01-01T00:00:00Z.
+      Timestamp timestamp;
+      timestamp.set_seconds((INT64) ((ticks / 10000000) - 11644473600LL));
+      timestamp.set_nanos((INT32) ((ticks % 10000000) * 100));
+
+  Example 4: Compute Timestamp from Java `System.currentTimeMillis()`.
+
+      long millis = System.currentTimeMillis();
+
+      Timestamp timestamp = Timestamp.newBuilder().setSeconds(millis / 1000)
+          .setNanos((int) ((millis % 1000) * 1000000)).build();
+
+  Example 5: Compute Timestamp from Java `Instant.now()`.
+
+      Instant now = Instant.now();
+
+      Timestamp timestamp =
+          Timestamp.newBuilder().setSeconds(now.getEpochSecond())
+              .setNanos(now.getNano()).build();
+
+  Example 6: Compute Timestamp from current time in Python.
+
+      timestamp = Timestamp()
+      timestamp.GetCurrentTime()
+
+  # JSON Mapping
+
+  In JSON format, the Timestamp type is encoded as a string in the
+  [RFC 3339](https://www.ietf.org/rfc/rfc3339.txt) format. That is, the
+  format is "{year}-{month}-{day}T{hour}:{min}:{sec}[.{frac_sec}]Z"
+  where {year} is always expressed using four digits while {month}, {day},
+  {hour}, {min}, and {sec} are zero-padded to two digits each. The fractional
+  seconds, which can go up to 9 digits (i.e. up to 1 nanosecond resolution),
+  are optional. The "Z" suffix indicates the timezone ("UTC"); the timezone
+  is required. A proto3 JSON serializer should always use UTC (as indicated by
+  "Z") when printing the Timestamp type and a proto3 JSON parser should be
+  able to accept both UTC and other timezones (as indicated by an offset).
+
+  For example, "2017-01-15T01:30:15.01Z" encodes 15.01 seconds past
+  01:30 UTC on January 15, 2017.
+
+  In JavaScript, one can convert a Date object to this format using the
+  standard
+  [toISOString()](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date/toISOString)
+  method. In Python, a standard `datetime.datetime` object can be converted
+  to this format using
+  [`strftime`](https://docs.python.org/2/library/time.html#time.strftime) with
+  the time format spec '%Y-%m-%dT%H:%M:%S.%fZ'. Likewise, in Java, one can use
+  the Joda Time's [`ISODateTimeFormat.dateTime()`](
+  http://joda-time.sourceforge.net/apidocs/org/joda/time/format/ISODateTimeFormat.html#dateTime()
+  ) to obtain a formatter capable of generating timestamps in this format.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line

--- a/lib/google/protobuf/wrappers.pb.ex
+++ b/lib/google/protobuf/wrappers.pb.ex
@@ -1,7 +1,11 @@
 defmodule Google.Protobuf.DoubleValue do
-  @moduledoc false
+  @moduledoc """
+  Wrapper message for `double`.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  The JSON representation for `DoubleValue` is JSON number.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line
@@ -39,9 +43,13 @@ defmodule Google.Protobuf.DoubleValue do
 end
 
 defmodule Google.Protobuf.FloatValue do
-  @moduledoc false
+  @moduledoc """
+  Wrapper message for `float`.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  The JSON representation for `FloatValue` is JSON number.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line
@@ -79,9 +87,13 @@ defmodule Google.Protobuf.FloatValue do
 end
 
 defmodule Google.Protobuf.Int64Value do
-  @moduledoc false
+  @moduledoc """
+  Wrapper message for `int64`.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  The JSON representation for `Int64Value` is JSON string.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line
@@ -119,9 +131,13 @@ defmodule Google.Protobuf.Int64Value do
 end
 
 defmodule Google.Protobuf.UInt64Value do
-  @moduledoc false
+  @moduledoc """
+  Wrapper message for `uint64`.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  The JSON representation for `UInt64Value` is JSON string.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line
@@ -159,9 +175,13 @@ defmodule Google.Protobuf.UInt64Value do
 end
 
 defmodule Google.Protobuf.Int32Value do
-  @moduledoc false
+  @moduledoc """
+  Wrapper message for `int32`.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  The JSON representation for `Int32Value` is JSON number.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line
@@ -199,9 +219,13 @@ defmodule Google.Protobuf.Int32Value do
 end
 
 defmodule Google.Protobuf.UInt32Value do
-  @moduledoc false
+  @moduledoc """
+  Wrapper message for `uint32`.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  The JSON representation for `UInt32Value` is JSON number.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line
@@ -239,9 +263,13 @@ defmodule Google.Protobuf.UInt32Value do
 end
 
 defmodule Google.Protobuf.BoolValue do
-  @moduledoc false
+  @moduledoc """
+  Wrapper message for `bool`.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  The JSON representation for `BoolValue` is JSON `true` and `false`.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line
@@ -279,9 +307,13 @@ defmodule Google.Protobuf.BoolValue do
 end
 
 defmodule Google.Protobuf.StringValue do
-  @moduledoc false
+  @moduledoc """
+  Wrapper message for `string`.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  The JSON representation for `StringValue` is JSON string.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line
@@ -319,9 +351,13 @@ defmodule Google.Protobuf.StringValue do
 end
 
 defmodule Google.Protobuf.BytesValue do
-  @moduledoc false
+  @moduledoc """
+  Wrapper message for `bytes`.
 
-  use Protobuf, protoc_gen_elixir_version: "0.14.0", syntax: :proto3
+  The JSON representation for `BytesValue` is JSON string.
+  """
+
+  use Protobuf, protoc_gen_elixir_version: "0.14.1", syntax: :proto3
 
   def descriptor do
     # credo:disable-for-next-line

--- a/mix.exs
+++ b/mix.exs
@@ -80,6 +80,7 @@ defmodule Protobuf.Mixfile do
   defp docs do
     [
       extras: ["README.md"],
+      groups_for_modules: ["Generated Protos": ~r/^Google\.Protobuf\./],
       main: "readme",
       source_url: @source_url,
       source_ref: "v#{@version}"
@@ -192,7 +193,11 @@ defmodule Protobuf.Mixfile do
       google/protobuf/wrappers.proto
     )
 
-    protoc!("-I \"#{proto_src}\" --elixir_opt=gen_descriptors=true", "./lib", files)
+    protoc!(
+      "-I \"#{proto_src}\" --elixir_opt=gen_descriptors=true,include_docs=true",
+      "./lib",
+      files
+    )
   end
 
   defp gen_google_test_protos(_args) do


### PR DESCRIPTION
Hello 👋🏼 

This PR regenerates the `Google.Protobuf` modules with documentation included. This is helpful in cases documentation in a consumer application refers to, for example, `Google.Protobuf.Timestamp.t()`. The goal of this PR is to eliminate the warnings produced by `ex_doc` because the `Google.Protobuf.Timestamp` module is hidden.

To keep the docs manageable, I also created a module group for the generated modules.

Documentation in this PR was generated with the indentation-preserving changes in #414.

❤️ 