### PR TITLE
fix: extension file uses the module_prefix option

### DIFF
--- a/test/protobuf/protoc/cli_integration_test.exs
+++ b/test/protobuf/protoc/cli_integration_test.exs
@@ -30,7 +30,7 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
         proto_path
       ])
 
-      assert [mod] = compile_file_and_clean_modules_on_exit("#{tmp_dir}/user.pb.ex")
+      assert [mod] = compile_file_and_clean_modules_on_exit("#{tmp_dir}/foo/user.pb.ex")
       assert mod == Foo.User
     end
 
@@ -43,7 +43,7 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
         proto_path
       ])
 
-      assert [mod] = compile_file_and_clean_modules_on_exit("#{tmp_dir}/user.pb.ex")
+      assert [mod] = compile_file_and_clean_modules_on_exit("#{tmp_dir}/foo/user.pb.ex")
       assert mod == Foo.User
 
       assert mod.transform_module() == TestMsg.TransformModule
@@ -58,7 +58,7 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
         proto_path
       ])
 
-      assert [mod] = compile_file_and_clean_modules_on_exit("#{tmp_dir}/user.pb.ex")
+      assert [mod] = compile_file_and_clean_modules_on_exit("#{tmp_dir}/foo/user.pb.ex")
       assert mod == Foo.User
 
       assert %Google.Protobuf.DescriptorProto{} = descriptor = mod.descriptor()
@@ -74,7 +74,7 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
         proto_path
       ])
 
-      modules_and_docs = get_docs_and_clean_modules_on_exit("#{tmp_dir}/user.pb.ex")
+      modules_and_docs = get_docs_and_clean_modules_on_exit("#{tmp_dir}/foo/user.pb.ex")
       assert [{Foo.User, docs}] = modules_and_docs
       assert {:docs_v1, _, :elixir, _, module_doc, _, _} = docs
       assert module_doc != :hidden
@@ -88,7 +88,7 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
         proto_path
       ])
 
-      modules_and_docs = get_docs_and_clean_modules_on_exit("#{tmp_dir}/user.pb.ex")
+      modules_and_docs = get_docs_and_clean_modules_on_exit("#{tmp_dir}/foo/user.pb.ex")
 
       assert [{Foo.User, docs}] = modules_and_docs
       assert {:docs_v1, _, :elixir, _, :hidden, _, _} = docs
@@ -122,7 +122,7 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
         proto_path
       ])
 
-      assert [mod] = compile_file_and_clean_modules_on_exit("#{tmp_dir}/user.pb.ex")
+      assert [mod] = compile_file_and_clean_modules_on_exit("#{tmp_dir}/mypkg/foo/user.pb.ex")
       assert mod == Mypkg.Foo.User
     end
 
@@ -178,7 +178,7 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
       proto_path
     ])
 
-    assert [mod] = compile_file_and_clean_modules_on_exit("#{tmp_dir}/timestamp_wrapper.pb.ex")
+    assert [mod] = compile_file_and_clean_modules_on_exit("#{tmp_dir}/my_type/timestamp_wrapper.pb.ex")
 
     assert mod == MyType.TimestampWrapper
     assert Map.fetch!(mod.__message_props__().field_props, 1).type == Google.Protobuf.Timestamp
@@ -244,13 +244,13 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
     ])
 
     assert [Bugs.Base = base_mod] =
-             compile_file_and_clean_modules_on_exit("#{tmp_dir}/base.pb.ex")
+             compile_file_and_clean_modules_on_exit("#{tmp_dir}/bugs/base.pb.ex")
 
     assert [Bugs.Ext1, Bugs.Ext1.PbExtension] =
-             compile_file_and_clean_modules_on_exit("#{tmp_dir}/ext1.pb.ex")
+             compile_file_and_clean_modules_on_exit("#{tmp_dir}/bugs/ext1.pb.ex")
 
     assert [Bugs.Ext2, Bugs.Ext2.PbExtension] =
-             compile_file_and_clean_modules_on_exit("#{tmp_dir}/ext2.pb.ex")
+             compile_file_and_clean_modules_on_exit("#{tmp_dir}/bugs/ext2.pb.ex")
 
     assert [Bugs.PbExtension] =
              compile_file_and_clean_modules_on_exit("#{tmp_dir}/bugs/pb_extension.pb.ex")
@@ -343,8 +343,8 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
       proto_path_two
     ])
 
