### PR TITLE
Add Protobuf.field_presence/2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,8 @@
 
   * Add `Protobuf.Any.pack/1`.
 
+  * Add `Protobuf.field_presence/2`.
+
   * Add deprecation warning when casting a non-struct enumerable to a Protobuf struct.
 
 ## v0.15.0

--- a/lib/protobuf.ex
+++ b/lib/protobuf.ex
@@ -51,6 +51,15 @@ defmodule Protobuf do
   """
   @type unknown_field() :: {field_number :: integer(), wire_type(), value :: any()}
 
+  @typedoc """
+  Describes whether a field is present in a Protobuf message.
+
+  `:maybe` means that the field uses implicit presence and its value is equal to
+  the generated default, so the struct cannot tell whether it was explicitly set.
+  """
+  @typedoc since: "0.17.0"
+  @type field_presence() :: :present | :not_present | :maybe
+
   @doc """
   Checks if the given value is a Protobuf message struct.
 
@@ -253,6 +262,50 @@ defmodule Protobuf do
             "likely means that its definition was not compiled with :protobuf 0.10.0+, which is the " <>
             "version that introduced implicit struct generation"
   end
+
+  @doc """
+  Returns whether a field is present, not present, or maybe present.
+
+  `:present` and `:not_present` mean that a field is explicitly present or not
+  present, respectively.
+
+  Some fields use implicit presence. For example, an empty repeated field and a
+  non-optional proto3 scalar set to its default value are indistinguishable from
+  their generated defaults. In these cases, this function returns `:maybe`.
+
+  For more information about field presence tracking rules, refer to the official
+  [Field Presence docs](https://protobuf.dev/programming-guides/field_presence/).
+
+  ## Examples
+
+      # Non-optional proto3 field:
+      Protobuf.field_presence(%MyMessage{foo: 42}, :foo)
+      #=> :present
+
+      Protobuf.field_presence(%MyMessage{foo: 0}, :foo)
+      #=> :maybe
+
+      # Optional proto3 field:
+      Protobuf.field_presence(%MyMessage{bar: 42}, :bar)
+      #=> :present
+
+      Protobuf.field_presence(%MyMessage{bar: 0}, :bar)
+      #=> :present
+
+      Protobuf.field_presence(%MyMessage{}, :bar)
+      #=> :not_present
+
+      # Repeated field:
+      Protobuf.field_presence(%MyMessage{items: []}, :items)
+      #=> :maybe
+
+      Protobuf.field_presence(%MyMessage{items: [1]}, :items)
+      #=> :present
+
+  """
+  @doc since: "0.17.0"
+  @spec field_presence(message :: struct(), field :: atom()) :: field_presence()
+  defdelegate field_presence(message, field), to: Protobuf.Presence
 
   @doc """
   Loads extensions modules.

--- a/lib/protobuf/encoder.ex
+++ b/lib/protobuf/encoder.ex
@@ -68,20 +68,13 @@ defmodule Protobuf.Encoder do
           "Got error when encoding #{inspect(struct_mod)}##{prop.name_atom}: #{Exception.format(:error, error)}"
   end
 
-  defp skip_field?(_syntax, [], _prop), do: true
-  defp skip_field?(_syntax, val, _prop) when is_map(val), do: map_size(val) == 0
-  defp skip_field?(:proto2, nil, %FieldProps{optional?: optional?}), do: optional?
-  defp skip_field?(:proto2, value, %FieldProps{default: value, oneof: nil}), do: true
-
-  defp skip_field?(:proto3, val, %FieldProps{proto3_optional?: true}),
-    do: is_nil(val)
-
-  defp skip_field?(:proto3, nil, _prop), do: true
-  defp skip_field?(:proto3, 0, %FieldProps{oneof: nil}), do: true
-  defp skip_field?(:proto3, +0.0, %FieldProps{oneof: nil}), do: true
-  defp skip_field?(:proto3, "", %FieldProps{oneof: nil}), do: true
-  defp skip_field?(:proto3, false, %FieldProps{oneof: nil}), do: true
-  defp skip_field?(_syntax, _val, _prop), do: false
+  defp skip_field?(syntax, value, field_prop) do
+    case Protobuf.Presence.get_field_presence(syntax, value, field_prop) do
+      :present -> false
+      :maybe -> not (syntax == :proto2 and field_prop.required?)
+      :not_present -> not (syntax == :proto2 and field_prop.required?)
+    end
+  end
 
   defp do_encode_field(
          :normal,
@@ -89,7 +82,7 @@ defmodule Protobuf.Encoder do
          syntax,
          %FieldProps{encoded_fnum: fnum, type: type, repeated?: repeated?} = prop
        ) do
-    if skip_field?(syntax, val, prop) or skip_enum?(syntax, val, prop) do
+    if skip_field?(syntax, val, prop) do
       :skip
     else
       apply_or_map(val, repeated?, &[fnum | Wire.encode(type, &1)])
@@ -123,7 +116,7 @@ defmodule Protobuf.Encoder do
   end
 
   defp do_encode_field(:packed, val, syntax, %FieldProps{type: type, encoded_fnum: fnum} = prop) do
-    if skip_field?(syntax, val, prop) or skip_enum?(syntax, val, prop) do
+    if skip_field?(syntax, val, prop) do
       :skip
     else
       encoded = Enum.map(val, &Wire.encode(type, &1))
@@ -195,20 +188,6 @@ defmodule Protobuf.Encoder do
 
   defp apply_or_map(val, _repeated? = true, func), do: Enum.map(val, func)
   defp apply_or_map(val, _repeated? = false, func), do: func.(val)
-
-  defp skip_enum?(:proto2, _value, _prop), do: false
-  defp skip_enum?(:proto3, _value, %FieldProps{proto3_optional?: true}), do: false
-  defp skip_enum?(_syntax, _value, %FieldProps{enum?: false}), do: false
-
-  defp skip_enum?(_syntax, _value, %FieldProps{enum?: true, oneof: oneof}) when not is_nil(oneof),
-    do: false
-
-  defp skip_enum?(_syntax, _value, %FieldProps{required?: true}), do: false
-  defp skip_enum?(_syntax, value, %FieldProps{type: type}), do: enum_default?(type, value)
-
-  defp enum_default?({:enum, enum_mod}, val) when is_atom(val), do: enum_mod.value(val) == 0
-  defp enum_default?({:enum, _enum_mod}, val) when is_integer(val), do: val == 0
-  defp enum_default?({:enum, _enum_mod}, list) when is_list(list), do: false
 
   # Returns a map of %{field_name => field_value} from oneofs. For example, if you have:
   # oneof body {

--- a/lib/protobuf/json/encode.ex
+++ b/lib/protobuf/json/encode.ex
@@ -188,7 +188,7 @@ defmodule Protobuf.JSON.Encode do
   defp encode_regular_fields(struct, %{field_props: field_props, syntax: syntax}, opts) do
     for {_field_num, %{name_atom: name, oneof: nil} = prop} <- field_props,
         %{^name => value} = struct,
-        emit?(syntax, prop, value) || opts[:emit_unpopulated] do
+        emit?(syntax, prop, value, opts[:emit_unpopulated]) do
       encode_field(prop, value, opts)
     end
   end
@@ -327,18 +327,17 @@ defmodule Protobuf.JSON.Encode do
   defp maybe_repeat(%{repeated?: false}, val, fun), do: fun.(val)
   defp maybe_repeat(%{repeated?: true}, val, fun), do: Enum.map(val, fun)
 
-  defp emit?(:proto2, %{default: value}, value), do: false
-  defp emit?(:proto2, %{optional?: true}, val), do: not is_nil(val)
-  defp emit?(:proto3, %{proto3_optional?: true}, val), do: not is_nil(val)
-  defp emit?(_syntax, _prop, +0.0), do: false
-  defp emit?(_syntax, _prop, nil), do: false
-  defp emit?(_syntax, _prop, 0), do: false
-  defp emit?(_syntax, _prop, false), do: false
-  defp emit?(_syntax, _prop, []), do: false
-  defp emit?(_syntax, _prop, ""), do: false
-  defp emit?(_syntax, _prop, %{} = map) when map_size(map) == 0, do: false
-  defp emit?(_syntax, %{type: {:enum, enum}}, key) when is_atom(key), do: enum.value(key) != 0
-  defp emit?(_syntax, _prop, _value), do: true
+  defp emit?(_syntax, _field_prop, _value, true = _emit_unpopulated?) do
+    true
+  end
+
+  defp emit?(syntax, field_prop, value, _emit_unpopulated?) do
+    case Protobuf.Presence.get_field_presence(syntax, value, field_prop) do
+      :present -> true
+      :maybe -> false
+      :not_present -> false
+    end
+  end
 
   defp transform_module(message, module) do
     if transform_module = module.transform_module() do

--- a/lib/protobuf/presence.ex
+++ b/lib/protobuf/presence.ex
@@ -1,0 +1,113 @@
+defmodule Protobuf.Presence do
+  @moduledoc false
+
+  # Centralizes Protobuf field presence rules for the public
+  # `Protobuf.field_presence/2` API and for encoder skip/emit decisions.
+
+  alias Protobuf.{FieldProps, MessageProps}
+
+  @type presence() :: :present | :not_present | :maybe
+
+  @spec field_presence(message :: struct(), field :: atom()) :: presence()
+  def field_presence(%mod{} = message, field) when is_atom(field) do
+    message_props = mod.__message_props__()
+    transformed_message = transform_module(message, mod)
+    field_prop = field_prop!(message_props, field)
+    value = field_value(transformed_message, message_props, field, field_prop)
+
+    field_presence_for_value(message_props.syntax, value, field_prop)
+  end
+
+  defp field_prop!(%MessageProps{field_tags: field_tags, field_props: field_props}, field) do
+    fnum = Map.fetch!(field_tags, field)
+    Map.fetch!(field_props, fnum)
+  end
+
+  defp field_value(message, _message_props, field, %FieldProps{oneof: nil}) do
+    Map.fetch!(message, field)
+  end
+
+  defp field_value(message, %MessageProps{oneof: oneofs}, field, %FieldProps{oneof: oneof_num}) do
+    {oneof_field, _oneof_num} = Enum.find(oneofs, fn {_name, tag} -> tag == oneof_num end)
+
+    case Map.fetch!(message, oneof_field) do
+      {^field, value} -> value
+      _other -> nil
+    end
+  end
+
+  defp field_presence_for_value(
+         syntax,
+         value,
+         %FieldProps{embedded?: true, type: mod} = field_prop
+       )
+       when not is_nil(value) do
+    get_field_presence(syntax, transform_module(value, mod), field_prop)
+  end
+
+  defp field_presence_for_value(syntax, value, field_prop) do
+    get_field_presence(syntax, value, field_prop)
+  end
+
+  @doc false
+  @spec get_field_presence(:proto2 | :proto3, term(), FieldProps.t()) :: presence()
+  def get_field_presence(syntax, value, field_prop)
+
+  # Repeated fields and maps have implicit presence. Empty values are ambiguous:
+  # they could be explicitly assigned or just be the generated default.
+  def get_field_presence(_syntax, [], _field_prop), do: :maybe
+
+  def get_field_presence(_syntax, %{} = value, %FieldProps{map?: true}) do
+    if map_size(value) == 0 do
+      :maybe
+    else
+      :present
+    end
+  end
+
+  # Proto2 singular fields track explicit presence, but this library's struct
+  # representation can't distinguish absent custom defaults from explicit ones.
+  def get_field_presence(:proto2, nil, _field_prop), do: :not_present
+  def get_field_presence(:proto2, value, %FieldProps{default: value, oneof: nil}), do: :maybe
+  def get_field_presence(:proto2, _value, _field_prop), do: :present
+
+  # Proto3 optional fields and oneofs track explicit presence.
+  def get_field_presence(:proto3, nil, %FieldProps{proto3_optional?: true}), do: :not_present
+  def get_field_presence(:proto3, _value, %FieldProps{proto3_optional?: true}), do: :present
+
+  def get_field_presence(_syntax, value, %FieldProps{oneof: oneof}) when not is_nil(oneof) do
+    if is_nil(value) do
+      :not_present
+    else
+      :present
+    end
+  end
+
+  def get_field_presence(:proto3, nil, _field_prop), do: :not_present
+  def get_field_presence(:proto3, 0, _field_prop), do: :maybe
+  def get_field_presence(:proto3, +0.0, _field_prop), do: :maybe
+  def get_field_presence(:proto3, "", _field_prop), do: :maybe
+  def get_field_presence(:proto3, false, _field_prop), do: :maybe
+
+  def get_field_presence(_syntax, value, %FieldProps{type: {:enum, enum_mod}}) do
+    if enum_default?(enum_mod, value) do
+      :maybe
+    else
+      :present
+    end
+  end
+
+  def get_field_presence(_syntax, _value, _field_prop), do: :present
+
+  defp transform_module(value, module) do
+    if transform_module = module.transform_module() do
+      transform_module.encode(value, module)
+    else
+      value
+    end
+  end
+
+  defp enum_default?(enum_mod, value) when is_atom(value), do: enum_mod.value(value) == 0
+  defp enum_default?(_enum_mod, value) when is_integer(value), do: value == 0
+  defp enum_default?(_enum_mod, values) when is_list(values), do: false
+end

--- a/test/protobuf/protobuf_test.exs
+++ b/test/protobuf/protobuf_test.exs
@@ -48,6 +48,85 @@ defmodule Protobuf.ProtobufTest do
     end
   end
 
+  describe "field_presence/2" do
+    test "returns presence for proto3 scalar fields" do
+      assert Protobuf.field_presence(%TestMsg.Foo{a: 42}, :a) == :present
+      assert Protobuf.field_presence(%TestMsg.Foo{a: 0}, :a) == :maybe
+      assert Protobuf.field_presence(%TestMsg.Foo{}, :a) == :maybe
+
+      assert Protobuf.field_presence(%TestMsg.Foo{c: "value"}, :c) == :present
+      assert Protobuf.field_presence(%TestMsg.Foo{c: ""}, :c) == :maybe
+
+      assert Protobuf.field_presence(%TestMsg.Foo{k: true}, :k) == :present
+      assert Protobuf.field_presence(%TestMsg.Foo{k: false}, :k) == :maybe
+    end
+
+    test "returns presence for proto3 optional fields" do
+      assert Protobuf.field_presence(%TestMsg.Proto3Optional{a: 0}, :a) == :present
+      assert Protobuf.field_presence(%TestMsg.Proto3Optional{a: nil}, :a) == :not_present
+      assert Protobuf.field_presence(%TestMsg.Proto3Optional{c: :UNKNOWN}, :c) == :present
+      assert Protobuf.field_presence(%TestMsg.Proto3Optional{c: nil}, :c) == :not_present
+    end
+
+    test "returns presence for embedded fields" do
+      assert Protobuf.field_presence(%TestMsg.Foo{e: %TestMsg.Foo.Bar{}}, :e) == :present
+      assert Protobuf.field_presence(%TestMsg.Foo{e: nil}, :e) == :not_present
+    end
+
+    test "returns presence for repeated fields and maps" do
+      assert Protobuf.field_presence(%TestMsg.Foo{g: [0]}, :g) == :present
+      assert Protobuf.field_presence(%TestMsg.Foo{g: []}, :g) == :maybe
+
+      assert Protobuf.field_presence(%TestMsg.Foo{l: %{"key" => 0}}, :l) == :present
+      assert Protobuf.field_presence(%TestMsg.Foo{l: %{}}, :l) == :maybe
+    end
+
+    test "returns presence for oneof fields" do
+      assert Protobuf.field_presence(%TestMsg.OneofProto3{first: {:a, 0}}, :a) == :present
+      assert Protobuf.field_presence(%TestMsg.OneofProto3{first: {:b, ""}}, :a) == :not_present
+      assert Protobuf.field_presence(%TestMsg.OneofProto3{first: nil}, :a) == :not_present
+      assert Protobuf.field_presence(%TestMsg.Oneof{first: {:e, :A}}, :e) == :present
+    end
+
+    test "returns presence for proto2 fields" do
+      assert Protobuf.field_presence(%TestMsg.Foo2{a: 0}, :a) == :present
+      assert Protobuf.field_presence(%TestMsg.Foo2{}, :a) == :not_present
+
+      assert Protobuf.field_presence(%TestMsg.Foo2{b: 5}, :b) == :maybe
+      assert Protobuf.field_presence(%TestMsg.Foo2{b: 0}, :b) == :present
+
+      assert Protobuf.field_presence(%TestMsg.Foo2{c: ""}, :c) == :present
+      assert Protobuf.field_presence(%TestMsg.Foo2{c: nil}, :c) == :not_present
+    end
+
+    test "returns presence for enum fields" do
+      assert Protobuf.field_presence(%TestMsg.Foo{j: :UNKNOWN}, :j) == :maybe
+      assert Protobuf.field_presence(%TestMsg.Foo{j: :A}, :j) == :present
+      assert Protobuf.field_presence(%TestMsg.Foo{j: 0}, :j) == :maybe
+      assert Protobuf.field_presence(%TestMsg.Foo{j: 1}, :j) == :present
+
+      assert Protobuf.field_presence(%TestMsg.EnumFoo2{a: 0}, :a) == :present
+    end
+
+    test "uses transform modules for embedded fields" do
+      assert Protobuf.field_presence(%TestMsg.ContainsTransformModule{field: 0}, :field) ==
+               :present
+
+      assert Protobuf.field_presence(%TestMsg.ContainsTransformModule{field: nil}, :field) ==
+               :not_present
+
+      assert Protobuf.field_presence(
+               %TestMsg.ContainsIntegerStringTransformModule{field: "42"},
+               :field
+             ) == :present
+
+      assert Protobuf.field_presence(
+               %TestMsg.ContainsIntegerStringTransformModule{field: "0"},
+               :field
+             ) == :maybe
+    end
+  end
+
   describe "is_protobuf_message/1" do
     test "returns true for protobuf message structs" do
       message = %TestMsg.Foo{a: 42}


### PR DESCRIPTION
Mostly extracts the `Protobuf.field_presence/2` concept from https://github.com/elixir-protobuf/protobuf/pull/398 into its own change.