### PR TITLE
Strip only-on tags from generated conformance failure list

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -333,10 +333,17 @@ defmodule Protobuf.Mixfile do
     other = if profile == "latest", do: "pinned", else: "latest"
     exclude = ~r/#\s*only-on:\s*#{other}\b/
 
+    # The conformance runner treats any text after `#` on a failure-list line as the *expected*
+    # failure message for that test, so our `# only-on: <profile>` tag must be stripped from the
+    # entries we keep — otherwise the runner compares "only-on: latest" against the real failure
+    # message and reports a (fatal) mismatch.
+    strip_tag = ~r/\s*#\s*only-on:\s*\w+\b.*$/
+
     contents =
       @exemptions_file
       |> File.stream!()
       |> Enum.reject(&Regex.match?(exclude, &1))
+      |> Enum.map(&Regex.replace(strip_tag, &1, ""))
       |> Enum.join()
 
     path = Path.join(System.tmp_dir!(), "protobuf_conformance_exemptions_#{profile}.txt")


### PR DESCRIPTION
## Problem

The scheduled **Latest conformance** workflow has been failing on `main`. The `conformance_test_runner` built from Protobuf's `main` branch now treats any text after `#` on a failure-list line as the **expected failure message** for that test.

Our `build_failure_list/1` in `mix.exs` filters out the *other* profile's entries but left the `# only-on: <profile>` tag attached to the entries it keeps. So the runner compared the literal string `only-on: latest` against the real failure message (`Output was not equivalent to reference message: ...`) and reported a fatal mismatch — failing the whole suite even though those MessageSet tests fail for the expected (unimplemented) reason.

```
CONFORMANCE SUITE FAILED: 2812 successes, 0 skipped, 1 expected failures, 0 unexpected failures.
```

## Fix

Strip the `# only-on: <profile>` tag from the entries we keep, so they are written as bare test names. The runner accepts a bare test name as "expected to fail with any message".

Verified by dispatching the `latest_conformance.yml` workflow against this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)