-    elixir_one = File.read!("#{tmp_dir}/one.pb.ex")
-    elixir_two = File.read!("#{tmp_dir}/two.pb.ex")
+    elixir_one = File.read!("#{tmp_dir}/tests/one.pb.ex")
+    elixir_two = File.read!("#{tmp_dir}/tests/two.pb.ex")
 
     assert elixir_one =~ """
            defmodule Tests.One do
@@ -414,7 +414,7 @@ defmodule Protobuf.Protoc.CLIIntegrationTest do
     ])
 
     assert [message_mod, extension_mod] =
-             compile_file_and_clean_modules_on_exit("#{tmp_dir}/extensions.pb.ex")
+             compile_file_and_clean_modules_on_exit("#{tmp_dir}/my_pkg/extensions.pb.ex")
 
     assert %Google.Protobuf.MessageOptions{} = options = message_mod.descriptor().options
     assert options.__pb_extensions__ == %{{extension_mod, :notes} => "This messge is cool"}

--- a/test/protobuf/protoc/generator/file_path_test.exs
+++ b/test/protobuf/protoc/generator/file_path_test.exs
@@ -1,0 +1,93 @@
+defmodule Protobuf.Protoc.FilePathTest do
+  use ExUnit.Case, async: true
+
+  alias Google.Protobuf.{DescriptorProto, FileDescriptorProto}
+  alias Protobuf.Protoc.Context
+  alias Protobuf.Protoc.Generator
+
+  describe "generate/2 - file naming with module_prefix" do
+    test "file path does not respect module_prefix when one_file_per_module is false (default)" do
+      ctx = %Context{
+        module_prefix: "MyApp.V1",
+        package: nil,
+        syntax: :proto2,
+        one_file_per_module?: false,
+        dep_type_mapping: %{},
+        global_type_mapping: %{"example.proto" => %{}}
+      }
+
+      desc = %FileDescriptorProto{
+        name: "example.proto",
+        message_type: [
+          %DescriptorProto{
+            name: "Foo"
+          }
+        ]
+      }
+
+      {_package_level_exts, files} = Generator.generate(ctx, desc)
+
+      assert length(files) == 1
+      file = List.first(files)
+
+      assert file.content =~ "defmodule MyApp.V1.Foo do"
+
+      assert file.name == "my_app/v1/example.pb.ex",
+             "File path should respect module_prefix. Expected 'my_app/v1/example.pb.ex' to match module 'MyApp.V1.Foo', but got '#{file.name}'"
+    end
+
+    test "file path respects module_prefix when one_file_per_module is true" do
+      ctx = %Context{
+        module_prefix: "MyApp.V1",
+        package: nil,
+        syntax: :proto2,
+        one_file_per_module?: true,
+        dep_type_mapping: %{},
+        global_type_mapping: %{"example.proto" => %{}}
+      }
+
+      desc = %FileDescriptorProto{
+        name: "example.proto",
+        message_type: [
+          %DescriptorProto{
+            name: "Foo"
+          }
+        ]
+      }
+
+      {_package_level_exts, files} = Generator.generate(ctx, desc)
+
+      assert length(files) == 1
+      file = List.first(files)
+
+      assert file.name == "my_app/v1/foo.pb.ex",
+             "Expected 'my_app/v1/foo.pb.ex' but got '#{file.name}'"
+    end
+
+    test "file path should respect module_prefix with extensions" do
+      ctx = %Context{
+        module_prefix: "Protobuf.Protoc.ExtTest",
+        package: "ext",
+        syntax: :proto2,
+        one_file_per_module?: false,
+        dep_type_mapping: %{".ext.Foo" => %{type_name: "Protobuf.Protoc.ExtTest.Foo"}},
+        global_type_mapping: %{"extension.proto" => %{}}
+      }
+
+      desc = %FileDescriptorProto{
+        name: "extension.proto",
+        message_type: [
+          %DescriptorProto{name: "Foo"}
+        ]
+      }
+
+      {_package_level_exts, files} = Generator.generate(ctx, desc)
+
+      assert length(files) == 1
+      file = List.first(files)
+
+      assert file.name == "protobuf/protoc/ext_test/extension.pb.ex",
+             "File path should respect module_prefix. Expected 'protobuf/protoc/ext_test/extension.pb.ex' to match module 'Protobuf.Protoc.ExtTest.*', but got '#{file.name}'"
+    end
+  end
+end


### PR DESCRIPTION
Compiling https://github.com/straw-hat-team/beam-monorepo/tree/master/apps/trogon_proto/lib/__generated__/trogon_proto I realized that the extensions aren't respecting the `module_prefix`