### PR TITLE
feat: add is_protobuf_message/1 guard for message identification

### DIFF
--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -51,6 +51,37 @@ defmodule Protobuf do
   """
   @type unknown_field() :: {field_number :: integer(), wire_type(), value :: any()}
 
+  @doc """
+  Checks if the given value is a Protobuf message struct.
+
+  This guard checks for the `__protobuf__: true` marker that is automatically added
+  to all Protobuf message structs.
+
+  ## Examples
+
+      defmodule MyMessage do
+        use Protobuf, syntax: :proto3
+        field :name, 1, type: :string
+      end
+
+      message = %MyMessage{name: "test"}
+
+      iex> is_protobuf_message(message)
+      true
+
+      iex> is_protobuf_message(%{})
+      false
+
+  Can be used in guards:
+
+      def process_message(msg) when is_protobuf_message(msg) do
+        msg.name
+      end
+
+  """
+  defguard is_protobuf_message(value)
+           when is_map(value) and :erlang.is_map_key(:__protobuf__, value)
+
   defmacro __using__(opts) do
     quote location: :keep do
       import Protobuf.DSL, only: [field: 3, field: 2, oneof: 2, extend: 4, extensions: 1]

--- a/lib/protobuf/dsl.ex
+++ b/lib/protobuf/dsl.ex
@@ -459,8 +459,10 @@ defmodule Protobuf.DSL do
       end
 
     unknown_fields = {:__unknown_fields__, _default = []}
+    protobuf_marker = {:__protobuf__, _default = true}
 
-    struct_fields = regular_fields ++ oneof_fields ++ extension_fields ++ [unknown_fields]
+    struct_fields =
+      regular_fields ++ oneof_fields ++ extension_fields ++ [unknown_fields, protobuf_marker]
 
     quote do
       defstruct unquote(Macro.escape(struct_fields))

--- a/lib/protobuf/dsl/typespecs.ex
+++ b/lib/protobuf/dsl/typespecs.ex
@@ -45,7 +45,12 @@ defmodule Protobuf.DSL.Typespecs do
        )}
     ]
 
-    field_specs = regular_fields ++ oneof_fields ++ extension_fields ++ unknown_fields
+    protobuf_marker = [
+      {:__protobuf__, quote(do: true)}
+    ]
+
+    field_specs =
+      regular_fields ++ oneof_fields ++ extension_fields ++ unknown_fields ++ protobuf_marker
 
     quote do: %__MODULE__{unquote_splicing(field_specs)}
   end

--- a/test/protobuf/dsl/typespecs_test.exs
+++ b/test/protobuf/dsl/typespecs_test.exs
@@ -7,7 +7,8 @@ defmodule Protobuf.DSL.TypespecsTest do
 
   @unknown_fields_spec quote(
                          do: [
-                           __unknown_fields__: [Protobuf.unknown_field()]
+                           __unknown_fields__: [Protobuf.unknown_field()],
+                           __protobuf__: true
                          ]
                        )
 

--- a/test/protobuf/protoc/generator/message_test.exs
+++ b/test/protobuf/protoc/generator/message_test.exs
@@ -22,6 +22,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %Pkg.Name.Foo{
+                     __protobuf__: true,
                      __unknown_fields__: [Protobuf.unknown_field()]
                    }
                )
@@ -47,6 +48,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %Foo{
+                     __protobuf__: true,
                      __unknown_fields__: [Protobuf.unknown_field()]
                    }
                )
@@ -175,6 +177,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %Foo{
+                     __protobuf__: true,
                      __unknown_fields__: [Protobuf.unknown_field()],
                      a: integer(),
                      b: String.t(),
@@ -366,6 +369,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %Foo{
+                     __protobuf__: true,
                      __unknown_fields__: [Protobuf.unknown_field()],
                      bar: Bar.t() | nil,
                      baz: [Baz.t()]
@@ -435,6 +439,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %FooBar.AbCd.Foo{
+                     __protobuf__: true,
                      __unknown_fields__: [Protobuf.unknown_field()],
                      a: %{optional(integer()) => FooBar.AbCd.Bar.t() | nil}
                    }
@@ -524,6 +529,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %FooBar.AbCd.Foo{
+                     __protobuf__: true,
                      __unknown_fields__: [Protobuf.unknown_field()],
                      a: OtherPkg.MsgFoo.t() | nil
                    }
@@ -584,6 +590,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %MyPkg.Foo{
+                     __protobuf__: true,
                      __unknown_fields__: [Protobuf.unknown_field()],
                      a: MyPkg.Foo.Nested.t() | nil
                    }
@@ -689,6 +696,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %Foo{
+                     __protobuf__: true,
                      __unknown_fields__: [Protobuf.unknown_field()],
                      first: {:a, integer()} | {:b, integer()} | nil,
                      other: integer() | nil,
@@ -772,6 +780,7 @@ defmodule Protobuf.Protoc.Generator.MessageTest do
                quote(
                  do:
                    t() :: %FooBar.AbCd.Foo{
+                     __protobuf__: true,
                      __unknown_fields__: [Protobuf.unknown_field()],
                      a: [FooBar.AbCd.EnumFoo.t()]
                    }


### PR DESCRIPTION
Add `__protobuf__: true` marker to all protobuf message structs and create an `is_protobuf_message/1` guard macro, following Elixir's convention for `is_exception/1`. This enables efficient, idiomatic checking of protobuf messages in guards and pattern matching.

Signed-off-by: Yordis Prieto <yordis.prieto@gmail.com>
